### PR TITLE
Fix saving to opened files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 JLSerror
 *.jls
-bin/
-bin
-bin*
+/bin
 *.class
-bin*
-.class
+/JLS.jar

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+classes: ./src/jls/*.java ./src/jls/edit/*.java ./src/jls/elem/*.java ./src/jls/edit/*.java ./src/jls/sim/*.java ./xz/*.java ./xz/org/tukaani/xz/*.java ./xz/org/tukaani/xz/check/*.java ./xz/org/tukaani/xz/common/*.java ./xz/org/tukaani/xz/delta/*.java ./xz/org/tukaani/xz/index/*.java ./xz/org/tukaani/xz/lz/*.java ./xz/org/tukaani/xz/lzma/*.java ./xz/org/tukaani/xz/rangecoder/*.java ./xz/org/tukaani/xz/simple/*.java
+	javac -d ./bin -cp ./lib/jhall.jar $^
+
+# not working - "Could not find or load main class bin.jls.JLS"
+# tried JLS, jls.JSL, and bin.jls.JLS
+JLS.jar: ./bin/jls/*.class ./bin/jls/edit/*.class ./bin/jls/elem/*.class ./bin/jls/edit/*.class ./bin/jls/sim/*.class ./bin/*.class ./bin/org/tukaani/xz/*.class ./bin/org/tukaani/xz/check/*.class ./bin/org/tukaani/xz/common/*.class ./bin/org/tukaani/xz/delta/*.class ./bin/org/tukaani/xz/index/*.class ./bin/org/tukaani/xz/lz/*.class ./bin/org/tukaani/xz/lzma/*.class ./bin/org/tukaani/xz/rangecoder/*.class ./bin/org/tukaani/xz/simple/*.class
+	jar cfe JLS.jar JLS $^

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -1043,7 +1043,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private void open(String filePath) {
 
 		File file = null;
-		String dir = "";
+		String dir = null;
 
 		// get circuit name from user if parameter is null
 		if (filePath == null) {
@@ -1073,6 +1073,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 			file = new File(filePath);
 			prevOpenDir = file.getParent().equals("") ? System.getProperty("user.dir") : file.getParent();
 		}
+		dir = prevOpenDir;
 		
 		Scanner input = getScannerForFile(filePath);
 
@@ -1082,7 +1083,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		// create new circuit
 		Circuit circ = new Circuit(cname);
-		//circ.setDirectory(dir);
+		circ.setDirectory(dir);
 
 		// read circuit from file
 		boolean loadOK = circ.load(input);

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -145,7 +145,6 @@ public class JLSStart extends JFrame implements ChangeListener {
 				JOptionPane.showMessageDialog(null, "invalid circuit file: " + JLSInfo.loadError );
 				System.exit(1);
 			}
-			input.close();
 
 			// finish up load
 			try {
@@ -247,7 +246,6 @@ public class JLSStart extends JFrame implements ChangeListener {
 				JOptionPane.showMessageDialog(null, "invalid circuit file: " + JLSInfo.loadError );
 				System.exit(1);
 			}
-			input.close();
 
 			// finish up load
 			try {

--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -65,7 +65,7 @@ public final class Editor extends SimpleEditor {
 			//out.putNextEntry(new ZipEntry("JLSCircuit"));
 		} catch (Exception ex) {
 			JOptionPane.showMessageDialog(getTopLevelAncestor(),
-					"Can't write to " + fileName, "Error",
+					"Can't write to " + fileName + ": " + ex.getMessage(), "Error",
 					JOptionPane.ERROR_MESSAGE);
 			return false;
 		}


### PR DESCRIPTION
Files that have been opened cannot be saved; only new files. The reason for this appears to be that the `dir` field is not assigned when opening a circuit from a file, and thus no directory path is prepended to the filename at save, causing the path to be relative to the root, which is inaccessible (or at least not the location of the actual file).