### PR TITLE
Add Maven build system with lint and SpotBugs gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    name: Build (JDK ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      # Compiles with -Xlint:deprecation,removal,unchecked -Werror and runs
+      # the SpotBugs check goal (threshold High, baseline in
+      # config/spotbugs-exclude.xml). Tests run here too once they exist.
+      - name: Build, lint, and analyze
+        run: mvn -B verify
+
+      - name: Upload jar
+        if: matrix.java == 21
+        uses: actions/upload-artifact@v4
+        with:
+          name: jls-jar
+          path: target/jls-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin*
 *.class
 bin*
 .class
+target/

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -116,7 +116,45 @@ All findings verified against the source; line references are to the current
   measure real circuits first, then preset 9, attribute pruning, hex+RLE
   memory encoding — keeping the loader backward compatible (#14 guards).
 
-### Phase 4 — Modernization
+### Phase 4 — Code health: de-duplication, simplification, generalization
+
+Findings from a dedicated duplication/simplification pass; counts verified
+against the source.
+
+- **#22 Gate subclasses**: `And/Or/Nand/Nor/Xor/Not/DelayGate` (~1,550 lines
+  over the 842-line `Gate` base) each duplicate the `previous*` settings
+  statics, `setup()`, `copy()`, and save plumbing; only the outline path and
+  the boolean reduction differ. Make `Gate` data-driven (name + shape +
+  reduction + inversion flag); this also removes 15 of the 25 baselined
+  SpotBugs static-write findings.
+- **#23 Element persistence**: loading is already generic
+  (`Circuit.java:350–441` typed-attribute parser + reflective instantiation)
+  but every element hand-writes `save()` and `copy()`, duplicating attribute
+  names as string literals in both directions. Declare attributes once per
+  element; derive save/load/copy from the declaration.
+- **#24 Orientation geometry**: rotation-aware elements enumerate coordinates
+  per orientation in `if/else` ladders (orientation-conditional references:
+  `TriState` 92, `Mux` 84, `Decoder` 49, `Register` 48, `Gate` 46,
+  `Constant` 46, `Adder` 45, `Clock` 39). Define canonical geometry once and
+  rotate on the 12px grid; verify with the existing headless image export as
+  a visual-regression tool.
+- **#25 Simulator merge**: `BatchSimulator.runSim` and `InterractiveSimulator`
+  duplicate the init + event-loop skeleton (and the interactive class
+  re-implements `Simulator.post()`); template-method the loop in the
+  `Simulator` base with pacing/UI hooks. Fix the `InterractiveSimulator`
+  typo while touching it.
+- **#26 Dialog framework**: 29 hand-rolled `extends JDialog` inner classes
+  across 25 files, with 73 `ok`/`cancel`/`help` button declarations in
+  `jls/elem` alone, each re-wiring the same skeleton and drifting in
+  Enter/Escape behavior. Extract a shared `ElementDialog` base.
+- **#27 Grab-bag**: dead `Circuit.load_JLS2` path referencing the nonexistent
+  `jls.elem2` package (would throw `ClassNotFoundException` if called);
+  `Circuit.getElements()` leaking its live mutable set; 88 `instanceof`
+  checks in `SimpleEditor` (plus the 4-pass `instanceof Wire` draw) to fold
+  into polymorphism or split collections; parallel `InputPin`/`OutputPin` and
+  `JumpStart`/`JumpEnd` structure to hoist into common bases.
+
+### Phase 5 — Modernization
 - **#9 Remove applet support**: `JLSApplet` extends `JApplet`, which is
   deprecated for removal and being dropped from the JDK; browsers removed
   applet support years ago. Remove the class and the `JLSInfo.isApplet` paths.
@@ -128,7 +166,7 @@ All findings verified against the source; line references are to the current
   either way remove the checked-in `lib/jhall.jar`, the stale absolute path
   in `.project`, and the binary `JavaHelpSearch` index files.
 
-### Phase 5 — Ship it
+### Phase 6 — Ship it
 - **#8 Release infrastructure**: version scheme decision, shaded runnable
   jar (`Main-Class: jls.JLS`), tag-triggered release workflow, optional
   `jpackage` installers.

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -12,6 +12,16 @@ audit. The actionable items are tracked on GitHub: see the roadmap in issue
 > latent NPE in `StateMachine`, and platform-default-encoding file I/O at 15
 > sites. Details in commit 1f67a7b.
 
+> **Issue format:** every GitHub issue in this program is structured as a
+> compact scientific paper — Abstract, Background, Observations, Research
+> Question, falsifiable Hypothesis, Predictions, Materials, Method/
+> Experimental Design (task checklists live here), Data Collection &
+> Analysis, Falsification Criteria, Threats to Validity, Related Work,
+> Conclusion — following the canonical scientific-method sequence
+> (observation → question → hypothesis → prediction → controlled test →
+> analysis → replication/review). Roadmap #16 is the umbrella research
+> program tying the studies together.
+
 ## Headline findings
 
 - **The code still compiles.** All 80 `.java` files under `src/` plus the

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -5,6 +5,13 @@ This document records the findings of a full maintenance audit of the JLS
 audit. The actionable items are tracked on GitHub: see the roadmap in issue
 #16, which links every item below as a sub-issue.
 
+> **Status update (this branch):** a Maven build (`mvn verify`) now exists with
+> lint (`-Xlint` + `-Werror`) and SpotBugs gates plus a GitHub Actions workflow
+> (progress on #6/#7/#10). The lint-and-correctness pass fixed 19 findings,
+> including a guaranteed `ClassCastException` in the JumpEnd name dialog, a
+> latent NPE in `StateMachine`, and platform-default-encoding file I/O at 15
+> sites. Details in commit 1f67a7b.
+
 ## Headline findings
 
 - **The code still compiles.** All 80 `.java` files under `src/` plus the

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -1,0 +1,98 @@
+# JLS Maintenance Audit — July 2026
+
+This document records the findings of a full maintenance audit of the JLS
+(Java Logic Simulator) repository. The actionable items are tracked on GitHub:
+see the roadmap in issue #16, which links every item below as a sub-issue.
+
+## Headline findings
+
+- **The code still compiles.** All 80 `.java` files under `src/` plus the
+  vendored XZ sources compile on OpenJDK 21 with zero errors. There are 36
+  lint warnings (deprecation/removal/unchecked) — see "Modernization" below.
+- **There is no infrastructure.** No build system beyond Eclipse project
+  metadata, no CI, no tests, no git tags, no GitHub Releases, no distributable
+  artifact. This — not code rot — is the main obstacle to maintaining and
+  shipping JLS.
+- **The known `.jls` (zip) loading bug has an identifiable root cause**
+  (issue #2): `JLSStart.getZipScanner` closes the `ZipFile` before the
+  `Scanner` reading from its entry stream has been consumed. `ZipFile.close()`
+  closes all streams obtained from it, so only the Scanner's already-buffered
+  data survives. Small files load fine (fully buffered), larger files
+  truncate — exactly matching the intermittent "text ends early" symptom
+  described in the last commit message (ed14ecd).
+
+## State of the repository
+
+| Aspect | State |
+| --- | --- |
+| Last substantive commit | 2015–2017 era (20 commits total) |
+| Origin | Fork of JLS 4.1 by David A. Poplawski, Michigan Technological University |
+| Version identity | Hardcoded in `JLSInfo.java`: 4.1.5, "built on March 18, 2014" |
+| Build | Eclipse `.classpath`/`.project` only, targeting JavaSE-1.7 |
+| Dependencies | `lib/jhall.jar` (JavaHelp 2.0, abandoned upstream ~2007), vendored XZ library sources in `xz/` |
+| Tests | None |
+| CI | None |
+| Releases/tags | None |
+| License | GPLv3 (`LICENSE`), with `pop_GPLv3.pdf` documenting the original author's grant |
+| README | One line |
+
+## Work items (tracked on GitHub)
+
+### Phase 1 — Foundation
+- **#6 Build system**: adopt Maven/Gradle; unvendor XZ (`org.tukaani:xz`);
+  consume JavaHelp from Maven Central; target a modern LTS; derive version
+  constants from the build.
+- **#12 Repo hygiene**: 31 `CVS/` metadata directories are tracked in git;
+  `.gitignore` has duplicate entries; Eclipse metadata needs a decision.
+- **#7 CI**: GitHub Actions build on JDK 17/21 with lint, artifact upload.
+- **#14 Tests**: JUnit 5; save/load round-trips for all three file formats
+  (`.jls` zip, `.jls_txt`, `.jls_xz`); headless batch-mode simulation tests;
+  a corpus of known-good circuit files for backward compatibility.
+
+### Phase 2 — Correctness
+- **#2 Zip loading bug**: root cause above; fix by not closing the `ZipFile`
+  until the data is fully read, and stop swallowing errors via
+  `catch (Throwable) { return null; }` in the format-sniffing chain.
+- **#15 Consolidate file I/O**: three inconsistent implementations exist
+  (`JLSStart` scanner helpers, the older zip-sniffing path in the image-export
+  branch, and the unused `jls/fileAbstractor.java` draft, which has its own
+  zip bugs — no `getNextEntry()`/`putNextEntry()`). Unify behind one
+  `FileAbstractor` with real error propagation.
+
+### Phase 3 — Modernization
+- **#9 Remove applet support**: `JLSApplet` extends `JApplet`, which is
+  deprecated for removal and being dropped from the JDK; browsers removed
+  applet support years ago. Remove the class and the `JLSInfo.isApplet` paths.
+- **#10 Deprecated APIs**: 28× `InputEvent.CTRL_MASK` → `CTRL_DOWN_MASK` /
+  `getMenuShortcutKeyMaskEx()` (fixes macOS shortcut convention too);
+  `new URL(String)` → `URI.create(...).toURL()`.
+- **#11 JavaHelp**: decide between consuming `javax.help:javahelp:2.0.05`
+  from Maven Central or replacing the help viewer with browser-launched HTML;
+  either way remove the checked-in `lib/jhall.jar`, the stale absolute path
+  in `.project`, and the binary `JavaHelpSearch` index files.
+
+### Phase 4 — Ship it
+- **#8 Release infrastructure**: version scheme decision, shaded runnable
+  jar (`Main-Class: jls.JLS`), tag-triggered release workflow, optional
+  `jpackage` installers.
+- **#13 README**: what JLS is, screenshot, run/build instructions, provenance
+  and licensing (explain `pop_GPLv3.pdf`), file-format notes, contribution
+  pointers.
+
+### Later / performance
+- **#3 Faster collision checking** (pre-existing issue): skeleton started in
+  commit f3e3b1c; a uniform grid keyed on the 12px snap spacing or a quadtree
+  over element bounding boxes would replace the current linear scans. Do after
+  tests exist.
+
+## Items investigated and considered fine for now
+
+- **Security**: no network-facing code beyond loading local files; the XZ
+  vendored code is the pure-Java org.tukaani implementation (unrelated to the
+  2024 xz-utils backdoor, which affected the C library's build scripts).
+  Moving to the Maven artifact still improves supply-chain hygiene.
+- **`pop_GPLv3.pdf` in the repo root**: unusual but load-bearing — it appears
+  to document the original author's GPLv3 relicensing grant. Keep (perhaps
+  under `docs/`) and explain in the README rather than delete.
+- **Swing as the UI toolkit**: still fully supported in modern JDKs; no
+  migration needed.

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -1,8 +1,9 @@
 # JLS Maintenance Audit — July 2026
 
 This document records the findings of a full maintenance audit of the JLS
-(Java Logic Simulator) repository. The actionable items are tracked on GitHub:
-see the roadmap in issue #16, which links every item below as a sub-issue.
+(Java Logic Simulator) repository, plus a follow-up performance/memory/file-size
+audit. The actionable items are tracked on GitHub: see the roadmap in issue
+#16, which links every item below as a sub-issue.
 
 ## Headline findings
 
@@ -59,7 +60,56 @@ see the roadmap in issue #16, which links every item below as a sub-issue.
   zip bugs — no `getNextEntry()`/`putNextEntry()`). Unify behind one
   `FileAbstractor` with real error propagation.
 
-### Phase 3 — Modernization
+### Phase 3 — Performance & efficiency
+
+Prompted by the report that selections with many elements are unworkably slow.
+All findings verified against the source; line references are to the current
+`master`.
+
+- **#17 Editor interaction scales badly**. Every mouse event does
+  full-circuit work:
+  - Hover (`SimpleEditor.mouseMoved`, line 2140): loops all elements and
+    triggers a full-canvas `repaint()` on every pixel of motion.
+  - Rubber-band selection (`mouseDragged`, line 2066): O(n) scan + full
+    repaint per event.
+  - Moving a selection (`overlap()`, line 2794): nested loop over
+    selected × all elements per drag event — **O(S×N) per event** — with
+    `untouchAll()` (line 3198) full scans on failure paths. This is the
+    reported "large selection" case. A commented-out optimization draft
+    already sits inside `overlap()` (relates to pre-existing issue #3).
+  - Repaint (`Circuit.draw`, line 640): iterates the element list four
+    times and draws everything; no clip-rect, dirty regions, or cached
+    static layer. Every wire segment and wire end is a separate Element,
+    so N is much larger than the visible component count.
+  - `Element.getRect()` allocates a new `Rectangle` per hit test → GC churn.
+  - Remedies: uniform-grid spatial index on the 12px snap spacing,
+    selection bounding-box broad phase, `repaint(Rectangle)` dirty regions,
+    offscreen static layer, hover short-circuit.
+- **#18 Undo deep-copies the whole circuit on every change**
+  (`markChanged` → `pushCopy` → `Util.copy`, SimpleEditor lines 3745/3793):
+  O(circuit) time per edit on the EDT and up to 11 live full copies in
+  memory. Remedy: command-pattern undo (deltas), or compact serialized
+  snapshots as an interim.
+- **#19 Checkpoints are written synchronously on the Swing event thread**
+  (every 10th change in `markChanged`): visible UI freezes on large
+  circuits; also non-atomic (truncated `.jls~` on crash) and zip-format
+  while saves are XZ. Remedy: background write, temp-file + rename, unify
+  format with #15.
+- **#3 Collision checking** (pre-existing): subsumed by the spatial index
+  in #17.
+- **#20 Memory efficiency**: the `Memory` element stores words as
+  `HashMap<Integer, BitSet>` (~100 bytes per word vs 8 in a `long[]`), and
+  its `activity` write history grows unbounded during a simulation with two
+  `BitSet` clones per write. Remedy: dense `long[]` for `bits <= 64` with
+  sparse fallback; bounded history; audit simulator-wide `BitSet` cloning.
+- **#21 Saved file size**: saves already write XZ (default preset 6) into
+  files named `.jls`, while checkpoints use zip; the text format is
+  dominated by per-wire-end `ELEMENT` blocks and saves recomputable
+  attributes; `Memory` initial contents are escaped decimal text. Remedy:
+  measure real circuits first, then preset 9, attribute pruning, hex+RLE
+  memory encoding — keeping the loader backward compatible (#14 guards).
+
+### Phase 4 — Modernization
 - **#9 Remove applet support**: `JLSApplet` extends `JApplet`, which is
   deprecated for removal and being dropped from the JDK; browsers removed
   applet support years ago. Remove the class and the `JLSInfo.isApplet` paths.
@@ -71,19 +121,13 @@ see the roadmap in issue #16, which links every item below as a sub-issue.
   either way remove the checked-in `lib/jhall.jar`, the stale absolute path
   in `.project`, and the binary `JavaHelpSearch` index files.
 
-### Phase 4 — Ship it
+### Phase 5 — Ship it
 - **#8 Release infrastructure**: version scheme decision, shaded runnable
   jar (`Main-Class: jls.JLS`), tag-triggered release workflow, optional
   `jpackage` installers.
 - **#13 README**: what JLS is, screenshot, run/build instructions, provenance
   and licensing (explain `pop_GPLv3.pdf`), file-format notes, contribution
   pointers.
-
-### Later / performance
-- **#3 Faster collision checking** (pre-existing issue): skeleton started in
-  commit f3e3b1c; a uniform grid keyed on the 12px snap spacing or a quadtree
-  over element bounding boxes would replace the current linear scans. Do after
-  tests exist.
 
 ## Items investigated and considered fine for now
 

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs baseline for JLS.
+
+  Everything excluded here is a KNOWN, intentionally deferred finding.
+  New findings of any other kind fail the build (threshold High, see pom.xml).
+  Shrink this file over time; do not add to it to silence a new bug.
+-->
+<FindBugsFilter>
+
+  <!-- Deliberate global state, pervasive in the original design:
+       JLSInfo.* globals, Circuit.lineNumber load cursor, Eula.ok, and the
+       per-gate-class "remember last dialog settings" statics
+       (previousBits/previousInputs/previousOrientation and similar).
+       Untangling this is an architectural refactor, not a point fix. -->
+  <Match>
+    <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
+  </Match>
+
+  <!-- DefaultExceptionHandler frees a ballast allocation and explicitly GCs
+       inside the OutOfMemoryError handler so the error dialog has headroom.
+       A legitimate System.gc() use. -->
+  <Match>
+    <Class name="jls.DefaultExceptionHandler"/>
+    <Bug pattern="DM_GC"/>
+  </Match>
+
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.github.anadon</groupId>
+  <artifactId>jls</artifactId>
+  <version>4.2.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>JLS - Java Logic Simulator</name>
+  <description>An educational digital logic circuit editor and simulator,
+    originally by David A. Poplawski (Michigan Technological University).</description>
+  <url>https://github.com/anadon/JLS</url>
+
+  <licenses>
+    <license>
+      <name>GNU General Public License v3.0</name>
+      <url>https://www.gnu.org/licenses/gpl-3.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <!-- replaces the vendored sources in xz/ (kept in-tree until #6 removes them;
+         they are not part of this build) -->
+    <dependency>
+      <groupId>org.tukaani</groupId>
+      <artifactId>xz</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <!-- replaces the checked-in lib/jhall.jar -->
+    <dependency>
+      <groupId>javax.help</groupId>
+      <artifactId>javahelp</artifactId>
+      <version>2.0.05</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- historical layout: sources in src/, not src/main/java -->
+    <sourceDirectory>src</sourceDirectory>
+    <resources>
+      <!-- images and other non-Java files that live inside the source tree -->
+      <resource>
+        <directory>src</directory>
+        <excludes>
+          <exclude>**/*.java</exclude>
+          <exclude>**/CVS/**</exclude>
+        </excludes>
+      </resource>
+      <!-- JavaHelp helpset -->
+      <resource>
+        <directory>resources</directory>
+        <excludes>
+          <exclude>**/CVS/**</exclude>
+        </excludes>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:deprecation,removal,unchecked</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>jls.JLS</mainClass>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.8.6.4</version>
+        <configuration>
+          <effort>Max</effort>
+          <!-- fail the build only on the highest-confidence findings;
+               the full backlog is tracked via the exclude baseline -->
+          <threshold>High</threshold>
+          <excludeFilterFile>config/spotbugs-exclude.xml</excludeFilterFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/jls/DefaultExceptionHandler.java
+++ b/src/jls/DefaultExceptionHandler.java
@@ -1,5 +1,7 @@
 package jls;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.swing.JOptionPane;
 import java.io.*;
 import java.util.*;
@@ -115,7 +117,7 @@ public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHa
 		
 		//th.printStackTrace(); // remove this when not debugging
 		try {
-			PrintWriter out = new PrintWriter("JLSerror");
+			PrintWriter out = new PrintWriter("JLSerror", StandardCharsets.UTF_8);
 			out.println("Please email this file to pop@mtu.edu");
 			out.println("along with a short description of what");
 			out.println("you were doing when the error occured.");
@@ -129,7 +131,7 @@ public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHa
 				circuit.save(out);
 			out.close();
 		}
-		catch (FileNotFoundException ex) {
+		catch (IOException ex) {
 			System.out.println("Can't create JLSerror file");
 		}
 	} // end of saveTrace method

--- a/src/jls/Eula.java
+++ b/src/jls/Eula.java
@@ -1,5 +1,9 @@
 package jls;
 
+import java.nio.charset.StandardCharsets;
+
+import java.nio.charset.Charset;
+
 import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
@@ -27,7 +31,7 @@ public final class Eula extends JDialog implements ActionListener {
 		String home = System.getProperty("user.home");
 		File f = new File(home + "/.jls" + JLSInfo.vers);
 		try {
-			Scanner input = new Scanner(new FileInputStream(f));
+			Scanner input = new Scanner(new FileInputStream(f), StandardCharsets.UTF_8);
 			if (input.hasNextLong()) {
 				long code = input.nextLong();
 				if (code%17==0 && code%97==0)
@@ -40,7 +44,7 @@ public final class Eula extends JDialog implements ActionListener {
 		presentEula();
 		if (ok) {
 			try {
-				PrintWriter output = new PrintWriter(new FileOutputStream(f));
+				PrintWriter output = new PrintWriter(new FileOutputStream(f), true, StandardCharsets.UTF_8);
 				int start = 1000000000;
 				int stop = Integer.MAX_VALUE;
 				long code = System.currentTimeMillis() % (stop-start) + start;
@@ -79,7 +83,7 @@ public final class Eula extends JDialog implements ActionListener {
 			System.out.println(line);
 		}
 		System.out.print("\nDo you accept the terms of the license agreement [Y/n]? ");
-		Scanner s = new Scanner(System.in);
+		Scanner s = new Scanner(System.in, Charset.defaultCharset());
 		String in = s.nextLine();
 		if(in.equalsIgnoreCase("y") || in.length() == 0) ok = true;
 	}

--- a/src/jls/JLS.java
+++ b/src/jls/JLS.java
@@ -128,7 +128,7 @@ public final class JLS  {
 		else {
 			try {
 				URL [] url = new URL[1];
-				url[0] = new URL("file:" + urlName);
+				url[0] = new File(urlName).toURI().toURL();
 				@SuppressWarnings({ "resource", "unchecked" })
 				Class<Element> newElement = (Class<Element>) new URLClassLoader(url).loadClass(cl);
 				Method[] methods = newElement.getMethods();

--- a/src/jls/JLSApplet.java
+++ b/src/jls/JLSApplet.java
@@ -19,6 +19,9 @@ import javax.help.*;
  * 
  * @author David A. Poplawski
  */
+// The Applet API is deprecated for removal from the JDK and applets no longer
+// run in browsers; removing this class entirely is tracked in issue #9.
+@SuppressWarnings("removal")
 public final class JLSApplet extends JApplet implements ActionListener, ChangeListener {
 
 	// properties

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -1,5 +1,7 @@
 package jls;
 
+import java.nio.charset.StandardCharsets;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -231,7 +233,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 				System.out.println("Can't read from " + startFile);
 				System.exit(1);
 			}
-			Scanner input = new Scanner(in);
+			Scanner input = new Scanner(in, StandardCharsets.UTF_8);
 
 			// create new circuit
 			Circuit circ = new Circuit(cname);
@@ -1237,7 +1239,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	
 	private static Scanner getXZScanner(String filePath){
 		try{
-			return testScanner(new Scanner(new SeekableXZInputStream(new SeekableFileInputStream(new File(filePath)))));
+			return testScanner(new Scanner(new SeekableXZInputStream(new SeekableFileInputStream(new File(filePath))), StandardCharsets.UTF_8));
 		}catch(Throwable e){
 			return null;
 		}
@@ -1246,7 +1248,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private static Scanner getZipScanner(String filePath){
 		try{
 			ZipFile target = new ZipFile(new File(filePath));
-			Scanner toReturn = testScanner(new Scanner(target.getInputStream(target.getEntry("JLSCircuit"))));
+			Scanner toReturn = testScanner(new Scanner(target.getInputStream(target.getEntry("JLSCircuit")), StandardCharsets.UTF_8));
 			target.close();
 			return toReturn;
 		}catch(Throwable e){
@@ -1256,7 +1258,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	
 	private static Scanner getTextScanner(String filePath){
 		try{
-			return testScanner(new Scanner(new File(filePath)));
+			return testScanner(new Scanner(new File(filePath), StandardCharsets.UTF_8));
 		}catch(Throwable e){
 			return null;
 		}
@@ -1355,7 +1357,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 			// open file, set up miscellaneous stuff
 			FileInputStream input = new FileInputStream(paramFile);
-			Scanner scan = new Scanner(input);
+			Scanner scan = new Scanner(input, StandardCharsets.UTF_8);
 
 			// read info
 			while (scan.hasNext()) {

--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -1,5 +1,9 @@
 package jls.edit;
 
+import java.nio.charset.StandardCharsets;
+
+import java.io.OutputStreamWriter;
+
 import java.awt.Component;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -69,7 +73,7 @@ public final class Editor extends SimpleEditor {
 					JOptionPane.ERROR_MESSAGE);
 			return false;
 		}
-		PrintWriter output = new PrintWriter(out);
+		PrintWriter output = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 
 		// save the circuit
 		circuit.save(output);

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -1,5 +1,9 @@
 package jls.edit;
 
+import java.nio.charset.StandardCharsets;
+
+import java.io.OutputStreamWriter;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -408,50 +412,50 @@ public abstract class SimpleEditor extends JPanel {
 
 				// set up popup menus
 				probe.setToolTipText("watch activity on this wire during simulation");
-				probe.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,InputEvent.CTRL_MASK));
+				probe.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,InputEvent.CTRL_DOWN_MASK));
 				watch.setToolTipText("watch activity on this element during simulation");
-				watch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_MASK));
+				watch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_DOWN_MASK));
 				modify.setToolTipText("view/modify element details");
-				modify.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M,InputEvent.CTRL_MASK));
+				modify.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M,InputEvent.CTRL_DOWN_MASK));
 				timing.setToolTipText("change propagation delay or access time");
-				timing.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T,InputEvent.CTRL_MASK));
+				timing.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T,InputEvent.CTRL_DOWN_MASK));
 				view.setToolTipText("view current simulated value");
-				view.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,InputEvent.CTRL_MASK));
+				view.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,InputEvent.CTRL_DOWN_MASK));
 				cut.setToolTipText("cut all selected elements to clipboard");
-				cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X,InputEvent.CTRL_MASK));
+				cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X,InputEvent.CTRL_DOWN_MASK));
 				copy.setToolTipText("copy all selected elements to clipboard");
-				copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,InputEvent.CTRL_MASK));
+				copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,InputEvent.CTRL_DOWN_MASK));
 				delete.setToolTipText("delete all selected elements");
 				delete.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,0));
 				lock.setToolTipText("make selected elements uneditable (cannot be undone)");
-				lock.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L,InputEvent.CTRL_MASK));
+				lock.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L,InputEvent.CTRL_DOWN_MASK));
 
 				// TODO: Make an action for this.
 				//matchJump.setToolTipText("create the wire end to match this wire start");
-				//matchJump.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R,InputEvent.CTRL_MASK));
+				//matchJump.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R,InputEvent.CTRL_DOWN_MASK));
 
 				connect.setToolTipText("create a new wire");
-				connect.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_MASK));
+				connect.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(connect);
 
 				paste.setToolTipText("paste contents of clipboard");
-				paste.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V,InputEvent.CTRL_MASK));
+				paste.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(paste);
 
 				selAll.setToolTipText("select all elements");
-				selAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,InputEvent.CTRL_MASK));
+				selAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(selAll);
 
 				close.setToolTipText("close this circuit");
-				close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E,InputEvent.CTRL_MASK));
+				close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(close);
 
 				undo.setToolTipText("undo last modification");
-				undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z,InputEvent.CTRL_MASK));
+				undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(undo);
 
 				redo.setToolTipText("redo last undo");
-				redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y,InputEvent.CTRL_MASK));
+				redo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y,InputEvent.CTRL_DOWN_MASK));
 				newMenu.add(redo);
 
 				makeElements();
@@ -536,7 +540,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_MASK),"ctrlw");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_W,InputEvent.CTRL_DOWN_MASK),"ctrlw");
 				getActionMap().put("ctrlw", ctrlw);
 
 				// set up end wire key binding
@@ -603,7 +607,7 @@ public abstract class SimpleEditor extends JPanel {
 
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_S,InputEvent.CTRL_MASK),"view");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_S,InputEvent.CTRL_DOWN_MASK),"view");
 				getActionMap().put("view", see);
 
 				// set up modify key binding
@@ -621,7 +625,7 @@ public abstract class SimpleEditor extends JPanel {
 						doModify();
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_M,InputEvent.CTRL_MASK),"modify");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_M,InputEvent.CTRL_DOWN_MASK),"modify");
 				getActionMap().put("modify", modify);
 
 				// set up probe key binding
@@ -644,7 +648,7 @@ public abstract class SimpleEditor extends JPanel {
 						doProbe();
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_P,InputEvent.CTRL_MASK),"probe");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_P,InputEvent.CTRL_DOWN_MASK),"probe");
 				getActionMap().put("probe", probe);
 
 				// set up timing key binding
@@ -667,7 +671,7 @@ public abstract class SimpleEditor extends JPanel {
 						doTiming();
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_T,InputEvent.CTRL_MASK),"timing");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_T,InputEvent.CTRL_DOWN_MASK),"timing");
 				getActionMap().put("timing",timing);
 
 				// set up selectAll key binding
@@ -681,7 +685,7 @@ public abstract class SimpleEditor extends JPanel {
 						doSelectAll();
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_A,InputEvent.CTRL_MASK),"select all");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_A,InputEvent.CTRL_DOWN_MASK),"select all");
 				getActionMap().put("select all", selectAll);
 
 				// set up close window key binding
@@ -690,7 +694,7 @@ public abstract class SimpleEditor extends JPanel {
 						close();
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_E,InputEvent.CTRL_MASK),"close window");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_E,InputEvent.CTRL_DOWN_MASK),"close window");
 				getActionMap().put("close window", closeWin);
 
 				// set up delete key binding
@@ -721,7 +725,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_X,InputEvent.CTRL_MASK),"do cut");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_X,InputEvent.CTRL_DOWN_MASK),"do cut");
 				getActionMap().put("do cut", cutKey);
 
 				// set up copy key binding
@@ -735,7 +739,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_C,InputEvent.CTRL_MASK),"do copy");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_C,InputEvent.CTRL_DOWN_MASK),"do copy");
 				getActionMap().put("do copy", copyKey);
 
 				// set up paste key binding
@@ -751,7 +755,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_V,InputEvent.CTRL_MASK),"do paste");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_V,InputEvent.CTRL_DOWN_MASK),"do paste");
 				getActionMap().put("do paste", pasteKey);
 
 				// set up undo key binding
@@ -763,7 +767,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z,InputEvent.CTRL_MASK),"do undo");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z,InputEvent.CTRL_DOWN_MASK),"do undo");
 				getActionMap().put("do undo", undoKey);
 
 				// set up redo key binding
@@ -775,7 +779,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Y,InputEvent.CTRL_MASK),"do redo");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Y,InputEvent.CTRL_DOWN_MASK),"do redo");
 				getActionMap().put("do redo", redoKey);
 
 				// set up lock key binding
@@ -805,7 +809,7 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_L,InputEvent.CTRL_MASK),"do lock");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_L,InputEvent.CTRL_DOWN_MASK),"do lock");
 				getActionMap().put("do lock", lockKey);
 
 			} // end of constructor
@@ -3775,7 +3779,7 @@ public abstract class SimpleEditor extends JPanel {
 							catch (IOException ex) {
 								return;
 							}
-							PrintWriter output = new PrintWriter(out);
+							PrintWriter output = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 
 							// save the circuit
 							boolean changed = circuit.hasChanged();

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -617,7 +617,7 @@ public abstract class Gate extends LogicElement {
 			// set up input panel
 			this.type = type;
 			JPanel info = null;
-			if (type.equals("NOT") || type.equals("XOR") || type == "Extend") {
+			if (type.equals("NOT") || type.equals("XOR") || type.equals("Extend")) {
 				info = new JPanel(new GridLayout(1,2));
 			}
 			else {

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -463,9 +463,9 @@ public abstract class Group extends LogicElement {
 		
 		// properties
 		private DefaultListModel<Entry> pick = new DefaultListModel<Entry>();
-		private JList choose = new JList(pick); // LeftList?
+		private JList<Entry> choose = new JList<Entry>(pick); // LeftList?
 		private DefaultListModel<Entry> picked = new DefaultListModel<Entry>();
-		private JList chosen = new JList(picked);
+		private JList<Entry> chosen = new JList<Entry>(picked);
 		private JButton add = new JButton(">>");
 		private JButton remove = new JButton("<<");
 		private JButton upjumper = new JButton("Move bundle to top");
@@ -515,7 +515,7 @@ public abstract class Group extends LogicElement {
 			// set up automatic disabling of already-bundled bits
 			choose.setCellRenderer(new DefaultListCellRenderer() {
 				@Override
-				public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+				public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
 					boolean allow = true;
 					Entry e = (Entry) pick.get(index);
 					if(e.isPicked()) {

--- a/src/jls/elem/JumpEnd.java
+++ b/src/jls/elem/JumpEnd.java
@@ -401,7 +401,7 @@ public class JumpEnd extends LogicElement {
 			heading.setAlignmentX((float)0.5);
 			window.add(heading);
 
-			starts = new JList<String>((String[]) circuit.getJumpStartNames().toArray());
+			starts = new JList<String>(circuit.getJumpStartNames().toArray(new String[0]));
 			starts.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			starts.setVisibleRowCount(Math.min(circuit.getJumpStartNames().size(),10));
 			JScrollPane pane = new JScrollPane(starts);

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -1,5 +1,7 @@
 package jls.elem;
 
+import java.nio.charset.StandardCharsets;
+
 import jls.*;
 import jls.sim.*;
 import java.awt.*;
@@ -1050,7 +1052,7 @@ public class Memory extends LogicElement {
 				File file = new File(fileName);
 				int length = (int)file.length();
 				FileInputStream in = new FileInputStream(file);
-				InputStreamReader input = new InputStreamReader(in);
+				InputStreamReader input = new InputStreamReader(in, StandardCharsets.UTF_8);
 				char [] info = new char[length];
 				input.read(info,0,length);
 				input.close();

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -950,7 +950,7 @@ public final class StateMachine extends LogicElement implements Printable {
 					createNewState();
 				}
 			};
-			editArea.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_N,InputEvent.CTRL_MASK),"new state");
+			editArea.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_N,InputEvent.CTRL_DOWN_MASK),"new state");
 			editArea.getActionMap().put("new state", newState);
 
 			// set up window close listener to cancel element
@@ -1975,7 +1975,7 @@ public final class StateMachine extends LogicElement implements Printable {
 			BitSet cval = getInput("clock").getValue();
 			if (cval == null)
 				cval = new BitSet();
-			int newClock = (int)(BitSetUtils.ToLong(getInput("clock").getValue()));
+			int newClock = (int)(BitSetUtils.ToLong(cval));
 			
 			// if still doing a transition, don't start another
 			if (busy) {

--- a/src/jls/elem/TestGen.java
+++ b/src/jls/elem/TestGen.java
@@ -1,5 +1,7 @@
 package jls.elem;
 
+import java.nio.charset.StandardCharsets;
+
 import jls.*;
 import jls.sim.*;
 
@@ -76,7 +78,7 @@ public class TestGen extends SigSim {
 				return;
 			}
 		}
-		Scanner input = new Scanner(in);
+		Scanner input = new Scanner(in, StandardCharsets.UTF_8);
 		super.initSim(sim,input);
 	} // end of initSim method
 	

--- a/src/jls/elem/Text.java
+++ b/src/jls/elem/Text.java
@@ -320,9 +320,9 @@ public class Text extends DisplayElement {
 	private class TextEdit extends JDialog implements ActionListener {
 
 		// GUI elements
-		private JComboBox fonts;
+		private JComboBox<String> fonts;
 		private String [] fontSizes = {"8","9","10","11","12","13","14","15","16","17","18","19","20","24","28","32","36","40","48","56","64","72"};
-		private JComboBox fontSz = new JComboBox(fontSizes);
+		private JComboBox<String> fontSz = new JComboBox<String>(fontSizes);
 		private JRadioButton bold = new JRadioButton("Bold");
 		private JRadioButton italic = new JRadioButton("Italic");
 		private JButton colorButton = new JButton("Color");
@@ -366,7 +366,7 @@ public class Text extends DisplayElement {
 			else {
 				fn = new String(fontName);
 			}
-			fonts = new JComboBox(names);
+			fonts = new JComboBox<String>(names);
 			fonts.setSelectedItem(fn);
 			details.add(new JLabel("Font:"));
 			details.add(fonts);

--- a/src/jls/fileAbstractor.java
+++ b/src/jls/fileAbstractor.java
@@ -1,5 +1,7 @@
 package jls;
 
+import java.nio.charset.StandardCharsets;
+
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -36,11 +38,11 @@ public class fileAbstractor {
 		Scanner textInput = null;
 		
 		if(filePath.endsWith(".jls_xz")){
-			textInput = new Scanner(new XZInputStream(new FileInputStream(filePath)));
+			textInput = new Scanner(new XZInputStream(new FileInputStream(filePath)), StandardCharsets.UTF_8);
 		}else if(filePath.endsWith(".jls_txt")){
-			textInput = new Scanner(new FileInputStream(filePath));
+			textInput = new Scanner(new FileInputStream(filePath), StandardCharsets.UTF_8);
 		}else if(filePath.endsWith(".jls")){
-			textInput = new Scanner(new ZipInputStream(new FileInputStream(filePath)));
+			textInput = new Scanner(new ZipInputStream(new FileInputStream(filePath)), StandardCharsets.UTF_8);
 		}else{
 			throw new IllegalArgumentException();
 		}
@@ -77,7 +79,7 @@ public class fileAbstractor {
 		}
 		
 		while(!toWrite.isEmpty()){
-			textOutput.write(toWrite.pop().concat(" ").getBytes());
+			textOutput.write(toWrite.pop().concat(" ").getBytes(StandardCharsets.UTF_8));
 		}
 		
 		textOutput.close();

--- a/src/jls/sim/Trace.java
+++ b/src/jls/sim/Trace.java
@@ -115,14 +115,8 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 			return;
 			
 		Change ch = new Change();
-		if (value == null) {
-			ch.value = off;
-			previousValue = off;
-		}
-		else {
-			ch.value = (BitSet)value.clone();
-			previousValue = (BitSet)value.clone();
-		}
+		ch.value = (BitSet)value.clone();
+		previousValue = (BitSet)value.clone();
 		ch.when = when;
 		pendingChanges.add(0,ch);
 		


### PR DESCRIPTION
## Summary

This PR establishes a modern Maven build infrastructure for JLS, replacing the Eclipse-only project metadata. It introduces compiler lint checks (`-Xlint:deprecation,removal,unchecked -Werror`) and SpotBugs static analysis as build gates, along with a GitHub Actions CI workflow. The changes also fix 19 correctness and modernization issues uncovered by these new checks.

## Key Changes

**Build Infrastructure:**
- Added `pom.xml` targeting Java 17 LTS, with dependencies on Maven Central artifacts (`org.tukaani:xz`, `javax.help:javahelp`) to replace vendored code
- Configured Maven compiler plugin with strict lint flags (`-Werror` fails on warnings)
- Integrated SpotBugs analysis (threshold: High confidence) with baseline exclusions in `config/spotbugs-exclude.xml`
- Added `.github/workflows/ci.yml` to run `mvn verify` on JDK 17 and 21 with artifact upload

**Correctness Fixes (19 findings):**
- **File I/O encoding:** Added explicit `StandardCharsets.UTF_8` to 15 `Scanner` and `PrintWriter` constructors across `JLSStart.java`, `Eula.java`, `fileAbstractor.java`, `DefaultExceptionHandler.java`, `Editor.java`, `Memory.java`, and `TestGen.java` to eliminate platform-default-encoding bugs
- **Deprecated API modernization:** Replaced 28 instances of `InputEvent.CTRL_MASK` with `InputEvent.CTRL_DOWN_MASK` (behavior-preserving; switching menu accelerators to `getMenuShortcutKeyMaskEx()` for macOS ⌘ is deliberately deferred — see issue #10) in `SimpleEditor.java` and `StateMachine.java`
- **URL construction:** Changed `new URL("file:" + path)` to `new File(path).toURI().toURL()` in `JLS.java` for proper URI handling
- **Generic type safety:** Added type parameters to raw `JList` and `JComboBox` declarations in `Group.java` and `Text.java`
- **Logic fix:** Removed dead null-check branch in `Trace.addValue()` that would never execute
- **String comparison:** Fixed `==` to `.equals()` for string comparison in `Gate.java`
- **Array cast safety:** Fixed guaranteed `ClassCastException` in `JumpEnd.java` name dialog (cast result of `toArray()` to correct type)
- **Applet deprecation:** Added `@SuppressWarnings("removal")` to `JLSApplet` class (full removal tracked in issue #9)

**Documentation:**
- Added comprehensive `MAINTENANCE_AUDIT.md` documenting the full audit findings, root causes (e.g., zip loading bug in #2), and a 6-phase roadmap with 24 tracked GitHub issues (umbrella: #16)

## Notable Details

- SpotBugs baseline (`spotbugs-exclude.xml`) intentionally defers architectural issues (global state, deliberate GC in OOM handler) to future refactors
- Maven layout respects historical source structure (`src/` instead of `src/main/java`)
- CI workflow caches Maven artifacts and uploads the built jar for JDK 21
- All changes are backward compatible; no functional behavior altered beyond bug fixes

https://claude.ai/code/session_0136UwuGGq3Q1X1WC6tBc1s5