### PR TITLE
Add post-modernization project and code audit (July 2026)

### DIFF
--- a/AUDIT-2026-07.md
+++ b/AUDIT-2026-07.md
@@ -1,0 +1,523 @@
+# JLS Project & Code Audit — July 2026 (post-modernization)
+
+This document records a full project and code audit of the JLS repository at
+commit `9afcce0` (merge of PR #32), performed after the completion of the
+2026 maintenance and modernization program tracked in issue #16. It succeeds
+[MAINTENANCE_AUDIT.md](MAINTENANCE_AUDIT.md), which is now a historical
+snapshot of the pre-modernization codebase.
+
+**Method.** The whole tree was re-read for this audit: the core `jls`
+package, `jls/edit`, `jls/sim`, all of `jls/elem` (~60 files), the test
+suite, build and CI configuration, and repository metadata. Every finding
+below was verified against the current source (several were additionally
+verified empirically by running code); recent refactors were diffed against
+their pre-refactor revisions to separate regressions from faithfully
+preserved legacy bugs. Line numbers refer to commit `9afcce0`.
+
+## Executive summary
+
+The modernization program achieved what it set out to do. The build is
+green: `mvn verify` compiles with `-Werror` lint, runs 70 tests in 12
+classes (all passing), and SpotBugs reports zero findings. All 25 roadmap
+issues are closed. The big refactors — data-driven gates (#22), the
+attribute-persistence registry (#23), canonical geometry + grid transforms
+(#24), the merged simulator event loop (#25), the shared dialog base (#26),
+dense Memory storage (#20), snapshot-based undo (#18), the spatial index
+(#17/#3), and the checkpoint pipeline (#19) — were each checked against
+their pre-refactor behavior and found faithful. The test suite, for a
+codebase that had zero tests a year ago, is genuinely good.
+
+The audit nevertheless found **two critical, user-facing defects** — both
+legacy, neither introduced by the recent work:
+
+1. **The primary open→edit→save workflow is broken.** Opening a circuit
+   never records its directory, so Save writes to the filesystem root and
+   fails (silently compounding into data loss, because the unsaved-changes
+   flag is cleared before the write is attempted).
+2. **Every right-click menu action is dead code** due to a brace error from
+   a historical merge conflict; rotate, flip, and create-matching-end are
+   completely unreachable (they have no keyboard bindings).
+
+Beyond those, the highest-value problems are: values above ~48 bits
+silently becoming 0 (`BitSetUtils`), saved-string corruption for strings
+containing backslashes, an order-dependent reflective load path that can
+make every circuit containing a jump end unloadable, broken wire hover
+repaints (the one real regression from the recent work), unsynchronized
+cross-thread simulator state, and — at the project level — a release
+identity crisis: the app still calls itself "4.1, built March 2014",
+still gates startup on the superseded proprietary MTU EULA, and no release
+has ever actually been published.
+
+---
+
+## Part 1 — Project audit
+
+### State of the project
+
+| Aspect | State |
+| --- | --- |
+| Build | Maven, JDK 17+ (`release=17`), `-Xlint` + `-Werror`, shaded runnable jar |
+| Static analysis | SpotBugs `threshold=High`, effort Max, small baseline file; currently zero findings |
+| Tests | 70 tests / 12 classes, all passing; headless |
+| CI | GitHub Actions, JDK 17 + 21 matrix, artifact upload |
+| Releases | Tag-triggered workflow exists; **no tag ever pushed, zero releases published** |
+| Issues | 25/25 roadmap issues closed; no open issues |
+| License | GPLv3 with the original author's grant (`pop_GPLv3.pdf`); relicense confirmed by the maintainer |
+
+### P1 (high) — Version identity is stale and not build-injected
+
+`src/jls/JLSInfo.java:16-23` hardcodes `vers=4; release=1; buildNum=5;
+year=2014` and "built on March 18, 2014", while `pom.xml:9` says
+`4.2.0-SNAPSHOT`. These constants feed the window title, About dialog,
+crash reports, and even the EULA marker filename (`~/.jls4`). Nothing in
+the build (no resource filtering, no manifest attribute read) derives them
+from the pom. A `v4.2.0` release today would ship a jar whose UI says
+"4.1 from 2014".
+
+### P2 (high) — The superseded MTU EULA still gates startup
+
+`src/jls/Eula.java:145-215`, invoked from `JLS.main`
+(`src/jls/JLS.java:35`): the app refuses to run (exits with status 1)
+until the user accepts license text stating "Licensee may not … make any
+derivative works" and that all ownership remains with the Licensor —
+terms flatly contradicted by the GPLv3 relicense documented in
+`pop_GPLv3.pdf` and confirmed by the maintainer. The text also contains
+mojibake (`Licensor�s`). This is not a question of the relicense's
+validity — it is a leftover that misinforms users. Remove the gate (or
+replace it with a non-blocking GPLv3 notice in About). Related: none of
+the 87 source files carries a license header, so outside the repo root the
+files say nothing about their terms; and `Eula.presentOnTerminal`
+(line 87) throws `NoSuchElementException` on closed stdin instead of
+treating it as "declined".
+
+### P3 (medium) — The release path has never been exercised and is version-blind
+
+`.github/workflows/release.yml:25-33` builds whatever version the pom
+declares and uploads `target/jls-*.jar` — pushing `v4.2.0` with the
+current pom publishes `jls-4.2.0-SNAPSHOT.jar` as the release asset.
+There is no check that the tag matches the pom version, no checksums, no
+build provenance/attestation, and third-party actions are pinned by
+mutable tag (including `softprops/action-gh-release@v2`, which runs with
+`contents: write`). Meanwhile README.md points users at a Releases page
+that is empty. For an app students download and run, add: a tag↔pom
+consistency check, `sha256sum` output on the release, and ideally
+`actions/attest-build-provenance`.
+
+### P4 (medium) — SpotBugs baseline suppresses a bug pattern repo-wide
+
+`config/spotbugs-exclude.xml:16-18` excludes
+`ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` with no `<Class>` scoping — any
+*new* instance of that bug anywhere in the codebase is masked forever
+(the second entry, `DM_GC` scoped to `DefaultExceptionHandler`, shows the
+right pattern). Also, with `threshold=High` (pom.xml:142),
+medium/low-confidence findings neither fail the build nor appear in the
+baseline, so the pom's claim that "the full backlog is tracked via the
+exclude baseline" overstates coverage.
+
+### P5 (medium) — Test-suite gaps
+
+The suite's strengths are real: file round-trips through the actual
+sniffing loader across all three container formats, true batch-simulation
+goldens (full truth tables through the real simulator), property-based
+spatial-index parity testing, save/copy equivalence across ~25 element
+types, and good negative tests for the RLE codec. The notable gaps:
+
+- **Edge-triggering is not actually pinned** — the flip-flop goldens
+  (`test/jls/SequentialGoldenTest.java:137-162`) drive constant data into
+  a free-running clock and assert the settled value; a transparent latch
+  would pass. Nothing tests capture-on-edge with data changing between
+  edges. The StateMachine golden is one state with a self-loop.
+- **No legacy-file corpus.** No circuit actually saved by JLS 4.1 exists
+  as a fixture (zip tests build fresh archives), and `.gitignore`'s
+  `*.jls` rule would ignore any fixture someone tries to add.
+- **Zero coverage** of editor interaction, the undo/redo stack as used
+  from the editor, clipboard, dialogs, the interactive simulator, printing,
+  image export, and the batch CLI end-to-end — which is exactly where this
+  audit's critical bugs live. The two critical findings below would both
+  have been caught by one open→save integration test and one
+  menu-action smoke test.
+- Minor: `HelpTopicsTest`'s "topics used by code" list is hand-maintained
+  (nothing scans the source); the orientation baseline embeds diagnostic
+  message text (rewording an error breaks a geometry test); the checkpoint
+  test is the suite's only sleep/poll-based test. No coverage measurement
+  (JaCoCo) is wired in — note surefire's hand-set `argLine` (pom.xml:131)
+  must become `@{argLine}`-prefixed when adding it.
+
+### P6 (low) — Documentation and hygiene
+
+- `MAINTENANCE_AUDIT.md` still says "Tests: none, CI: none, Build:
+  Eclipse-only" — misleading without a historical disclaimer (added
+  alongside this document).
+- README omits that first launch currently demands EULA acceptance (P2),
+  and doesn't mention that files saved with RLE memory contents lose
+  their initial memory contents silently when opened in upstream JLS 4.1
+  (unknown attributes are ignored).
+- `resources/help/elements/Thumbs.db` is tracked and ships inside the
+  release jar (resource excludes only cover `**/CVS/**`).
+- Stale comments: pom.xml:30-31 references the deleted `xz/` tree;
+  ci.yml:28 says tests will run "once they exist".
+- CI builds same-repo PR branches twice (`push: branches: ["**"]` +
+  `pull_request`) with no `concurrency` cancellation; Linux-only (fine for
+  the headless suite, but OS-specific paths are never exercised).
+- No dependabot/renovate config; no enforcer plugin; no reproducible-build
+  `project.build.outputTimestamp`. (Dependency hygiene is otherwise fine:
+  two deps, both pinned.)
+- Merge-conflict marker text (`<<<<<<< HEAD`, `>>>>>>> 6fff4f8...`) is
+  shipped inside javadoc comments at `Circuit.java:754-770` and `943-951`.
+
+---
+
+## Part 2 — Code audit
+
+Findings are ordered by severity. "[regression]" marks defects introduced
+by the 2026 refactors; everything else is legacy behavior that survived
+them.
+
+### Critical
+
+**C1. Opened circuits never get their directory set — Save and checkpoints
+target the filesystem root.**
+`src/jls/JLSStart.java:1006-1077`: `open()` declares `String dir = ""`,
+never assigns it, and the only `circ.setDirectory(dir)` call is commented
+out (line 1057). `Circuit.dir` defaults to `""` (Circuit.java:52), so
+`Editor.save()` (src/jls/edit/Editor.java:59-66) builds
+`"" + "/" + name + ".jls"` = `/name.jls`. Open `/home/user/work/foo.jls`,
+edit, File→Save → "Can't write to /foo.jls" on Linux, or a silent write to
+the drive root on Windows. Checkpoints (`SimpleEditor.java:3932`) go to
+`/foo.jls~` the same way. The primary open→edit→save workflow is broken
+for any circuit opened from disk; only New→Save-As→Save works.
+
+**C2. Every popup-menu action is dead code.**
+`src/jls/edit/SimpleEditor.java:1301-1597`: in `actionPerformed`, the
+`if (event.getSource() == probe) {` branch is never closed until line
+1597, so the handlers for watch, modify, timing, view, cut, copy, delete,
+lock, paste, select-all, close, undo, redo, rotate CW/CCW, flip,
+create-matching-end, and connect are all nested inside it — and since an
+event source can't be both `probe` and `watch`, none can ever run (the
+original `doProbe()` call was also lost). Verified by brace-depth
+analysis. Most operations survive via separate keyboard InputMap actions,
+but **Rotate Clockwise, Rotate Counter-Clockwise, Flip, and Create
+Matching End have no keyboard binding and are completely unreachable**,
+and probe attach/remove via menu is a no-op. Introduced by a historical
+merge-conflict resolution (commit `3a996a8`), long before the 2026 work.
+
+### High
+
+**H1. A failed save silently disables the unsaved-changes protection.**
+`src/jls/Circuit.java:746` clears `changed = false` at serialization
+time, but `Editor.save()` serializes to a `StringWriter` *before* calling
+`FileAbstractor.writeCircuit`. If the write throws (disk full,
+permissions — or every time, given C1), the user sees the error dialog,
+but `hasChanged()` is already false: closing the window or app then exits
+with **no "save changes?" prompt and no checkpoint** → silent data loss.
+Clear the flag only after the write succeeds.
+
+**H2. `BitSetUtils.Create(long)` silently zeroes values above ~48 bits.**
+`src/jls/BitSetUtils.java:33-37` computes the bit count with
+floating-point `log`/`ceil`, which under-counts when `value+1` rounds to
+the same double as `value`. Verified empirically in this audit:
+`Create(1L<<k)` returns an **empty BitSet (value 0)** for k = 49, 50, 52,
+53, 54, 56, 57, 60, 61. Callers include `Register` initial values,
+`Constant`, `Memory`, and `SigSim` — a 50+ bit register initial value or
+constant simulates as 0 with no error. Use `64 -
+Long.numberOfLeadingZeros(value)` instead.
+
+**H3. Saved strings containing backslashes are corrupted on load.**
+`src/jls/Circuit.java:540-544, 585-589` (duplicated in the probe branch):
+the loader unescapes `\\`→`\` *first*, in the same order the writer
+escaped (`jls/elem/Attribute.java:193-195`), which is wrong — unescaping
+must run in reverse. A text attribute containing the literal characters
+`\n` round-trips into a real newline; a string ending in `\` loses the
+backslash and then mis-trims a quote. Round-trip data corruption for any
+element text containing a backslash.
+
+**H4. Element loading uses `getConstructors()[0]`, whose order is
+unspecified.**
+`src/jls/Circuit.java:400-401`. `jls.elem.JumpEnd` has two public
+constructors (`JumpEnd.java:41, 52`); if the JVM returns the two-arg one
+first, `newInstance(this)` throws and **every saved circuit containing a
+jump end fails to load** with a cryptic error. Works or breaks depending
+on JVM build. Select the 1-arg `(Circuit)` constructor explicitly.
+
+**H5. Wire hover repaints are broken — dirty regions use `Wire.getRect()`,
+a degenerate 0×0 rectangle. [regression]**
+`src/jls/edit/SimpleEditor.java:2279, 2287` (hover) and `2199, 2204`
+(rubber band): `Wire` doesn't override `getRect()` and its own javadoc
+(`Wire.java:195-197`) says the default rect "would be wrong". Hovering a
+wire repaints a 24×24 region at the canvas origin instead of the wire's
+span, so the highlight doesn't appear — and if a full repaint paints it,
+it is never un-painted when the cursor leaves (stale pink highlight). In
+the rubber-band path the degenerate rect silently defeats the dirty-region
+optimization whenever wires are involved. Regression from commit
+`4db8652` (#17); give `Wire` a real `getRect()` (it already has correct
+`getIndexBounds`). A cousin: `mousePressed` idle→selecting
+(lines 1668-1672) clears hover highlights without any repaint.
+
+**H6. Undo/redo restores the circuit but leaves editor gesture state
+pointing at the discarded one.**
+`src/jls/edit/SimpleEditor.java` — `finishDo` (4022-4075) swaps in a
+freshly loaded `Circuit` but never clears `selected`, `selRect`,
+`wireEnd`/`wire`/`net`, or `currentState`, and the ctrl-Z/ctrl-Y bindings
+(811-832) don't gate on editor state. Undo mid-move, mid-selection, or
+mid-wire-draw leaves the next mouse event operating on elements of the
+pre-undo circuit — wire drawing can bridge an orphaned `WireNet` into the
+restored circuit. (Snapshot *content* fidelity is good — see Part 3;
+this is about the surrounding editor state.) Reset gesture state in
+`finishDo`, or only honor undo/redo in the idle state.
+
+**H7. Simulator control state is shared across threads with no
+synchronization.**
+`src/jls/sim/Simulator.java:29` (`stopping`) and
+`src/jls/sim/InteractiveSimulator.java:26-30, 52, 732-748` (`stepAmount`,
+`stepEnd`, `paused`, `sim`, `timer`): plain non-volatile fields written by
+the EDT and the animation `Timer` thread, read in the sim thread's hot
+loop — Stop/Pause can legally be missed indefinitely under JIT hoisting.
+`runSim()`'s `if (sim != null) return;` races with `sim = null` at the end
+of `run()`. `SimpleEditor.enabled` is likewise set from the sim thread and
+read by EDT mouse handlers, so edits during simulation may be allowed.
+Make the flags volatile (or use `AtomicReference`/proper handoffs).
+
+**H8. Swing components are mutated from the simulator thread throughout
+the interactive simulator.**
+`src/jls/sim/InteractiveSimulator.java`: `beforeReact` (671-677) calls
+`showClock.setText` + `window.validate()` **per event**; `beforeEvent`
+(619-662), `run()` (536-585), and `pause()` (713-726, called from the
+Pause element mid-react) all mutate live components; `MemTrace.update()`
+does the same. Classic EDT violations — intermittent layout corruption
+plus a real slowdown (`validate()` per event). Pre-existing behavior that
+the #25 loop merge preserved rather than introduced; route UI updates
+through `SwingUtilities.invokeLater` and throttle the clock display.
+
+### Medium
+
+**M1. `-p`/`-v` print mode prints an empty book.** `src/jls/JLSStart.java:1574-1631`:
+`printCirc()` does `new Circuit(name)` + `finishLoad(null)` but never
+opens or loads the file — `jls -pPrinter counter.jls` prints blank pages.
+The feature is 100% non-functional (arguably High, but the feature has
+likely been broken and unused for years).
+
+**M2. Untrusted-file decompression bombs.** (a) `FileAbstractor.readZip`
+(`src/jls/FileAbstractor.java:150`) calls `readAllBytes()` on a zip entry
+with no size cap — a tiny archive inflating to gigabytes OOMs the app.
+(b) [regression] `Memory.decodeInitRLE` (`src/jls/elem/Memory.java:451-482`,
+commit `fa343ce`) checks `run >= 1` but no upper bound: a saved file
+containing `initrle "0:0:7fffffff"` expands to ~2³¹ lines in a
+`StringBuilder` during load → heap exhaustion; `addr + i` can also
+overflow int. Cap both against the memory's capacity. (c) The XZ path has
+the same property via `findInLine(".*")` materializing unbounded lines
+(`Circuit.java:535, 580`). DoS only, but fully attacker-controlled; the
+repo's own SECURITY.md anticipates malicious circuit files being shared.
+
+**M3. `FileAbstractor.readXZ` leaks a file descriptor on every non-XZ
+open.** `src/jls/FileAbstractor.java:126-131`: if the
+`SeekableXZInputStream` constructor throws (which it does by design for
+every legacy zip/plain-text file in the sniffing cascade), the inner
+`SeekableFileInputStream` is never closed — one leaked FD per open for the
+process lifetime, and a locked file on Windows. Same pattern in
+`writeCircuit` (line 104).
+
+**M4. Batch-mode error paths crash headlessly.**
+`src/jls/JLSStart.java:144, 159, 231, 241`: after
+`java.awt.headless=true` is set, error paths still call
+`JOptionPane.showMessageDialog` → `HeadlessException`, the intended
+`System.exit(1)` is skipped, and a routine user error (e.g. `jls -b
+bad.jls`) is reported as "UNEXPECTED INTERNAL ERROR!" with a crash file.
+
+**M5. Command-line parsing crashes on malformed input.**
+`src/jls/JLSStart.java:354-446`: six flags read `args[pos+1]` without a
+bounds check (`jls -t` → `ArrayIndexOutOfBoundsException` + crash file
+instead of usage); a bare `-` or empty argument crashes at lines 328-329.
+
+**M6. Load-error reporting is unreliable.** `src/jls/Circuit.java:402-405`:
+`ClassNotFoundException`/`InstantiationException` return false without
+setting `JLSInfo.loadError`, and `loadError` is never reset per load
+(`JLSInfo.java:108`) — the user sees a stale message from a previous
+failure. Subcircuit `finishLoad` failures are `printStackTrace`'d and
+swallowed (471-478); `fileImport` (`JLSStart.java:1249`) ignores
+`finishLoad`'s result; `Circuit.draw` (776-777) silently retries a failed
+deferred finish every repaint. `Scanner.ioException()` is checked nowhere,
+so mid-stream I/O corruption reads as clean EOF.
+
+**M7. Checkpoint race can resurrect a deleted `.jls~` after Save.**
+`src/jls/edit/Editor.java:75, 159, 274` + `SimpleEditor.java:155-172`: an
+edit queues a coalesced checkpoint; if the user saves before the writer
+thread drains it, `save()` deletes `file.jls~` and the background writer
+then re-creates it with pre-save content — next launch offers recovery
+from a checkpoint that shouldn't exist. Same hole in `saveAs()` and
+`shutdown()`. (The coalescing protocol itself is sound; it's only the
+delete/enqueue ordering.) Related legacy bug: after opening
+`/projects/foo.jls`, the checkpoint delete (`JLSStart.java:1072`) targets
+`./foo.jls~` in the CWD — deleting an unrelated same-named checkpoint and
+leaving the real one.
+
+**M8. Undo leaves sibling editors' Import menus pointing at the pre-undo
+circuit.** `SimpleEditor.java:263, 3874, 4041`: `finishDo` replaces the
+`Circuit` object but other editors' `circMap` still references the
+abandoned instance — Import then silently copies stale content.
+
+**M9. Interactive simulator handshake races.**
+`InteractiveSimulator.java:300-310, 353-363, 746`: Step releases the pause
+semaphore *before* updating `stepEnd`, so a woken sim thread can re-pause
+immediately (a Step click intermittently advances zero time); `stop()`
+releases a permit unconditionally and permits are never drained, so the
+first Pause of the next run falls through once. Trace buffers
+(`Trace.java:108-138`) are plain `LinkedList`s shared between the sim
+thread and the EDT (Apply/scale → `traces.draw()`), risking
+`ConcurrentModificationException` mid-run.
+
+**M10. `TextFilter.setMax(long)` parses the decimal rendering of max in
+the field's base.** `src/jls/TextFilter.java:39`: for a hex field,
+`setMax(255)` yields limit 0x255=597 (out-of-range values accepted); for a
+binary field, `setMax(5)` throws `NumberFormatException` on the EDT.
+
+**M11. Plugin loading resolves the manifest against the CWD and is not
+XXE-hardened.** `src/jls/JLS.java:88-99`: existence is checked with
+`base + entry` but `db.parse(entry)` uses the relative name — running the
+jar from any other directory makes startup `System.exit(1)`;
+`dirFile.list()` can also return null → NPE; and the
+`DocumentBuilderFactory` has no secure-processing/doctype hardening
+(low-value XXE since plugins are code execution by design, but the
+hardening is one line).
+
+**M12. Memory capacity is never validated; dense storage turned a silent
+misbehavior into a crash. [partly regression]**
+`src/jls/elem/Memory.java:269-274, 761-786, 1172-1175, 1245-1250`: neither
+the dialog (checks only `bits < 1`) nor the load path rejects
+`capacity < 1`; `new DenseWordStore(-5)` → `NegativeArraySizeException`
+at simulation start (pre-#20 the Map store just read misses). Reject
+non-positive capacity in both places.
+
+**M13. StateMachine with no initial state NPEs at simulation start.**
+`src/jls/elem/StateMachine.java:1933-1941, 1117-1151`: deleting the
+initial state (the editor never reassigns or validates initial status)
+or creating a zero-state machine leaves `currentState` null →
+`currentState.sendOutputs` NPEs when the simulation starts.
+
+**M14. Legacy `orient 0` Display corrupts its file on re-save.**
+`src/jls/elem/Display.java:60, 260-272`: the internal sentinel for "new
+format" is `-1`, but the registry's `omitted` predicate is
+`orient <= 0` — dropping the legacy marker for the valid legacy value 0
+(Top). Such a file loads once, re-saves without the marker, and the next
+load NPEs in `WireEnd.init` (put renamed) — the file no longer loads.
+Faithful reproduction of the handwritten save's bug; fix is `orient < 0`.
+
+**M15. "Run in background" is a race, not a feature.**
+`src/jls/JLSStart.java:774-783`: the listener toggles the global
+non-volatile `JLSInfo.batch` around `runSim()`, which returns immediately
+after spawning the sim thread — the thread's later `!JLSInfo.batch` checks
+almost always see the flag already restored.
+
+**M16. Remaining editor hot-path scans.**
+`SimpleEditor.canConnect` (2735-2750) scans all elements per net end on
+every drag event whenever a wire end overlaps a put — O(netEnds×N),
+outside the spatial index's coverage. Full repaints also remain on the
+move/place paths (2152, 3124, 2343) — the dirty-region work (#17) covered
+hover and rubber-band only ("first slice"). `Trace.paintComponent` indexes
+a `LinkedList` in a loop (O(n²) per paint).
+
+### Low
+
+- **`connect(Put,Put)` calls `end1.init` twice, never `end2.init`**
+  (`SimpleEditor.java:2868`) — the second end keeps 0×0 size and can't be
+  hovered or hit-tested.
+- **Clock accepts non-positive cycle times** from hand-edited files and
+  partially from the dialog (`Clock.java:392-408`) → zero-delay repost
+  livelock at t=0.
+- **TruthTable malformed-table crashes** (`TruthTable.java:1590, 338-346,
+  1518-1545`): `table[-1]` when no row matches kills the sim thread;
+  load-time index crashes are contained by the loader's catch-all.
+- **`Group.setPair` NPEs on negative/sparse indices** from malformed files
+  (`Group.java:200-223`) — contained by the loader.
+- **`SigEntry.selected()` re-adds menu listeners on every popup**
+  (`SigEntry.java:69-81`) — after reopening a header menu, the next choice
+  executes twice (e.g. move-right jumps two columns).
+- **`Eula.accepted()` never closes its stream** (`Eula.java:34`); the EULA
+  dialog is shown off the EDT (`Eula.java:72`).
+- **`DefaultExceptionHandler.saveTrace` mutates state in the crash path**
+  (calls `circuit.save`, renumbering element IDs and clearing `changed` as
+  a side effect of writing a diagnostic) and dumps all system properties
+  into a file users are told to email.
+- **`Util.isValidFileName` splits only on the platform separator**
+  (`Util.java:237-241`) — on Windows, `C:/work/foo.jls` (valid for Java)
+  is rejected and the file won't open.
+- **`Circuit.getJumpStartNames()` returns the live keySet**
+  (`Circuit.java:1176`) — callers can delete jump starts through it
+  (`getElements()` was fixed in #27; this one was missed).
+- **`Circuit.elementMap` is never cleared after load** (line 72), pinning
+  every loaded element for the circuit's lifetime; `lineNumber` is a
+  static with an instance getter — fine only while loads stay
+  single-threaded.
+- **Interactive stop-reason misreport** (`InteractiveSimulator.java:543,
+  562-570`): `now` is advanced before the reason is computed, so a
+  drained queue near the limit reports "Simulation Time Limit".
+- **Dead code**: unreachable duplicate SubCircuit branch in `findTraces`
+  (`InteractiveSimulator.java:811-816`); `updateNamesUsed`'s subcircuit
+  arm is unreachable (`SimpleEditor.java:4103-4115`); `Constant.java:708-712`
+  compares `BigInteger` by reference in dead code; `Decoder.java:134` has
+  a literal `"/n | /n"` in a never-drawn string; cached paint `Graphics`
+  reused outside the paint cycle (`SimpleEditor.java:1282-1286`).
+- **Reflective instantiation runs constructors before the type check**
+  (`Circuit.java:399-415`): confined to the `jls.elem.` prefix, but any
+  static/constructor side effect there is reachable from a file; the
+  parallel path in `processParamFile` (`JLSStart.java:1285, 1563`) then
+  hits an unguarded `(LogicElement)` cast → crash on e.g. `TYPE Wire`.
+
+---
+
+## Part 3 — Verified clean
+
+Checked deliberately and found sound (details matter as much as defects):
+
+- **The 2026 refactors are faithful.** Gate `Kind` descriptors match every
+  pre-refactor per-class constant (delays, fixed input counts, inverting
+  initial values); `GridTransform` rotation/mirror math was hand-checked
+  for every orientation of TriState (8), Mux, Adder, Clock against the old
+  if/else ladders — identical pin positions and sizes, pinned further by
+  the committed geometry baseline; the attribute registry preserves save
+  order, omission rules, and load/copy side effects for all converted
+  elements; the merged simulator event loop preserves both batch and
+  interactive semantics exactly (its threading defects are inherited, not
+  introduced); the ElementDialog conversions keep original validation and
+  cleanup; the Pin and truth-table-cell hoists are byte-faithful.
+- **SpatialIndex** (`jls/SpatialIndex.java`) is clean: collision-free cell
+  keys, removal by recorded bounds, `floorDiv` for negatives, huge-rect
+  fallback; every mutation path traced (add/remove/markChanged/
+  reindexAfterMove/setState/undo) invalidates correctly — no stale-index
+  path found. The property-based parity test is the strongest in the suite.
+- **Undo snapshot content fidelity**: probes, watch flags, trace positions,
+  wire nets, and parent-SubCircuit pin remapping all survive the
+  save/load snapshot path (H6/M8 concern surrounding editor state, not
+  snapshot content).
+- **Checkpoint pipeline**: serialization happens only on the EDT; the
+  coalescing ConcurrentHashMap protocol has no lost-update interleaving;
+  temp-file + `ATOMIC_MOVE` prevents torn files (M7's delete ordering is
+  the one hole).
+- **The #2 zip-truncation fix is sound** (entry fully drained before
+  `ZipFile.close`), and the save path's atomic-rename structure is correct
+  apart from M3's constructor leak.
+- **No path traversal** in file handling: zip reading extracts a
+  fixed-name entry to memory only; save paths are user-chosen.
+- **Help.java** (the JavaHelp replacement) uses try-with-resources and
+  bounded parsing; `resources/help/Map.jhm` and `JLSHelpTOC.xml` are
+  load-bearing for it (not JavaHelp leftovers — do not delete).
+- **Wire/WireNet propagation, SigSim/SigGen/TestGen parsing** — no defects
+  found.
+
+## Part 4 — Recommended priorities
+
+1. **Fix the two criticals** (C1 open→save directory, C2 dead menu
+   actions) with regression tests — an open→edit→save integration test
+   and a menu-action smoke test. Both fixes are small.
+2. **Stop the data-loss amplifiers**: H1 (clear `changed` only after a
+   successful write), M7 (checkpoint delete ordering).
+3. **Correctness of stored values**: H2 (BitSetUtils bit math), H3
+   (unescape order), H4 (explicit constructor selection), M14 (Display
+   legacy marker). All are one-to-five-line fixes with easy unit tests.
+4. **Release identity**: derive `JLSInfo` version from the build, remove
+   the EULA gate (P2), add the tag↔pom check — then actually tag v4.2.0
+   and publish the first release (P1/P3).
+5. **Repaint/threading**: H5 (Wire.getRect), then the simulator volatile
+   fields (H7) and EDT routing (H8), which also speeds up interactive runs.
+6. **Harden untrusted-file parsing** (M2 caps, M3 leak) — cheap, and
+   SECURITY.md already anticipates hostile circuit files.
+7. Fold the remaining medium/low items and P4-P6 into tracked issues.

--- a/AUDIT-2026-07.md
+++ b/AUDIT-2026-07.md
@@ -233,11 +233,18 @@ element text containing a backslash.
 
 **H4. Element loading uses `getConstructors()[0]`, whose order is
 unspecified.**
-`src/jls/Circuit.java:400-401`. `jls.elem.JumpEnd` has two public
-constructors (`JumpEnd.java:41, 52`); if the JVM returns the two-arg one
-first, `newInstance(this)` throws and **every saved circuit containing a
-jump end fails to load** with a cryptic error. Works or breaks depending
-on JVM build. Select the 1-arg `(Circuit)` constructor explicitly.
+`src/jls/Circuit.java:400-401`. If any element class exposes a second
+public constructor and the JVM returns it first, `newInstance(this)`
+throws and **every saved circuit containing that element fails to load**
+with a cryptic error. *Correction (verified by reflection over the
+compiled classes after this audit was first published):* the second
+`JumpEnd(Circuit, String)` constructor (`JumpEnd.java:52`) is currently
+neutralized by a block comment (`*//*` at line 51), so today every
+element class has exactly one public constructor and the defect is
+**latent** — one uncommented convenience constructor away from a
+JVM-order-dependent load failure. The fix is unchanged and cheap: select
+the `(Circuit)` constructor explicitly via `getConstructor(Circuit.class)`.
+Tracked as issue #55.
 
 **H5. Wire hover repaints are broken — dirty regions use `Wire.getRect()`,
 a degenerate 0×0 rectangle. [regression]**

--- a/MAINTENANCE_AUDIT.md
+++ b/MAINTENANCE_AUDIT.md
@@ -1,5 +1,13 @@
 # JLS Maintenance Audit — July 2026
 
+> **Historical snapshot.** This document describes the repository as it was
+> *before* the modernization program it proposed. That program is complete —
+> all 25 roadmap issues (#2–#27) are closed, and statements below such as
+> "no build system", "no tests", and "no CI" no longer describe the tree.
+> For the current state of the project, see the follow-up audit in
+> [AUDIT-2026-07.md](AUDIT-2026-07.md). This file is kept unedited below as
+> the record of the program's starting point and rationale.
+
 This document records the findings of a full maintenance audit of the JLS
 (Java Logic Simulator) repository, plus a follow-up performance/memory/file-size
 audit. The actionable items are tracked on GitHub: see the roadmap in issue

--- a/docs/hdl-support-research.md
+++ b/docs/hdl-support-research.md
@@ -10,6 +10,14 @@ independently verified and are orientation only. All claims current as of
 2026-07-08; supported-board lists, parser coverage, and release states are
 moving targets.*
 
+*Follow-up, same month: the report's open questions 1–3 were finalized by a
+second, targeted research pass (Logisim-evolution source read; Yosys cell
+library, pass, and yosys2digitaljs source read plus JLS element-model
+analysis; ANTLR grammar issue-tracker and Maven-ecosystem survey). The
+resolved answers are in §7, and §§2–3 and the staged path in §6 are updated
+where the answers changed them. Implementation issues for the staged path
+are filed as sub-issues of #59.*
+
 ## Executive summary
 
 HDL "support" is three different problems with very different feasibility for
@@ -140,19 +148,58 @@ no in-house HDL semantics; the synthesizer defines the accepted subset. This
 is a working, maintained proof of the exact pipeline JLS would need for
 import.
 
+### Logisim-evolution — the other Java reference point **[verified follow-up]**
+
+Resolved by a source-level read of `github.com/logisim-evolution/logisim-evolution`
+(`main` branch, 2026-07-08); every claim below is backed by fetched source
+files (see §7.1 for the detailed evidence trail):
+
+- **Direction: export both VHDL and Verilog; no general HDL import.** The
+  output language is a global preference defaulting to VHDL
+  (`AppPreferences.java`, `hdlType`); the `HdlGeneratorFactory` interface
+  declares both languages.
+- **Implementation: its own HDL generator framework, one Java generator
+  class per library component** (`com.cburch.logisim.fpga.hdlgenerator` +
+  e.g. `MultiplexerHdlGeneratorFactory`, `AbstractGateHdlGenerator`) — the
+  opposite build-vs-delegate choice from the Yosys-netlist pattern, and a
+  maintenance burden JLS should note: every new component needs a matching
+  generator.
+- **FPGA flow drives four external toolchains via generated scripts**:
+  Quartus, Xilinx ISE, Vivado, and an open-source flow (GHDL→Yosys→
+  nextpnr-ecp5→ecppack→openFPGALoader — currently Lattice ECP5 only).
+  The download pipeline is DRC → fits-board check → interactive pin-mapping
+  GUI (click on a photo of the board) → HDL generation → vendor script →
+  tool invocation.
+- **Board database: 29 built-in XML board files** (BASYS3, DE0/DE10, Zybo,
+  Alchitry Au, …), each with FPGA part, pin assignments, and an embedded
+  board photo; users can add up to 20 external board files and there is a
+  full board-editor GUI.
+- **Its embedded-HDL component is VHDL-only and needs a commercial
+  simulator**: the `VhdlEntity` component parses the entity header for
+  ports, but in-simulator behavior requires **Questa/ModelSim** over a
+  TCP/Tcl socket bridge; without it the component outputs UNKNOWN. An open
+  issue (#84) has sought GHDL co-simulation for years; a fork did it but was
+  never merged. This validates the report's Stage 3 shape (external
+  co-simulation) while warning against a commercial-tool dependency —
+  Digital's GHDL/Icarus choice is the better model.
+- **Test vectors and autograder machinery are strong**: a documented
+  test-vector file format (don't-cares, high-Z, sequential mode), a GUI
+  runner, and a headless CLI (`--test-vector` with exit codes, `--tty`
+  with csv/table outputs, `--substitute` for grading against reference
+  implementations, `--test-fpga … HDLONLY` for scripted HDL generation).
+  This is the concrete catch-up bar for JLS's batch mode (§4).
+- **Pedagogical framing is thin**: the FPGA/HDL flow is presented
+  operationally (generated files + board-mapping GUI), with no first-party
+  "how your schematic maps to HDL" material — consistent with Digital's
+  "deployment vehicle" philosophy arrived at independently.
+
 ### Other free and proprietary tools **[unverified survey]**
 
-The harness's claims about the tools below did **not** survive adversarial
-verification (mostly for lack of independently fetchable primary sources
-within the run), so research question 2 is only partially answered with
-verified material. The following is orientation from general knowledge —
-treat as leads to confirm, not facts:
+The harness's claims about the remaining tools did **not** survive
+adversarial verification (mostly for lack of independently fetchable primary
+sources within the run). The following is orientation from general
+knowledge — treat as leads to confirm, not facts:
 
-- **Logisim-evolution** (Java, the most widely used Logisim fork): has an
-  FPGA-synthesis flow that generates VHDL/Verilog for supported boards —
-  export-direction, like Digital. How its HDL generation and board database
-  are implemented, and its test-vector/autograder features, is the top open
-  question left by this research (§7).
 - **DEEDS** (Genoa): exports VHDL for FPGA use; schematic-first teaching tool.
 - **TkGate**: its own Verilog-*like* save format; not standard-Verilog
   interoperable.
@@ -182,11 +229,58 @@ treat as leads to confirm, not facts:
 | Yosys | External synthesizer; `read_verilog` → `write_json` netlist | ISC | ✔ (subprocess — no linking question at all) | Defines the accepted synthesizable subset for you; VHDL possible via the GHDL Yosys plugin. |
 | GHDL, Icarus Verilog | External simulators for co-simulation and CI validation | GPLv2+ | ✔ as subprocesses | The Digital-proven pattern. |
 
-Bottom line: for **Verilog**, JLS can have a native-Java parser today (ANTLR,
-MIT) if it ever wants one — but the recommended import path doesn't need it.
-For **VHDL**, there is *no* good maintained Java parsing option; VHDL import
-would route through Yosys+GHDL-plugin the same way as Verilog. External
-subprocess integration sidesteps license-linking questions entirely.
+**Follow-up findings that sharpen this table** (§7.3 for full evidence):
+
+- The ANTLR grammars are weaker in practice than their existence suggests.
+  Their preprocessor grammars only *recognize* backtick directives on a side
+  token channel — macros are **never expanded**, includes never resolved
+  (grammars-v4 is action-free by policy), so `input [\`WIDTH-1:0] x` parses
+  wrongly unless the caller preprocesses first. The Verilog-2005
+  lexer+pre-parser combination has an open, unfixed "produces an empty tree"
+  CI-coverage bug (grammars-v4 #3348); the SystemVerilog grammar reportedly
+  rejects non-ANSI module headers (#3082), behaves differently across
+  targets (#2401), and is ~23× slower than the Verilog grammar on the
+  repo's own performance table (independent reports: 131 s / 1.3 GB for a
+  1.3 MB design). Test corpora are smoke-test sized (9 real files for
+  Verilog; ~120 spec snippets for SV). Neither grammar is published to
+  Maven Central.
+- **No maintained Java semantic layer exists.** Maven Central's only
+  Verilog artifact is a tree-sitter CST binding (no semantics); Verible and
+  slang are C++ with Python bindings only; the closest JVM prior art
+  (xprova/netlist-graph, Java+ANTLR, MIT) is dormant since ~2018.
+  vMAGIC is additionally **not on Maven Central** (repo1 returns 404).
+- **For the black-box use case (parse a module/entity header for ports),
+  the pragmatic ranking is therefore inverted**: a small hand-written
+  header scanner (comments, a minimal `` `define/`ifdef `` subset, ANSI and
+  non-ANSI port styles — a few hundred dependency-free lines) beats
+  carrying the ANTLR runtime plus an under-tested grammar *plus* a macro
+  expander you'd still have to write. For robust real-world files, external
+  Yosys already emits exactly the needed data (`write_json`: port
+  directions, exact bit offsets/widths, evaluated parameter defaults);
+  Verilator `-E`/`--json-only` is an alternative; Icarus has no JSON
+  output. VHDL has no preprocessor, so an `entity … end` header scanner is
+  even simpler; GHDL's `--file-to-xml` exists but its format is
+  version-unstable.
+
+**Auto-layout licensing (needed for import, §6 Stage 2):** ELK (Eclipse
+Layout Kernel) is the proven algorithm family for schematic layout — pure
+Java, on Maven Central, and DigitalJS ships on elkjs (`layered` +
+orthogonal routing). But ELK is plain **EPL-2.0 with no GPL secondary-license
+designation** (Exhibit A unfilled, NOTICE declares none), which the FSF
+classifies as GPL-incompatible — **GPLv3 JLS cannot link ELK in-process and
+distribute the result**. Clean options: run ELK out-of-process (separate
+JVM, JSON over pipes — mere aggregation), or hand-roll a heuristic layered
+layout. JGraphX (BSD-3, has a Sugiyama layout) is archived/EOL since 2020;
+JUNG has no layered layout; yFiles is proprietary.
+
+Bottom line: for **Verilog**, the recommended import path needs no Java
+parser at all (Yosys does the parsing), and the black-box feature needs
+only a header scanner — the ANTLR grammars are a last resort, not a
+foundation. For **VHDL**, there is *no* good maintained Java parsing
+option; VHDL routes through Yosys+GHDL-plugin (import) or a trivial
+entity-header scanner (black-box). External subprocess integration
+sidesteps license-linking questions entirely — which matters twice over
+now that ELK's license rules out in-process linking too.
 
 ---
 
@@ -253,23 +347,65 @@ Memory/StateMachine templates dominating the effort.
 
 **Stage 2 — synthesizable-Verilog import via external Yosys (separate
 milestone, decide after Stage 1 ships).**
-`yosys -p "read_verilog …; prep; write_json"` → parse JSON (one small,
-well-documented format) → map Yosys cells to JLS elements. The key open
-technical question is the **cell-mapping cost**: JLS's element set (gates,
-mux, decoder, adder, register, memory) covers the common cells (`$and`,
-`$mux`, `$dff`, `$mem`, …) but Yosys emits a wider family (`$adffe`,
-`$sdffce`, width-parameterized cells); either run a `techmap` pass to a
-restricted cell library first (recommended) or grow JLS's element set.
-Auto-placement of the imported netlist is a real sub-project (DigitalJS uses
-an auto-layouter; JLS would need one). Yosys is an external user-installed
+The mapping-cost question (§7.2) resolved **favorably**: with the pipeline
+
+```
+read_verilog design.v
+setattr -mod -unset top; hierarchy -auto-top
+proc; opt_clean
+memory -nomap; wreduce -memx; opt    # keep $mem_v2 for the ROM case
+dffunmap                             # clock-enable + sync-reset → $dff + $mux (exact)
+pmuxtree                             # $pmux → $mux trees
+techmap -map jls_map.v               # ~6-10 rules: $sub,$neg,$xnor,$eq/$ne,
+                                     # comparators, variable shifts, $demux
+opt_clean; write_json out.json
+```
+
+the surviving cell set is ~15 types, every one with a direct or ≤4-element
+JLS realization — JLS's N-input gates, true-parity XOR, latch-capable
+Register with initial values, tri-state nets, Mux (which is exactly
+`$bmux`), Adder with carry in/out, and Splitter/Binder line up unusually
+well with Yosys's model. Because the importer writes JLS's *text save
+format* directly (the loader accepts plain text; wires attach by
+element-id + port-name references, not geometry), no GUI automation is
+needed and connectivity is correct independent of layout quality.
+
+The importer must **reject loudly and precisely** (residual named cells
+make this easy) the genuine gaps: **async-reset flip-flops** (`$adff`
+family — the idiomatic `always @(posedge clk or posedge rst)` pattern;
+either teach sync reset, which `dffunmap` handles exactly, or grow Register
+with an async-clear pin as a contained element change), **clocked or
+multi-port memories** (JLS Memory is an async single-port SRAM/ROM; only
+the async-read ROM maps faithfully — offer `memory_map` for small RAMs),
+**wide arithmetic** (`$mul/$div/$mod/$pow`), latches with set/reset, and
+x/z semantics (JLS is 2-state; coerce and document). Signedness is compiled
+away in the techmap rules.
+
+**Auto-placement is the larger half and its own workstream**: layer 1,
+the mechanical netlist-to-JLS-graph conversion (bit-vector connections →
+Splitter/Binder mesh, Constants, WireEnd chains on the 12-px grid) is the
+bulk of the importer; layer 2, placement proper, should start as a
+hand-rolled heuristic layered layout (longest-path layering, barycenter
+ordering, greedy orthogonal routing — adequate at classroom scale) behind
+an interface, because the proven layouter (ELK Layered, which DigitalJS
+uses) is EPL-2.0-only and **cannot be linked into GPLv3 JLS**; an
+out-of-process ELK runner can slot in later. Treat layout quality as a
+ratchet, not a launch gate. Yosys is an external user-installed
 dependency — document it, detect it, degrade gracefully.
 
 **Stage 3 (optional) — HDL black-box components co-simulated externally.**
-Digital-style: an "HDL component" element whose ports come from parsing the
-module header (the one place the ANTLR grammar earns its keep) and whose
-behavior runs in a GHDL/Icarus subprocess stepped in lockstep with JLS's
-event loop. Highest plumbing cost, biggest didactic payoff (mixed
-schematic/HDL labs). Decide only after Stages 1–2 see classroom use.
+Digital-style: an "HDL component" element whose ports come from a **small
+hand-written module/entity header scanner** (comments + minimal
+`` `define/`ifdef `` + ANSI and non-ANSI port styles; a few hundred
+dependency-free lines — §7.3 found this strictly better than the ANTLR
+route, whose grammars never expand macros and carry open correctness/
+performance bugs), with external Yosys `write_json` as the robust fallback
+for gnarly files. Behavior runs in a GHDL/Icarus subprocess stepped in
+lockstep with JLS's event loop — Digital's choice; Logisim-evolution's
+Questa/ModelSim socket bridge shows why a *commercial* simulator dependency
+is the mistake to avoid (its own issue tracker has sought GHDL for years).
+Highest plumbing cost, biggest didactic payoff (mixed schematic/HDL labs).
+Decide only after Stages 1–2 see classroom use.
 
 **Stage 4 — SystemC:** structural C++ netlist printer on the Stage 1 walk,
 *if and only if* user demand appears. Otherwise explicitly out of scope.
@@ -281,20 +417,90 @@ dependency, a mapping layer, and a layout problem; Stage 3 adds process
 lifecycle and simulation-synchronization complexity. Size each stage against
 the actual codebase before committing (see open questions).
 
-## 7. Open questions for follow-up
+## 7. Open questions — resolved (July 2026 follow-up)
 
-1. **Logisim-evolution's actual HDL/FPGA implementation** (direction, subset,
-   parser vs. toolchain, board database, test vectors, autograders) — the
-   biggest verified-coverage gap in this report; worth a focused code-level
-   read of its repo before Stage 1 design freezes.
-2. **Yosys cell ↔ JLS element mapping cost** — can JLS's element model
-   represent a `techmap`-restricted Yosys cell library without lossy
-   transformation, and what does auto-placement require?
-3. **ANTLR Verilog grammar completeness on real student code** (preprocessor,
-   elaboration) and whether any maintained Java semantic layer exists on top.
-4. **A maintained GPLv3-compatible VHDL-2008 path usable from Java** —
-   subprocess wrapper around hdlConvertor or GHDL's libghdl, a revived
-   vMAGIC fork, or the Yosys+GHDL-plugin route as the only VHDL door.
+Questions 1–3 were finalized by a targeted second research pass; question 4
+was largely answered in passing.
+
+### 7.1 Logisim-evolution's HDL/FPGA implementation — RESOLVED
+
+Source-level read of the repo (`main`, 2026-07-08); summary in §2. Key
+facts, each verified against fetched source files: export-only for VHDL
+**and** Verilog via its own per-component Java generator framework
+(`com.cburch.logisim.fpga.hdlgenerator`; output language is a global
+preference, `AppPreferences.java` `hdlType`, default VHDL); no general HDL
+import; the FPGA download flow scripts four external toolchains
+(`VendorSoftware.java`: Quartus `quartus_sh/…`, Xilinx ISE `xst/…`, Vivado,
+and open-source `ghdl`→`yosys -m ghdl`→`nextpnr-ecp5`→`ecppack`→
+`openFPGALoader`, ECP5-only per issue #84); 29 built-in XML board files
+with embedded photos, user-extensible (20 external slots) plus a board
+editor GUI; the `VhdlEntity` embedded-HDL component parses entity headers
+in Java (`VhdlParser.java`) but co-simulates only via **Questa/ModelSim**
+over a Tcl/TCP socket (`VhdlSimulatorTclBinder.java`) — outputs UNKNOWN
+without it, GHDL support requested for years (#84) but never merged;
+test-vector engine with documented format plus headless CLI
+(`--test-vector` exit codes, `--tty` csv/table, `--substitute`,
+`--test-fpga … HDLONLY`). Consequences adopted in §6: per-component
+generator frameworks are viable but costly (Digital's approach remains the
+model for JLS); avoid commercial-simulator co-simulation dependencies; the
+CLI/test-vector feature set is the §4 catch-up bar. Evidence URLs: repo
+paths cited above under
+`github.com/logisim-evolution/logisim-evolution/…` (README,
+`src/main/java/com/cburch/logisim/{fpga,vhdl,prefs}/…`,
+`src/main/resources/resources/logisim/boards/`, `docs/test_vector.md`,
+discussions #859, issue #84).
+
+### 7.2 Yosys cell ↔ JLS element mapping cost — RESOLVED, favorable
+
+Full analysis from JLS source (element capabilities at file:line level) plus
+Yosys cell-library/pass sources (`techlibs/common/simlib.v`, `simcells.v`,
+`passes/techmap/{techmap,dffunmap,dfflegalize,pmuxtree,simplemap}.cc`,
+`passes/memory/memory_map.cc`, `backends/json/json.cc`) and the
+yosys2digitaljs pipeline (`src/core.ts`). Verdict: **tractable and small.**
+`dffunmap` eliminates clock-enable/sync-reset FF variants *exactly* at word
+level; `pmuxtree` eliminates `$pmux`; one custom `jls_map.v` (~6–10 rules)
+covers `$sub/$neg/$xnor/$eq/$ne`/comparators/variable-shifts/`$demux`; the
+surviving ~15 cell types all map directly or in ≤4 JLS elements (details
+and the full mapping table are reflected in §6 Stage 2). Genuine,
+loudly-rejectable gaps: async-reset FFs (`$adff` family — JLS Register has
+no reset pin; sync-reset teaching idiom works exactly), clocked/multi-port
+memories (JLS Memory is async single-port with tri-state output; async-read
+ROM maps faithfully), `$mul/$div/$mod/$pow`, set/reset latches, and x/z
+bits (JLS BitSet is 2-state). The importer generates JLS's plain-text save
+format directly (loader accepts it; wires attach by id+port-name refs), so
+correctness is layout-independent. Auto-placement: ELK Layered is the
+proven algorithm (DigitalJS ships elkjs) but ELK is EPL-2.0 **without** the
+GPL secondary-license designation — per the FSF, GPL-incompatible for
+linking; start with a hand-rolled heuristic layered layout behind an
+interface, optionally an out-of-process ELK runner later.
+
+### 7.3 ANTLR Verilog grammars on real code — RESOLVED, negative
+
+The grammars-v4 Verilog/SystemVerilog grammars *recognize* preprocessor
+directives on a side token channel but **never expand macros or resolve
+includes** (action-free by policy) — `input [\`WIDTH-1:0] x` fails without
+external preprocessing; the Verilog lexer+pre-parser combination has an
+open "empty tree on any input" bug (#3348); the SV grammar is reported
+ANSI-header-only (#3082), target-inconsistent (#2401), and ~23× slower
+than the Verilog grammar (repo performance table; independent report:
+131 s/1.3 GB for 1.3 MB of SV). Test corpora: 9 real Verilog files, ~120 SV
+spec snippets; not on Maven Central. **No maintained Java semantic layer
+exists** (Central's only Verilog artifact is a tree-sitter CST binding;
+Verible/slang are C++/Python-facing; nearest JVM prior art dormant since
+~2018). Recommendation adopted in §6 Stage 3: hand-written header scanner
+as the built-in path; external Yosys `write_json` (directions, exact bit
+widths, evaluated parameter defaults) as the robust path; ANTLR demoted to
+last resort.
+
+### 7.4 VHDL-from-Java path — largely answered in passing
+
+vMAGIC is dead *and* absent from Maven Central (repo1 404s); GHDL's
+`--file-to-xml` can dump an analyzed AST for entity/port extraction via
+subprocess but its format is version-unstable and huge. Since VHDL has no
+preprocessor, a hand-written `entity … end` header scanner covers the
+black-box case, and Yosys+GHDL-plugin remains the only credible VHDL
+*import* door. No further research needed unless Stage 3 VHDL support is
+prioritized.
 
 ## 8. Refuted during verification (for the record)
 
@@ -317,3 +523,11 @@ the actual codebase before committing (see open questions).
 - https://github.com/Nic30/hdlConvertor (VHDL parser capabilities and limits)
 - https://sourceforge.net/projects/vmagic/ + Pohl et al., Int. J. Reconfigurable Computing 2009, doi:10.1155/2009/205149 (vMAGIC)
 - https://ghdl.github.io/ghdl/using/Synthesis.html (GHDL synthesis/Yosys plugin)
+
+Added by the July 2026 follow-up pass (§7):
+
+- Logisim-evolution sources: https://github.com/logisim-evolution/logisim-evolution — README; `src/main/java/com/cburch/logisim/fpga/hdlgenerator/HdlGeneratorFactory.java`; `fpga/download/Download.java`; `fpga/settings/VendorSoftware.java`; `prefs/AppPreferences.java`, `prefs/FpgaBoards.java`; `vhdl/base/VhdlEntity.java`, `vhdl/sim/VhdlSimulatorTclBinder.java`; `src/main/resources/resources/logisim/boards/` (29 board XMLs, e.g. BASYS3.xml); `docs/test_vector.md`; `gui/start/Startup.java`; issue #84, discussion #859
+- Yosys cell library & passes: https://github.com/YosysHQ/yosys — `techlibs/common/simlib.v`, `techlibs/common/simcells.v`, `docs/source/cell/*.rst`, `passes/techmap/{techmap,simplemap,dffunmap,dfflegalize,pmuxtree}.cc`, `passes/memory/memory_map.cc`, `backends/json/json.cc` (readthedocs renderings were proxy-blocked; the generating sources were read instead)
+- yosys2digitaljs pipeline: https://github.com/tilk/yosys2digitaljs (`src/core.ts` `prepare_yosys_script`, `src/index.ts`); DigitalJS layout: https://github.com/tilk/digitaljs (`package.json` elkjs ^0.11.0, `src/elkjs.mjs`)
+- ELK licensing: https://github.com/eclipse-elk/elk (LICENSE.md, NOTICE.md, `Layered.melk`); https://repo1.maven.org/maven2/org/eclipse/elk/; https://www.gnu.org/licenses/license-list.html#EPL2; https://www.gnu.org/licenses/gpl-faq.html#MereAggregation; alternatives https://github.com/jgraph/jgraphx (archived), https://github.com/jrtom/jung
+- ANTLR grammar practicalities: https://github.com/antlr/grammars-v4 issues #3348, #3082, #2401, #2363, #1438, #3632; performance table (repo `performance.html`); https://groups.google.com/g/antlr-discussion/c/ynvgmjjsZTw; https://central.sonatype.com/artifact/io.github.bonede/tree-sitter-verilog; https://github.com/chipsalliance/verible; https://github.com/MikePopoloski/slang; https://github.com/xprova/netlist-graph; Verilator `--json-only`/`-E`: https://github.com/verilator/verilator/blob/master/docs/guide/exe_verilator.rst; Icarus targets: https://steveicarus.github.io/iverilog/usage/command_line_flags.html; GHDL `--file-to-xml`: https://github.com/ghdl/ghdl/blob/master/doc/using/CommandReference.rst

--- a/docs/hdl-support-research.md
+++ b/docs/hdl-support-research.md
@@ -1,0 +1,319 @@
+# HDL Support for JLS: VHDL, Verilog/SystemVerilog, and SystemC — Research Report
+
+*July 2026. Prepared for the JLS maintainer as input to the roadmap (issue #33,
+Phase 6). Produced with a multi-agent research harness: 5 search angles, 22
+sources fetched, 93 candidate claims extracted, 25 subjected to 3-vote
+adversarial verification — 23 confirmed, 2 refuted. Facts below marked
+**[verified]** survived that process with unanimous or majority votes and are
+cited; sections marked **[unverified survey]** did not survive or were not
+independently verified and are orientation only. All claims current as of
+2026-07-08; supported-board lists, parser coverage, and release states are
+moving targets.*
+
+## Executive summary
+
+HDL "support" is three different problems with very different feasibility for
+an educational Java schematic simulator:
+
+1. **Export (schematic → HDL)** is the proven, achievable baseline.
+   hneemann's *Digital* — the closest comparable tool to JLS (educational,
+   Java Swing, schematic-first) — ships exactly this ("A circuit can be
+   exported to VHDL or Verilog") and treats it as a **deployment vehicle for
+   FPGAs, not a way to teach the HDL**. **[verified]**
+2. **Import (HDL → editable schematic)** is realistic only for the
+   *synthesizable subset*, and the working architecture in the wild does it
+   without writing an HDL parser at all: an external synthesizer (Yosys)
+   emits a JSON netlist which the tool maps onto its own elements (the
+   yosys2digitaljs → DigitalJS pipeline). **[verified]**
+3. **Simulation of full HDL semantics in-house is a trap.** Peer-reviewed
+   work (Lööw, OOPSLA 2025) finds the IEEE Verilog simulation semantics
+   inconsistent both with itself and with practice; every serious educational
+   tool surveyed delegates HDL simulation to mature external simulators
+   (GHDL, Icarus Verilog) rather than reimplementing an event scheduler.
+   **[verified]**
+4. **SystemC is a C++ class library consumed by high-level-synthesis tools**,
+   not a netlist format; meaningful *import* is out of scope for JLS. At most,
+   JLS could *emit* a structural SystemC netlist, which is just a C++-flavored
+   variant of export. **[verified]**
+
+**Recommended staged path** (§6): Verilog + VHDL netlist export first,
+validated in CI against external `iverilog`/`ghdl`; then synthesizable-Verilog
+import via external Yosys JSON netlists; then (optional) HDL-defined black-box
+components co-simulated via GHDL/Icarus; SystemC limited to structural C++
+emission or skipped. All license constraints check out for a GPLv3 project.
+
+---
+
+## 1. What the three formats are, and what "support" would mean
+
+### The languages
+
+- **Verilog / SystemVerilog** (IEEE 1364 / IEEE 1800) is, in practice, two
+  languages sharing syntax: *synthesizable Verilog*, the subset describing
+  hardware structure and behavior, and the full simulation/testbench
+  language. IEEE 1364.1-2002 formally defined the RTL-synthesis subset
+  ("defines the subset of IEEE 1364 … suitable for RTL synthesis and defines
+  the semantics of that subset for the synthesis domain"); it is now
+  withdrawn (superseded by IEC/IEEE 62142-2005), so the exact subset boundary
+  today is tool-defined. **[verified]** ([IEEE 1364.1](https://standards.ieee.org/standard/1364_1-2002.html),
+  [Lööw 2025](https://arxiv.org/pdf/2502.19348))
+- Full Verilog **simulation semantics is a poor reimplementation target**:
+  Lööw (OOPSLA 2025, peer-reviewed) reports that the standard's simulation
+  semantics "has thus far eluded definitive mathematical formalisation" and
+  that "the Verilog standard is inconsistent both with Verilog practice and
+  itself" (corroborated independently by the well-known IEEE 1364 scheduling
+  nondeterminism literature). This is one author's peer-reviewed judgment,
+  but it matches why no surveyed educational tool wrote its own Verilog
+  simulator. **[verified, attributed]**
+- **VHDL** (IEEE 1076, current revision 2019) has the same
+  synthesizable-subset-vs-simulation-language split (the analogous synthesis
+  subset standard is IEEE 1076.6, also withdrawn). Parser infrastructure for
+  VHDL is notably weaker on the JVM than for Verilog (§4).
+- **SystemC** (IEEE 1666) is not an HDL file format at all but a **C++ class
+  library**; a "SystemC design" is a C++ program. Accellera's *SystemC
+  Synthesizable Subset* v1.4.7 (approved March 2016, still the current
+  release) "defines the syntactic elements in C++ and SystemC that are
+  appropriate for use in SystemC models intended as input for High Level
+  Synthesis (HLS) tools." Supporting SystemC *import* therefore means
+  building the front half of an HLS tool — categorically out of scope for
+  JLS. **[verified]** ([Accellera subset](https://www.accellera.org/images/downloads/standards/systemc/SystemC_Synthesis_Subset_1_4_7.pdf);
+  note: the PDF itself was proxy-blocked during research; scope wording was
+  verified via Accellera working-group pages and search-index text.)
+
+### The four possible meanings of "support"
+
+| Mode | What it is | Feasibility for JLS |
+| --- | --- | --- |
+| **Export** | Generate HDL from a drawn circuit | Proven in a direct comparable (Digital); structural netlist emission over JLS's element graph |
+| **Import** | Parse HDL into an editable schematic | Realistic for the synthesizable subset only, via an external synthesizer + netlist intermediate |
+| **Co-simulation** | HDL-defined components inside a JLS schematic, simulated externally | Proven in Digital (GHDL/Icarus subprocesses); real but significant plumbing |
+| **Round-trip** | Edit the same design alternately as HDL and schematic | Not observed in any surveyed tool; generated HDL and hand-written HDL are stylistically disjoint; **do not promise this** |
+
+---
+
+## 2. How comparable programs handle these formats
+
+### Digital (hneemann) — the reference point **[verified]**
+
+*Digital* is ~98.6% Java, Swing-based, explicitly "designed for educational
+purposes" — the closest thing to a more-developed JLS. Its choices:
+
+- **Export to VHDL and Verilog** is a shipped, advertised feature (Verilog
+  added after maintainer issue [#52](https://github.com/hneemann/Digital/issues/52),
+  Sept 2017; VHDL predates it).
+- **Design philosophy** (hneemann, in #52): "At the moment I use the VHDL
+  export only as a vehicle to run a circuit created with Digital on an FPGA,
+  without explaining the VHDL code itself further… an HDL export is not
+  suitable to teach the HDL itself. This is because the generated code uses
+  only a small fraction of the HDL." He analogizes exported HDL to a JEDEC
+  file nobody reads. **JLS should adopt the same honest framing.**
+- **No in-house HDL parser or simulator.** Schematic components can be
+  *described in* VHDL or Verilog, and those components are simulated by
+  external open-source simulators — GHDL for VHDL, Icarus Verilog for
+  Verilog ("The open source VHDL simulator ghdl needs to be installed to
+  simulate a VHDL defined component…").
+- **Generated HDL is validated against real toolchains, in tests**: emitted
+  VHDL tested with Xilinx Vivado and GHDL, emitted Verilog with Icarus, via
+  automated tests (`VHDLSimulatorTest.java` / `VerilogSimulatorTest.java`)
+  that skip when the external tool is absent. This CI pattern transfers
+  directly to JLS's Maven/Actions setup.
+- **The export is coupled to a student-facing FPGA flow**: when a supported
+  board is configured, Digital also generates a pin-assignment constraints
+  file (manual v0.31 documents BASYS3 and Mimas/Mimas V2; README also lists
+  TinyFPGA BX) and the manual walks students through Vivado project →
+  bitstream → programming. Plain HDL export works standalone without a board.
+
+Two candidate claims about Digital were **refuted** in verification and must
+not be treated as fact: that its export is "one-click/single-file" and that
+its manual documents no HDL import (1–2 vote — the nuance around board
+configuration and the characterization were not sustained).
+
+### DigitalJS / yosys2digitaljs — the import architecture **[verified]**
+
+[DigitalJS](https://github.com/tilk/digitaljs) (Marek Materzok, University of
+Wrocław) is a browser-based teaching simulator whose Verilog import is exactly:
+external **Yosys** synthesizes user Verilog → **JSON netlist** →
+[yosys2digitaljs](https://github.com/tilk/yosys2digitaljs) (BSD-2-Clause,
+actively maintained — 165 commits, latest release 0.10.3 on 2026-02-24)
+converts the JSON into the simulator's own element graph. No in-house parser,
+no in-house HDL semantics; the synthesizer defines the accepted subset. This
+is a working, maintained proof of the exact pipeline JLS would need for
+import.
+
+### Other free and proprietary tools **[unverified survey]**
+
+The harness's claims about the tools below did **not** survive adversarial
+verification (mostly for lack of independently fetchable primary sources
+within the run), so research question 2 is only partially answered with
+verified material. The following is orientation from general knowledge —
+treat as leads to confirm, not facts:
+
+- **Logisim-evolution** (Java, the most widely used Logisim fork): has an
+  FPGA-synthesis flow that generates VHDL/Verilog for supported boards —
+  export-direction, like Digital. How its HDL generation and board database
+  are implemented, and its test-vector/autograder features, is the top open
+  question left by this research (§7).
+- **DEEDS** (Genoa): exports VHDL for FPGA use; schematic-first teaching tool.
+- **TkGate**: its own Verilog-*like* save format; not standard-Verilog
+  interoperable.
+- **Icarus Verilog, Verilator, GHDL, nvc**: not schematic tools at all —
+  they are the external simulators/compilers that schematic tools delegate
+  to (Verilator compiles synthesizable SystemVerilog to C++; GHDL also has a
+  Yosys plugin enabling VHDL through the Yosys netlist path).
+- **Proprietary (ModelSim/Questa, Vivado, Quartus, Active-HDL/Riviera, VCS,
+  Xcelium)**: HDL-first simulators/toolchains where the schematic view, if
+  any, is a *derived* visualization (RTL/elaborated schematic viewers), not
+  an editable source of truth. Their block-design editors (e.g. Vivado IP
+  Integrator) wire pre-verified IP rather than gate-level schematics. The
+  relevant lesson: in industry tools the HDL is the design; schematics are
+  views — the opposite of JLS's model, which is why the educational niche
+  (schematic as source of truth, HDL as export) remains distinct.
+
+---
+
+## 3. Java-accessible infrastructure and licensing **[verified]**
+
+| Component | What it is | License | GPLv3 fit | Caveats |
+| --- | --- | --- | --- | --- |
+| [antlr/grammars-v4 `verilog`](https://github.com/antlr/grammars-v4/tree/master/verilog) | ANTLR4 grammar, IEEE 1364-2005 Verilog | MIT (grammar), BSD-3 (ANTLR runtime) | ✔ compatible | **Syntax only**: parse tree + separate pre-parser for compiler directives; elaboration/semantics are yours to build. Java is a first-class CI-tested target. |
+| antlr/grammars-v4 `systemverilog` | ANTLR4 grammar, IEEE 1800-2017 | MIT | ✔ | Same syntax-only caveat. |
+| [hdlConvertor](https://github.com/Nic30/hdlConvertor) | C++/ANTLR parser → universal AST, Python bindings | MIT | ✔ license-wise | **No Java API** — usable only via subprocess/JNI. VHDL-2008 + earlier (no PSL/tool_directive; June 2025 commits still fixing VHDL-93-era constructs). Its claimed *full* SystemVerilog 1800-2017 coverage was **refuted (0-3)** — do not rely on it for SystemVerilog. |
+| [vMAGIC](https://sourceforge.net/projects/vmagic/) | The only native-Java VHDL library found: VHDL'93 parser + object model + writer | LGPLv3 | ✔ (one-way, linkable) | **Abandoned**: Alpha status, last update 2013-05-21, VHDL-93 only, no maintained fork found. At most a starting point for VHDL *generation*. |
+| Yosys | External synthesizer; `read_verilog` → `write_json` netlist | ISC | ✔ (subprocess — no linking question at all) | Defines the accepted synthesizable subset for you; VHDL possible via the GHDL Yosys plugin. |
+| GHDL, Icarus Verilog | External simulators for co-simulation and CI validation | GPLv2+ | ✔ as subprocesses | The Digital-proven pattern. |
+
+Bottom line: for **Verilog**, JLS can have a native-Java parser today (ANTLR,
+MIT) if it ever wants one — but the recommended import path doesn't need it.
+For **VHDL**, there is *no* good maintained Java parsing option; VHDL import
+would route through Yosys+GHDL-plugin the same way as Verilog. External
+subprocess integration sidesteps license-linking questions entirely.
+
+---
+
+## 4. Where JLS stands against its contemporaries
+
+What JLS already has that matches the class: subcircuits, test-vector-driven
+batch simulation (`-t` test files, `TestGen`), signal-trace window, printing,
+image export, state machines and truth tables as first-class elements (the
+latter two are *ahead* of some contemporaries).
+
+What the more-developed contemporaries signal students/instructors now expect
+(verified for Digital; Logisim-evolution unverified but consistent):
+
+1. **HDL export as an FPGA on-ramp** — the flagship gap this report addresses.
+2. **Board-aware export** (constraints/pin files for named cheap dev boards)
+   — the part that makes #1 pedagogically exciting ("your drawing is now on
+   real hardware").
+3. **External-toolchain honesty** — none of these tools pretend to be Vivado;
+   they generate input for it and document the handoff.
+4. **Test-vector UX** — Digital has an in-editor test-case component;
+   JLS's batch `-t` machinery is functionally similar but CLI-only. An
+   in-editor test panel is a smaller, HDL-independent catch-up item.
+5. **Autograder friendliness** (stable CLI, machine-readable results) — JLS's
+   batch mode is already close; worth documenting as a use case.
+
+## 5. What to promise per language
+
+- **Verilog**: Export (structural netlist, Verilog-2005 for maximum tool
+  acceptance) and, later, synthesizable-subset import via Yosys JSON.
+  SystemVerilog: accept as *input* only insofar as Yosys accepts it; never
+  promise full-language anything.
+- **VHDL**: Export second (same element-graph walk, different printer —
+  Digital ships both, and FPGA courses split roughly evenly between the two
+  languages). Import only via the Yosys/GHDL-plugin route, and only if
+  Verilog import proves its value first.
+- **SystemC**: Do not promise import or co-simulation. If demand
+  materializes, a structural SystemC netlist emitter (modules +
+  `sc_signal` wiring) is a low-cost third printer on the same export
+  walk — but survey actual demand first; in education SystemC appears in
+  architecture/HLS courses, not gate-level logic courses.
+
+---
+
+## 6. Recommended staged path
+
+**Stage 0 — prerequisites (already tracked).** The #33 program's correctness
+fixes precede this work; in particular the save-path and loader fixes (#34,
+#41, #55) touch the same `Circuit`/element-graph code an exporter walks, and
+issue #56's test-corpus work provides the harness HDL export validation will
+reuse.
+
+**Stage 1 — Verilog + VHDL export (issue-sized: one milestone).**
+Walk the element graph (elements, wire nets, pins already carry names and
+bit-widths); emit one structural module per circuit, one per subcircuit type;
+map each JLS element to a primitive instantiation or a small behavioral
+template (gates → expressions; Register/Clock → clocked `always`/process
+blocks; Memory → array + init from the existing contents model; TriState →
+conditional assigns; StateMachine/TruthTable → generated case blocks).
+Follow Digital's framing (deployment vehicle, not HDL tutorial) and its CI
+pattern: golden-file tests always; `iverilog`/`ghdl` compile-and-simulate
+tests that skip when the tool is absent. Risks: name legalization (JLS
+allows names HDL doesn't), multi-driver nets/tri-state semantics, and
+Memory/StateMachine templates dominating the effort.
+
+**Stage 2 — synthesizable-Verilog import via external Yosys (separate
+milestone, decide after Stage 1 ships).**
+`yosys -p "read_verilog …; prep; write_json"` → parse JSON (one small,
+well-documented format) → map Yosys cells to JLS elements. The key open
+technical question is the **cell-mapping cost**: JLS's element set (gates,
+mux, decoder, adder, register, memory) covers the common cells (`$and`,
+`$mux`, `$dff`, `$mem`, …) but Yosys emits a wider family (`$adffe`,
+`$sdffce`, width-parameterized cells); either run a `techmap` pass to a
+restricted cell library first (recommended) or grow JLS's element set.
+Auto-placement of the imported netlist is a real sub-project (DigitalJS uses
+an auto-layouter; JLS would need one). Yosys is an external user-installed
+dependency — document it, detect it, degrade gracefully.
+
+**Stage 3 (optional) — HDL black-box components co-simulated externally.**
+Digital-style: an "HDL component" element whose ports come from parsing the
+module header (the one place the ANTLR grammar earns its keep) and whose
+behavior runs in a GHDL/Icarus subprocess stepped in lockstep with JLS's
+event loop. Highest plumbing cost, biggest didactic payoff (mixed
+schematic/HDL labs). Decide only after Stages 1–2 see classroom use.
+
+**Stage 4 — SystemC:** structural C++ netlist printer on the Stage 1 walk,
+*if and only if* user demand appears. Otherwise explicitly out of scope.
+
+**Effort honesty:** no external effort estimates survived verification; the
+ordering above is this report's synthesis. Stage 1 is bounded and
+low-risk (a printer over an existing graph + CI); Stage 2 adds an external
+dependency, a mapping layer, and a layout problem; Stage 3 adds process
+lifecycle and simulation-synchronization complexity. Size each stage against
+the actual codebase before committing (see open questions).
+
+## 7. Open questions for follow-up
+
+1. **Logisim-evolution's actual HDL/FPGA implementation** (direction, subset,
+   parser vs. toolchain, board database, test vectors, autograders) — the
+   biggest verified-coverage gap in this report; worth a focused code-level
+   read of its repo before Stage 1 design freezes.
+2. **Yosys cell ↔ JLS element mapping cost** — can JLS's element model
+   represent a `techmap`-restricted Yosys cell library without lossy
+   transformation, and what does auto-placement require?
+3. **ANTLR Verilog grammar completeness on real student code** (preprocessor,
+   elaboration) and whether any maintained Java semantic layer exists on top.
+4. **A maintained GPLv3-compatible VHDL-2008 path usable from Java** —
+   subprocess wrapper around hdlConvertor or GHDL's libghdl, a revived
+   vMAGIC fork, or the Yosys+GHDL-plugin route as the only VHDL door.
+
+## 8. Refuted during verification (for the record)
+
+- "Digital's export is one-click/single-file and its manual documents no HDL
+  import" — 1–2 vote; characterization not sustained (board-configuration
+  nuance).
+- "hdlConvertor provides full IEEE 1800-2017 SystemVerilog coverage" — 0–3;
+  do not present hdlConvertor as a SystemVerilog solution.
+
+## Sources (primary, verified against)
+
+- https://github.com/hneemann/Digital (README, feature list)
+- https://github.com/hneemann/Digital/issues/52 (Verilog export; maintainer's design philosophy)
+- Digital manual (v0.31-era mirror): https://wcours.gel.ulaval.ca/2021/a/GIF1002/default/6travaux/Doc_English2019.pdf (FPGA flow, external-simulator validation)
+- https://github.com/tilk/digitaljs and https://github.com/tilk/yosys2digitaljs (Yosys-JSON import architecture)
+- https://standards.ieee.org/standard/1364_1-2002.html (Verilog RTL-synthesis subset, withdrawn)
+- Lööw, *A Correct-by-Authorship Verilog Semantics*, OOPSLA 2025: https://arxiv.org/pdf/2502.19348 / https://dl.acm.org/doi/10.1145/3720484 (simulation-semantics inconsistency)
+- https://www.accellera.org/images/downloads/standards/systemc/SystemC_Synthesis_Subset_1_4_7.pdf (+ Accellera working-group pages) (SystemC synthesizable subset = HLS input)
+- https://github.com/antlr/grammars-v4/tree/master/verilog (MIT Verilog-2005 / SystemVerilog-2017 grammars, Java target)
+- https://github.com/Nic30/hdlConvertor (VHDL parser capabilities and limits)
+- https://sourceforge.net/projects/vmagic/ + Pohl et al., Int. J. Reconfigurable Computing 2009, doi:10.1155/2009/205149 (vMAGIC)
+- https://ghdl.github.io/ghdl/using/Synthesis.html (GHDL synthesis/Yosys plugin)


### PR DESCRIPTION
Full re-audit of the tree at 9afcce0 after the completion of the #16
roadmap: build/CI/test/release posture plus a code audit of the core,
editor, simulator, and element packages, with every finding verified
against the source (several empirically).

Headlines: two critical legacy defects (open() never sets the circuit
directory so Save targets the filesystem root; a merge-conflict brace
error makes every popup-menu action dead code), plus high-severity
findings in BitSetUtils bit math, string escape round-tripping, the
reflective element loader, wire hover dirty-regions, undo gesture
state, and simulator threading. The 2026 refactors themselves were
diffed against their pre-refactor behavior and found faithful.

Marks MAINTENANCE_AUDIT.md as a historical snapshot pointing here.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MqndNcpZ9F8f3wGD9p1KrR