### PR TITLE
Reopen development at 5.0.1-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
+## [Unreleased] — 5.0.1-SNAPSHOT
+
+*(Nothing yet.)*
+
 ## [5.0.0] — 2026-07-16
 
 *(Renumbered from 4.3.0-SNAPSHOT: the plugin-mechanism removal below is a

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.0</version>
+  <version>5.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>


### PR DESCRIPTION
Post-release housekeeping after v5.0.0: the pom returns to a SNAPSHOT (`5.0.1-SNAPSHOT`) and the changelog gets a fresh Unreleased section, so development builds no longer claim to be the released 5.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)