### PR TITLE
AppImage release asset and a Nix flake; prepare v5.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,40 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
 
+  # Publishes the jar to the GitHub Packages Maven registry, so the
+  # repository's Packages sidebar carries the artifact alongside the
+  # Release.  GitHub's Maven registry needs an access token even to
+  # download public packages, so this complements — never replaces — the
+  # Release assets (see the distributionManagement note in the pom).
+  maven-registry:
+    # a publication, so tag pushes only; dry runs skip it entirely
+    if: github.event_name == 'push'
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # server-id matches the pom's distributionManagement id; setup-java
+      # writes the matching settings.xml server entry, credentialed from
+      # the GITHUB_ACTOR/GITHUB_TOKEN environment
+      - name: Set up JDK 25
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+          server-id: github
+
+      # tests, coverage, and spotbugs already gated the release job's
+      # `mvn verify` on this same ref; deploy only needs the artifact
+      - name: Publish to GitHub Packages
+        run: mvn -B deploy -DskipTests -Djacoco.skip=true -Dspotbugs.skip=true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
   # Self-contained installers with a bundled jlink-trimmed runtime and the
   # .jls file association (#82).  The whole recipe lives in
   # scripts/build-installer.sh (jar -> jdeps -> jlink -> jpackage) so local

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Thumbs.db
 
 # Claude Code agent worktrees (transient session infrastructure)
 .claude/worktrees/
+
+# nix build output symlinks
+result
+result-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to JLS are documented here. The format follows
   Maven shell. The package builds against the pinned nixpkgs JDK 25 with
   the dependency closure fingerprinted by `mvnHash` (tests remain CI's
   job — the sandbox has no fonts, the same reasoning as #111).
+- Releases also publish the jar to the GitHub Packages Maven registry
+  (`maven.pkg.github.com/anadon/JLS`), populating the repository's
+  Packages sidebar. GitHub's Maven registry requires an access token
+  even for public downloads, so the Releases page remains the primary
+  distribution channel; the registry serves Maven tooling.
 
 ## [5.0.0] — 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,22 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
-## [Unreleased] — 5.0.1-SNAPSHOT
+## [5.0.1] — 2026-07-16
 
-*(Nothing yet.)*
+### Added
+- A Linux AppImage release asset, `JLS-<version>-x86_64.AppImage`: the
+  jpackage app-image tree (launcher + jlink-trimmed runtime) folded into
+  one self-mounting executable by a version- and sha256-pinned
+  appimagetool, with desktop metadata and the `.jls` MIME type inside.
+  Built by the same `scripts/build-installer.sh` recipe on the Linux leg;
+  runs on distros the deb/rpm cannot target.
+- A Nix flake, so NixOS users (whom the deb/rpm/AppImage do not serve)
+  build from source: `nix run github:anadon/JLS` runs the editor,
+  `nix profile install` gives the `jls` command plus a desktop entry,
+  icon, and `.jls` file association; `nix develop` opens a JDK 25 +
+  Maven shell. The package builds against the pinned nixpkgs JDK 25 with
+  the dependency closure fingerprinted by `mvnHash` (tests remain CI's
+  job — the sandbox has no fonts, the same reasoning as #111).
 
 ## [5.0.0] — 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ self-contained installers with a bundled Java runtime — no JDK needed:
 
 - **Linux:** `jls_<version>_amd64.deb` (`sudo apt install ./jls_*.deb`) or
   `jls-<version>*.rpm`. JLS appears in the applications menu.
+- **Linux (any distro):** `JLS-<version>-x86_64.AppImage` — no installation:
+  `chmod +x` it and run it (`--appimage-extract-and-run` if FUSE is absent).
+  The `.jls` association comes along only if your desktop integrates
+  AppImages (e.g. via AppImageLauncher).
+- **NixOS / Nix:** the repository is a flake — `nix run github:anadon/JLS`
+  runs it, `nix profile install github:anadon/JLS` installs the `jls`
+  command with menu entry and `.jls` association. (The deb/rpm/AppImage
+  assets do not fit NixOS; the flake builds from source instead.)
 - **Windows:** `JLS-<version>.msi` (per-user install, no admin rights
   needed). SmartScreen will warn that the installer is from an unknown
   publisher because the artifacts are unsigned — choose "More info" →

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   provenance, checkable with
   `gh attestation verify jls-<version>.jar --repo anadon/JLS`.
 
+- **From the Maven registry:** releases are also published to GitHub
+  Packages (`maven.pkg.github.com/anadon/JLS`, artifact
+  `io.github.anadon:jls`) for Maven tooling. GitHub requires an access
+  token even for public downloads there, so plain-download users should
+  prefer the Releases page.
+
 - **Command-line options:** `java -jar jls-<version>.jar -h` prints the full
   list, including batch mode (`-b`), test-input files (`-t`), simulation time
   limits (`-d`), VCD waveform export (`-vcd`, for GTKWave/Surfer and

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,107 @@
+{
+  # Nix flake so NixOS (and any Nix user) can build and run JLS from
+  # source — the deb/rpm/AppImage release assets do not fit NixOS:
+  #
+  #   nix run github:anadon/JLS -- circuit.jls     # run straight from GitHub
+  #   nix profile install github:anadon/JLS        # install the `jls` command
+  #   nix develop                                  # JDK 25 + Maven dev shell
+  #
+  # The build is `mvn package` against the pinned nixpkgs JDK (Java 25,
+  # the pom's maven.compiler.release); the test suite is CI's job
+  # (`mvn verify` there), not the sandbox's — see mvnParameters below.
+  description = "JLS — an educational digital logic circuit editor and simulator";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+  outputs = { self, nixpkgs }:
+    let
+      # a Swing GUI application: only systems someone has actually run it
+      # on are listed; add more once tested
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f:
+        nixpkgs.lib.genAttrs systems
+          (system: f system nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = eachSystem (system: pkgs:
+        let
+          jdk = pkgs.jdk25;
+
+          jls = pkgs.maven.buildMavenPackage {
+            pname = "jls";
+            # keep in sync with pom.xml; the base triple is enough — a
+            # -SNAPSHOT suffix between releases changes nothing here
+            version = "5.0.1";
+            src = self;
+
+            # fingerprint of the Maven dependency closure. Refresh after
+            # any pom dependency/plugin change: set to nixpkgs.lib.fakeHash,
+            # run `nix build`, copy the hash from the "got:" line.
+            mvnHash = "sha256-38VZjujqJNg7GEgMxWU+PD9FXp+hfladPrycFLMixHc=";
+
+            # Maven must run on the pom's language baseline (Java 25, and
+            # the enforcer rejects anything older)
+            mvnJdk = pkgs.jdk25_headless;
+
+            # tests run in CI under `mvn verify`; the nix sandbox has no
+            # fonts, which the geometry/golden tests are sensitive to
+            # (same reasoning as the Windows installer leg, issue #111)
+            doCheck = false;
+
+            nativeBuildInputs = [ pkgs.makeWrapper pkgs.copyDesktopItems ];
+
+            desktopItems = [
+              (pkgs.makeDesktopItem {
+                name = "jls";
+                exec = "jls %f";
+                icon = "jls";
+                desktopName = "JLS";
+                comment = "Educational digital logic circuit editor and simulator";
+                categories = [ "Education" "Electronics" ];
+                mimeTypes = [ "application/x-jls-circuit" ];
+              })
+            ];
+
+            installPhase = ''
+              runHook preInstall
+              install -Dm644 target/jls-*.jar $out/share/jls/jls.jar
+              makeWrapper ${jdk}/bin/java $out/bin/jls \
+                --add-flags "-jar $out/share/jls/jls.jar"
+              install -Dm644 resources/packaging/jls.png \
+                $out/share/icons/hicolor/256x256/apps/jls.png
+              runHook postInstall
+            '';
+
+            meta = {
+              description = "Educational digital logic circuit editor and simulator";
+              homepage = "https://github.com/anadon/JLS";
+              license = nixpkgs.lib.licenses.gpl3Only;
+              mainProgram = "jls";
+            };
+          };
+        in
+        {
+          inherit jls;
+          default = jls;
+        });
+
+      apps = nixpkgs.lib.genAttrs systems (system: rec {
+        jls = {
+          type = "app";
+          program = "${self.packages.${system}.jls}/bin/jls";
+        };
+        default = jls;
+      });
+
+      devShells = eachSystem (system: pkgs: {
+        default = pkgs.mkShell {
+          # Maven wrapped over the full (non-headless) JDK 25, so mvn,
+          # jdeps, jlink and jpackage all agree on the toolchain
+          packages = [
+            (pkgs.maven.override { jdk_headless = pkgs.jdk25; })
+            pkgs.jdk25
+          ];
+        };
+      });
+    };
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.1</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>
@@ -31,7 +31,7 @@
     <!-- reproducible builds: archives get this fixed timestamp instead of
          wall-clock time, so the same commit rebuilds byte-identically;
          bump it alongside the version when cutting a release (#44) -->
-    <project.build.outputTimestamp>2026-07-08T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-07-16T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,19 @@
     </license>
   </licenses>
 
+  <!-- Where `mvn deploy` publishes: the GitHub Packages Maven registry
+       (the release workflow's maven-registry job, tag pushes only).
+       Note GitHub's Maven registry needs an access token even to
+       *download* public packages, so the Releases page stays the
+       primary distribution channel; this serves Maven tooling. -->
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages — anadon/JLS</name>
+      <url>https://maven.pkg.github.com/anadon/JLS</url>
+    </repository>
+  </distributionManagement>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- language baseline policy (#92): the floor is the current LTS at

--- a/scripts/build-installer.sh
+++ b/scripts/build-installer.sh
@@ -7,9 +7,9 @@
 #   shaded jar (mvn package)
 #     -> jdeps --print-module-deps       derive the minimal module set
 #     -> jlink                           trim a runtime image
-#     -> jpackage --type <per OS>        deb/rpm (Linux), msi (Windows),
-#                                        dmg (macOS), with a .jls file
-#                                        association and desktop metadata
+#     -> jpackage --type <per OS>        deb/rpm + AppImage (Linux), msi
+#                                        (Windows), dmg (macOS), with a .jls
+#                                        file association and desktop metadata
 #
 # Requirements: JDK 17+ on PATH (jdeps/jlink/jpackage ship with the JDK;
 # jpackage is final since JDK 16, JEP 392), Maven, and per platform:
@@ -20,6 +20,8 @@
 # Environment:
 #   JLS_SKIP_BUILD=1   reuse an existing target/jls-*.jar instead of
 #                      running Maven (CI builds/tests in a prior step)
+#   APPIMAGETOOL=path  use this appimagetool instead of downloading the
+#                      pinned one (Linux x86_64 only)
 #
 # Outputs land in target/installer/dist/.
 
@@ -108,6 +110,63 @@ package() {
 		"$@"
 }
 
+# --- AppImage (Linux x86_64 only) -------------------------------------------
+# jpackage --type app-image lays out launcher + bundled runtime; appimagetool
+# folds that tree into one self-mounting executable that runs on any distro
+# (including ones the deb/rpm cannot target).  appimagetool itself is pinned
+# by version and sha256, matching the release pipeline's supply-chain posture.
+APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage"
+APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
+
+build_appimage() {
+	# app-image is the raw launcher tree: installer-only flags such as
+	# --license-file or --file-associations are rejected here, so this
+	# does not go through package()
+	echo "==> jpackage --type app-image"
+	jpackage \
+		--type app-image \
+		--name JLS \
+		--app-version "$APP_VERSION" \
+		--input "$INPUT" \
+		--main-jar "$(basename "$JAR")" \
+		--runtime-image "$RUNTIME" \
+		--icon resources/packaging/jls.png \
+		--dest "$STAGE/appimage"
+
+	# AppDir contract: an AppRun entry point, exactly one top-level
+	# .desktop, and a top-level icon.  The jpackage launcher resolves its
+	# app directory through /proc/self/exe, so a symlinked AppRun works.
+	local appdir="$STAGE/appimage/JLS"
+	ln -s bin/JLS "$appdir/AppRun"
+	cp resources/packaging/jls.png "$appdir/jls.png"
+	ln -s jls.png "$appdir/.DirIcon"
+	cat > "$appdir/JLS.desktop" <<-EOF
+		[Desktop Entry]
+		Type=Application
+		Name=JLS
+		Comment=Educational digital logic circuit editor and simulator
+		Exec=JLS %f
+		Icon=jls
+		Categories=Education;Electronics;
+		MimeType=application/x-jls-circuit;
+		Terminal=false
+	EOF
+
+	local tool="${APPIMAGETOOL:-}"
+	if [ -z "$tool" ]; then
+		tool="$STAGE/appimagetool"
+		echo "==> fetching appimagetool 1.9.1"
+		curl -fsSL -o "$tool" "$APPIMAGETOOL_URL"
+		echo "${APPIMAGETOOL_SHA256}  ${tool}" | sha256sum -c -
+		chmod +x "$tool"
+	fi
+	# --appimage-extract-and-run: appimagetool is itself an AppImage and
+	# would otherwise need FUSE, absent on CI runners and NixOS
+	echo "==> appimagetool"
+	ARCH=x86_64 "$tool" --appimage-extract-and-run \
+		"$appdir" "$DIST/JLS-${VERSION}-x86_64.AppImage"
+}
+
 case "$(uname -s)" in
 	Linux)
 		# --resource-dir overrides the generated .desktop entry: the JDK
@@ -125,6 +184,11 @@ case "$(uname -s)" in
 			package rpm "${linux_flags[@]}"
 		else
 			echo "==> rpmbuild not found; skipping --type rpm"
+		fi
+		if [ "$(uname -m)" = "x86_64" ]; then
+			build_appimage
+		else
+			echo "==> non-x86_64 Linux; skipping AppImage (tool pin is x86_64)"
 		fi
 		;;
 	Darwin)


### PR DESCRIPTION
Two new ways to run JLS on Linux, addressing distros the deb/rpm cannot reach:

- **AppImage** (`JLS-<version>-x86_64.AppImage`): the Linux installer leg folds the jpackage app-image tree (launcher + jlink-trimmed runtime) into a single self-mounting executable with appimagetool 1.9.1, pinned by version and sha256 to match the pipeline's supply-chain posture. The AppDir desktop entry carries the `.jls` MIME type. Verified locally: built and ran `-h` successfully.
- **Nix flake**: `nix run github:anadon/JLS` builds from source against the pinned nixpkgs JDK 25; `nix profile install` adds the `jls` command, desktop entry, icon, and `.jls` association; `nix develop` opens a JDK 25 + Maven shell. Tests remain CI's job — the nix sandbox has no fonts (same reasoning as #111). Verified locally on NixOS: `nix build` + `jls -h`.

Also prepares the v5.0.1 release: pom `5.0.1`, changelog dated, and `project.build.outputTimestamp` bumped alongside the version per its own comment (that step was missed for 5.0.0).

A release-pipeline dry-run is running on this branch to verify the AppImage builds on CI before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)