### PR TITLE
Batch-mode container image on ghcr.io; prepare v5.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,49 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+  # Batch-mode (headless) container image for autograders and CI:
+  # `docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests c.jls`.
+  # The recipe lives in scripts/build-container.sh + the Dockerfile under
+  # resources/packaging/ so local builds and CI cannot drift.  Dry runs
+  # build and smoke-test the image but never push.
+  container-image:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      # the full test suite already gated the release job's `mvn verify`
+      # on this same ref; this leg only needs the jar
+      - name: Build jar (tests ran in the release job)
+        run: mvn -B -q package -DskipTests
+
+      - name: Build container image
+        env:
+          JLS_SKIP_BUILD: "1"
+        run: bash scripts/build-container.sh
+
+      - name: Smoke-test the image
+        run: |
+          VERSION="$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)"
+          docker run --rm "ghcr.io/anadon/jls:${VERSION}" -h
+
+      # a publication, so tag pushes only (dry runs stop at the smoke test)
+      - name: Push to ghcr.io
+        if: github.event_name == 'push'
+        run: |
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push --all-tags ghcr.io/anadon/jls
+
   # Self-contained installers with a bundled jlink-trimmed runtime and the
   # .jls file association (#82).  The whole recipe lives in
   # scripts/build-installer.sh (jar -> jdeps -> jlink -> jpackage) so local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
-## [Unreleased] — 5.0.2-SNAPSHOT
+## [5.0.2] — 2026-07-16
 
-*(Nothing yet.)*
+### Added
+- A batch-mode container image on the GitHub container registry:
+  `docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests c.jls`
+  gives autograders and CI the whole headless surface (#72's batch API,
+  VCD export, image export, HDL export) without a local Java runtime.
+  Headless only — no display stack. Multi-stage build: jdeps/jlink trim
+  the runtime from the shaded jar (the installer recipe's approach)
+  onto ubuntu:24.04 with fontconfig + DejaVu so `-i` image export
+  renders text; one recipe, `scripts/build-container.sh` +
+  `resources/packaging/Dockerfile`, shared by CI and local builds;
+  `latest` tracks stable releases only.
 
 ## [5.0.1] — 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   token even for public downloads there, so plain-download users should
   prefer the Releases page.
 
+- **Container image (batch mode only):** for autograders and CI,
+  `ghcr.io/anadon/jls` runs the headless surface — test vectors, VCD
+  waveform export, circuit image export, HDL export — with no local
+  Java runtime:
+
+  ```sh
+  docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests circuit.jls
+  ```
+
+  The image is headless by construction (no display stack); use an
+  installer or the jar for the GUI editor.
+
 - **Command-line options:** `java -jar jls-<version>.jar -h` prints the full
   list, including batch mode (`-b`), test-input files (`-t`), simulation time
   limits (`-d`), VCD waveform export (`-vcd`, for GTKWave/Surfer and

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.0.2</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>

--- a/resources/packaging/Dockerfile
+++ b/resources/packaging/Dockerfile
@@ -1,0 +1,40 @@
+# JLS batch-mode container image (headless), for autograders and CI that
+# want `docker run` instead of a local Java runtime.  GUI use is out of
+# scope — no display stack is included.  Built and published to
+# ghcr.io/anadon/jls by the release workflow's container-image job via
+# scripts/build-container.sh, which stages the shaded jar next to this
+# file (the build context contains exactly jls.jar and this Dockerfile).
+#
+#   docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests circuit.jls
+#
+# Multi-stage: jdeps derives the module set from the shaded jar and jlink
+# trims a runtime from it (the same recipe as scripts/build-installer.sh),
+# so the final image carries ~50 MB of JVM instead of a full JDK.
+
+FROM eclipse-temurin:25 AS runtime
+COPY jls.jar /build/jls.jar
+RUN set -eux; \
+    MODULES="$(jdeps --print-module-deps --ignore-missing-deps /build/jls.jar)"; \
+    jlink --add-modules "$MODULES" --strip-debug --no-header-files \
+          --no-man-pages --compress zip-6 --output /build/runtime
+
+# ubuntu:24.04 is the same base eclipse-temurin:25 builds on, so the
+# jlink runtime meets the glibc it was linked against; fontconfig +
+# DejaVu let batch image export (-i) render text fully headlessly
+FROM ubuntu:24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# the source label links the ghcr package to the repository
+LABEL org.opencontainers.image.source="https://github.com/anadon/JLS" \
+      org.opencontainers.image.description="JLS batch mode (headless): test vectors, VCD waveform export, circuit image export, HDL export" \
+      org.opencontainers.image.licenses="GPL-3.0-only"
+
+COPY --from=runtime /build/runtime /opt/jls/runtime
+COPY jls.jar /opt/jls/jls.jar
+
+# batch runs read and write files relative to the caller's mount
+WORKDIR /work
+ENTRYPOINT ["/opt/jls/runtime/bin/java", "-Djava.awt.headless=true", "-jar", "/opt/jls/jls.jar"]
+CMD ["-h"]

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Build the JLS batch-mode container image (headless; see
+# resources/packaging/Dockerfile).  One recipe, used both locally and by
+# .github/workflows/release.yml, so the two cannot drift:
+#
+#   shaded jar (mvn package)
+#     -> stage jls.jar + Dockerfile into a minimal build context
+#     -> docker build   (jdeps/jlink run inside the Dockerfile)
+#
+# Environment:
+#   JLS_SKIP_BUILD=1   reuse an existing target/jls-*.jar instead of
+#                      running Maven (CI builds/tests in a prior step)
+#   IMAGE              image name (default ghcr.io/anadon/jls)
+#   DOCKER             container tool (default docker; podman works)
+#
+# Tags <version> always, and `latest` only for stable releases (no
+# pre-release/SNAPSHOT suffix).  Pushing is the workflow's job, not ours.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+DOCKER="${DOCKER:-docker}"
+IMAGE="${IMAGE:-ghcr.io/anadon/jls}"
+
+VERSION="$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)"
+echo "==> version ${VERSION}"
+
+if [ "${JLS_SKIP_BUILD:-0}" != "1" ]; then
+	echo "==> mvn package"
+	mvn -B -q package
+fi
+JAR="$(ls target/jls-*.jar)"
+echo "==> jar: ${JAR}"
+
+# minimal build context: exactly the jar and the Dockerfile
+STAGE="target/container"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+cp "$JAR" "$STAGE/jls.jar"
+cp resources/packaging/Dockerfile "$STAGE/Dockerfile"
+
+tags=(-t "$IMAGE:$VERSION")
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	tags+=(-t "$IMAGE:latest")
+fi
+
+echo "==> $DOCKER build"
+"$DOCKER" build "${tags[@]}" "$STAGE"
+
+echo "==> built:"
+"$DOCKER" image ls "$IMAGE"


### PR DESCRIPTION
Adds `ghcr.io/anadon/jls`, a headless batch-mode container image for autograders and CI:

```sh
docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests circuit.jls
```

- One recipe shared by CI and local builds: `scripts/build-container.sh` + `resources/packaging/Dockerfile`. Multi-stage — jdeps/jlink trim the runtime from the shaded jar (the installer recipe's approach) onto `ubuntu:24.04` with fontconfig + DejaVu so `-i` image export renders text headlessly. ~150 MB.
- The `container-image` release job builds and smoke-tests on every run; only tag pushes log in and push. `latest` tracks stable versions only (regex-guarded in the script).
- The `org.opencontainers.image.source` label links the package to this repository.
- Verified locally: built the image, ran `-h` (usage prints) and a batch invocation (proper `jls: error:` contract).

Also prepares v5.0.2 (pom, changelog; the flake version was already 5.0.2).

A release dry-run is running on this branch to exercise the container job on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)