### PR TITLE
Multi-arch: ARM installers, arm64+riscv64 container; prepare v5.0.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,14 +214,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest # x86_64
+            jdk: temurin
             experimental: false
           - os: ubuntu-24.04-arm # aarch64; uninstalled on real hardware
+            jdk: temurin
             experimental: true
           - os: windows-latest # x86_64; uninstalled on real hardware (#82)
+            jdk: temurin
             experimental: true
+          # zulu: Temurin publishes no Windows-aarch64 JDK 25; Azul does
           - os: windows-11-arm # aarch64; uninstalled on real hardware
+            jdk: zulu
             experimental: true
           - os: macos-latest # aarch64; uninstalled on real hardware (#82)
+            jdk: temurin
             experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
@@ -231,7 +237,7 @@ jobs:
       - name: Set up JDK 25
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
-          distribution: temurin
+          distribution: ${{ matrix.jdk }}
           java-version: 25
           cache: maven
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,18 @@ jobs:
               ;;
           esac
 
+      # the windows-11-arm image ships without WiX (windows-latest
+      # preinstalls it), and jpackage needs candle/light for --type msi;
+      # the x86 WiX binaries run fine under Windows-on-ARM emulation.
+      # choco's PATH edit does not reach later steps, hence GITHUB_PATH.
+      - name: Install WiX Toolset (Windows on ARM)
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          choco install wixtoolset -y --no-progress
+          $wix = (Resolve-Path 'C:\Program Files (x86)\WiX Toolset*\bin')[0].Path
+          Add-Content $env:GITHUB_PATH $wix
+
       # The full test suite already ran under `mvn verify` in the release
       # job; this leg only needs the jar.  Three tests fail on the Windows
       # runner for environmental reasons (CRLF-sensitive round-trip
@@ -295,8 +307,10 @@ jobs:
         shell: bash
         run: |
           cd target/installer/dist
-          ARCH="$(uname -m)"
-          case "$ARCH" in arm64) ARCH=aarch64 ;; amd64) ARCH=x86_64 ;; esac
+          # RUNNER_ARCH first: git-bash's uname reports x86_64 under
+          # Windows-on-ARM emulation
+          ARCH="${RUNNER_ARCH:-$(uname -m)}"
+          case "$ARCH" in ARM64|arm64) ARCH=aarch64 ;; X64|amd64) ARCH=x86_64 ;; esac
           SUMS="SHA256SUMS-installers-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')-${ARCH}"
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum * > "$SUMS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,11 @@ jobs:
   # Batch-mode (headless) container image for autograders and CI:
   # `docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests c.jls`.
   # The recipe lives in scripts/build-container.sh + the Dockerfile under
-  # resources/packaging/ so local builds and CI cannot drift.  Dry runs
-  # build and smoke-test the image but never push.
+  # resources/packaging/ so local builds and CI cannot drift.  Multi-arch
+  # (amd64 native, arm64 + riscv64 via QEMU) — for RISC-V this image and
+  # the jar are the only channels, since no riscv64 runners exist and
+  # jpackage cannot cross-compile installers.  Dry runs build and
+  # smoke-test every platform but never push.
   container-image:
     needs: release
     runs-on: ubuntu-latest
@@ -152,7 +155,9 @@ jobs:
       - name: Build jar (tests ran in the release job)
         run: mvn -B -q package -DskipTests
 
-      - name: Build container image
+      # native single-arch build first: it is the smoke-testable one
+      # (a multi-arch buildx result cannot be --load-ed for docker run)
+      - name: Build container image (native, for the smoke test)
         env:
           JLS_SKIP_BUILD: "1"
         run: bash scripts/build-container.sh
@@ -162,12 +167,24 @@ jobs:
           VERSION="$(mvn -B -q help:evaluate -Dexpression=project.version -DforceStdout)"
           docker run --rm "ghcr.io/anadon/jls:${VERSION}" -h
 
-      # a publication, so tag pushes only (dry runs stop at the smoke test)
-      - name: Push to ghcr.io
+      # arm64 and riscv64 run under QEMU user-mode emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to ghcr.io
         if: github.event_name == 'push'
-        run: |
-          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          docker push --all-tags ghcr.io/anadon/jls
+        run: echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # dry runs prove all three platforms build; tag pushes publish the
+      # multi-arch manifest (PUSH=1)
+      - name: Build multi-arch image (and push on tag)
+        env:
+          JLS_SKIP_BUILD: "1"
+          PLATFORMS: linux/amd64,linux/arm64,linux/riscv64
+          PUSH: ${{ github.event_name == 'push' && '1' || '0' }}
+        run: bash scripts/build-container.sh
 
   # Self-contained installers with a bundled jlink-trimmed runtime and the
   # .jls file association (#82).  The whole recipe lives in
@@ -175,24 +192,36 @@ jobs:
   # builds and CI cannot drift.
   #
   # Verification status:
-  #   - ubuntu-latest (deb + rpm): recipe verified end-to-end on Linux
-  #     (deb installed, launcher ran, .jls association files present).
-  #   - windows-latest (msi) and macos-latest (dmg): built successfully in
-  #     the v5.0.0 dry-run; still continue-on-error until a real msi/dmg
-  #     has been installed and checked on hardware — flip experimental to
-  #     false then.  The icons are real per-platform files (jls.ico /
-  #     jls.icns are PNG-bearing containers from scripts/GenerateIcons.java).
+  #   - ubuntu-latest (x86_64 deb + rpm + AppImage): recipe verified
+  #     end-to-end on Linux (deb installed, launcher ran, .jls
+  #     association files present).
+  #   - windows-latest (msi) and macos-latest (dmg, Apple silicon — the
+  #     macos-latest runners are arm64): built successfully in dry-runs;
+  #     still continue-on-error until a real msi/dmg has been installed
+  #     and checked on hardware — flip experimental to false then.  The
+  #     icons are real per-platform files (jls.ico / jls.icns are
+  #     PNG-bearing containers from scripts/GenerateIcons.java).
+  #   - ubuntu-24.04-arm (aarch64 deb + rpm + AppImage) and
+  #     windows-11-arm (aarch64 msi): same recipe on ARM runners;
+  #     experimental until installed and checked on hardware.
+  #   - riscv64: no GitHub runners exist and jpackage cannot
+  #     cross-compile its launcher, so RISC-V is served by the container
+  #     image (built via QEMU below) and the architecture-independent jar.
   installers:
     needs: release
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-latest # x86_64
             experimental: false
-          - os: windows-latest # builds; uninstalled on real hardware (#82)
+          - os: ubuntu-24.04-arm # aarch64; uninstalled on real hardware
             experimental: true
-          - os: macos-latest # builds; uninstalled on real hardware (#82)
+          - os: windows-latest # x86_64; uninstalled on real hardware (#82)
+            experimental: true
+          - os: windows-11-arm # aarch64; uninstalled on real hardware
+            experimental: true
+          - os: macos-latest # aarch64; uninstalled on real hardware (#82)
             experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
@@ -252,18 +281,23 @@ jobs:
         with:
           subject-path: target/installer/dist/*
 
-      # Extends the release's SHA256SUMS with a per-OS list covering the
-      # installers built on this leg (macOS runners lack sha256sum).
+      # Extends the release's SHA256SUMS with a per-OS-and-arch list
+      # covering the installers built on this leg (macOS runners lack
+      # sha256sum; the arch suffix keeps the two Linux legs and the two
+      # Windows legs from overwriting each other's asset).
       - name: Generate sha256 checksums
         shell: bash
         run: |
           cd target/installer/dist
+          ARCH="$(uname -m)"
+          case "$ARCH" in arm64) ARCH=aarch64 ;; amd64) ARCH=x86_64 ;; esac
+          SUMS="SHA256SUMS-installers-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')-${ARCH}"
           if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum * > "SHA256SUMS-installers-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
+            sha256sum * > "$SUMS"
           else
-            shasum -a 256 * > "SHA256SUMS-installers-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')"
+            shasum -a 256 * > "$SUMS"
           fi
-          cat SHA256SUMS-installers-*
+          cat "$SUMS"
 
       # Appends assets to the release the `release` job created (dry runs
       # stop here: the installers were built and checksummed, nothing ships)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,29 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
-## [Unreleased] — 5.0.3-SNAPSHOT
+## [5.0.3] — 2026-07-16
 
-*(Nothing yet.)*
+### Added
+- Multi-architecture distribution (ARM and RISC-V):
+  - The container image `ghcr.io/anadon/jls` is now a multi-arch
+    manifest — `linux/amd64`, `linux/arm64`, `linux/riscv64` — built on
+    `ubuntu:26.04` + OpenJDK 25, the one JDK-25-bearing base published
+    for all three architectures (eclipse-temurin has no riscv64);
+    arm64/riscv64 legs build under QEMU, and dry-runs prove every
+    platform without pushing.
+  - aarch64 Linux installers (deb, rpm, AppImage) from an
+    `ubuntu-24.04-arm` runner, with a per-architecture pinned
+    appimagetool, and an aarch64 Windows installer from a
+    `windows-11-arm` runner (both experimental until checked on real
+    hardware, like their x86_64 predecessors were).
+  - Installer names now carry the architecture
+    (`JLS-<version>-<arch>.msi`/`.dmg`; deb/rpm already did), and the
+    per-leg checksum assets became `SHA256SUMS-installers-<os>-<arch>`
+    so same-OS legs cannot overwrite each other.
+  - RISC-V gets no native installer — no GitHub runners exist and
+    jpackage cannot cross-compile its launcher — so it is served by the
+    container image and the architecture-independent jar. The macOS dmg
+    was already ARM: macos-latest runners are Apple silicon.
 
 ## [5.0.2] — 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -14,28 +14,35 @@ his JLS 4.1.
 The [Releases page](https://github.com/anadon/JLS/releases) carries
 self-contained installers with a bundled Java runtime — no JDK needed:
 
-- **Linux:** `jls_<version>_amd64.deb` (`sudo apt install ./jls_*.deb`) or
-  `jls-<version>*.rpm`. JLS appears in the applications menu.
-- **Linux (any distro):** `JLS-<version>-x86_64.AppImage` — no installation:
-  `chmod +x` it and run it (`--appimage-extract-and-run` if FUSE is absent).
-  The `.jls` association comes along only if your desktop integrates
-  AppImages (e.g. via AppImageLauncher).
+- **Linux:** `jls_<version>_<arch>.deb` (`sudo apt install ./jls_*.deb`) or
+  `jls-<version>*.rpm`, for x86_64 (`amd64`) and ARM (`arm64`/`aarch64`).
+  JLS appears in the applications menu.
+- **Linux (any distro):** `JLS-<version>-x86_64.AppImage` or
+  `JLS-<version>-aarch64.AppImage` — no installation: `chmod +x` it and
+  run it (`--appimage-extract-and-run` if FUSE is absent). The `.jls`
+  association comes along only if your desktop integrates AppImages
+  (e.g. via AppImageLauncher).
 - **NixOS / Nix:** the repository is a flake — `nix run github:anadon/JLS`
   runs it, `nix profile install github:anadon/JLS` installs the `jls`
   command with menu entry and `.jls` association. (The deb/rpm/AppImage
   assets do not fit NixOS; the flake builds from source instead.)
-- **Windows:** `JLS-<version>.msi` (per-user install, no admin rights
-  needed). SmartScreen will warn that the installer is from an unknown
-  publisher because the artifacts are unsigned — choose "More info" →
-  "Run anyway". Verify the download against `SHA256SUMS-installers-windows`
+- **Windows:** `JLS-<version>-x86_64.msi`, or `JLS-<version>-aarch64.msi`
+  for Windows on ARM (per-user install, no admin rights needed).
+  SmartScreen will warn that the installer is from an unknown publisher
+  because the artifacts are unsigned — choose "More info" → "Run anyway".
+  Verify the download against `SHA256SUMS-installers-windows-<arch>`
   first if you want the assurance signing would otherwise give.
-- **macOS:** `JLS-<version>.dmg`. The app is unsigned, so Gatekeeper blocks
-  a plain double-click the first time: right-click (Control-click) the app
-  and choose "Open", then confirm — needed only once.
+- **macOS:** `JLS-<version>-aarch64.dmg` (Apple silicon). The app is
+  unsigned, so Gatekeeper blocks a plain double-click the first time:
+  right-click (Control-click) the app and choose "Open", then confirm —
+  needed only once. Intel Macs: use the jar below.
+- **RISC-V:** no installer (nothing exists to build one on), but the jar
+  below runs on any riscv64 JDK 25+, and the container image ships a
+  `linux/riscv64` variant.
 
 Installing associates `.jls` circuit files with JLS: double-click a `.jls`
 file and it opens in the editor. Each installer has a sha256 entry in the
-`SHA256SUMS-installers-<os>` release asset.
+`SHA256SUMS-installers-<os>-<arch>` release asset.
 
 ## Running JLS from the jar (no installer)
 
@@ -73,8 +80,9 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests circuit.jls
   ```
 
-  The image is headless by construction (no display stack); use an
-  installer or the jar for the GUI editor.
+  Multi-arch: `linux/amd64`, `linux/arm64`, and `linux/riscv64` under
+  one tag. The image is headless by construction (no display stack);
+  use an installer or the jar for the GUI editor.
 
 - **Command-line options:** `java -jar jls-<version>.jar -h` prints the full
   list, including batch mode (`-b`), test-input files (`-t`), simulation time

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.3-SNAPSHOT</version>
+  <version>5.0.3</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>

--- a/resources/packaging/Dockerfile
+++ b/resources/packaging/Dockerfile
@@ -7,21 +7,32 @@
 #
 #   docker run --rm -v "$PWD:/work" ghcr.io/anadon/jls -b -t tests circuit.jls
 #
+# Multi-arch: linux/amd64, linux/arm64, linux/riscv64.  Both stages use
+# ubuntu:26.04 + the archive's OpenJDK 25 because it is the one
+# JDK-25-bearing base published for all three architectures
+# (eclipse-temurin and bellsoft/liberica images have no riscv64), and a
+# single FROM keeps the jlink runtime and the final stage on the same
+# glibc on every platform.
+#
 # Multi-stage: jdeps derives the module set from the shaded jar and jlink
 # trims a runtime from it (the same recipe as scripts/build-installer.sh),
 # so the final image carries ~50 MB of JVM instead of a full JDK.
 
-FROM eclipse-temurin:25 AS runtime
+# binutils: the archive's JDK carries unstripped native libraries, so
+# jlink --strip-debug shells out to objcopy (Temurin's jmods come
+# pre-stripped, which is why the old Temurin build stage never needed it)
+FROM ubuntu:26.04 AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openjdk-25-jdk-headless binutils \
+    && rm -rf /var/lib/apt/lists/*
 COPY jls.jar /build/jls.jar
 RUN set -eux; \
     MODULES="$(jdeps --print-module-deps --ignore-missing-deps /build/jls.jar)"; \
     jlink --add-modules "$MODULES" --strip-debug --no-header-files \
           --no-man-pages --compress zip-6 --output /build/runtime
 
-# ubuntu:24.04 is the same base eclipse-temurin:25 builds on, so the
-# jlink runtime meets the glibc it was linked against; fontconfig +
-# DejaVu let batch image export (-i) render text fully headlessly
-FROM ubuntu:24.04
+# fontconfig + DejaVu let batch image export (-i) render text headlessly
+FROM ubuntu:26.04
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*

--- a/resources/packaging/Dockerfile
+++ b/resources/packaging/Dockerfile
@@ -22,8 +22,9 @@
 # jlink --strip-debug shells out to objcopy (Temurin's jmods come
 # pre-stripped, which is why the old Temurin build stage never needed it)
 FROM ubuntu:26.04 AS runtime
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends openjdk-25-jdk-headless binutils \
+RUN apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        openjdk-25-jdk-headless binutils \
     && rm -rf /var/lib/apt/lists/*
 COPY jls.jar /build/jls.jar
 RUN set -eux; \
@@ -32,9 +33,12 @@ RUN set -eux; \
           --no-man-pages --compress zip-6 --output /build/runtime
 
 # fontconfig + DejaVu let batch image export (-i) render text headlessly
+# (Acquire::Retries: the arm64/riscv64 ports mirror drops connections
+# often enough under QEMU-length builds that one retry pass is not enough)
 FROM ubuntu:26.04
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends fontconfig fonts-dejavu-core \
+RUN apt-get -o Acquire::Retries=3 update \
+    && apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+        fontconfig fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # the source label links the ghcr package to the repository

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -12,6 +12,15 @@
 #                      running Maven (CI builds/tests in a prior step)
 #   IMAGE              image name (default ghcr.io/anadon/jls)
 #   DOCKER             container tool (default docker; podman works)
+#   PLATFORMS          comma-separated buildx platforms (e.g.
+#                      linux/amd64,linux/arm64,linux/riscv64) — switches
+#                      to `docker buildx build`; needs QEMU binfmt for
+#                      non-native entries
+#   PUSH=1             with PLATFORMS: push the multi-arch manifest
+#                      (buildx cannot --load a multi-arch result, so
+#                      without PUSH=1 the build only proves the
+#                      platforms compile — nothing lands in `docker
+#                      image ls`)
 #
 # Tags <version> always, and `latest` only for stable releases (no
 # pre-release/SNAPSHOT suffix).  Pushing is the workflow's job, not ours.
@@ -46,8 +55,19 @@ if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 	tags+=(-t "$IMAGE:latest")
 fi
 
-echo "==> $DOCKER build"
-"$DOCKER" build "${tags[@]}" "$STAGE"
+if [ -n "${PLATFORMS:-}" ]; then
+	push_flag=()
+	if [ "${PUSH:-0}" = "1" ]; then
+		push_flag=(--push)
+	else
+		echo "==> PLATFORMS without PUSH=1: build-only, results stay in the buildx cache"
+	fi
+	echo "==> $DOCKER buildx build --platform ${PLATFORMS}"
+	"$DOCKER" buildx build --platform "$PLATFORMS" "${tags[@]}" "${push_flag[@]}" "$STAGE"
+else
+	echo "==> $DOCKER build"
+	"$DOCKER" build "${tags[@]}" "$STAGE"
 
-echo "==> built:"
-"$DOCKER" image ls "$IMAGE"
+	echo "==> built:"
+	"$DOCKER" image ls "$IMAGE"
+fi

--- a/scripts/build-installer.sh
+++ b/scripts/build-installer.sh
@@ -56,11 +56,13 @@ APP_VERSION="$(printf '%s' "$VERSION" | sed -E 's/^([0-9]+(\.[0-9]+){0,2}).*$/\1
 
 # normalized machine architecture for artifact names (macOS says arm64
 # where Linux says aarch64); deb/rpm carry their own arch fields, but
-# msi/dmg/AppImage names need it to keep multi-arch releases collision-free
-ARCH="$(uname -m)"
+# msi/dmg/AppImage names need it to keep multi-arch releases collision-free.
+# On Windows-on-ARM the git-bash uname is an emulated x64 binary and
+# reports x86_64, so the runner's own RUNNER_ARCH wins when present.
+ARCH="${RUNNER_ARCH:-$(uname -m)}"
 case "$ARCH" in
-	arm64) ARCH=aarch64 ;;
-	amd64) ARCH=x86_64 ;;
+	ARM64 | arm64) ARCH=aarch64 ;;
+	X64 | amd64) ARCH=x86_64 ;;
 esac
 
 echo "==> version ${VERSION} (installer version ${APP_VERSION}, arch ${ARCH})"

--- a/scripts/build-installer.sh
+++ b/scripts/build-installer.sh
@@ -54,7 +54,16 @@ VENDOR="$(mvn -B -q help:evaluate -Dexpression=project.groupId -DforceStdout)"
 # refuses SNAPSHOT releases; local snapshot builds just get the base triple.
 APP_VERSION="$(printf '%s' "$VERSION" | sed -E 's/^([0-9]+(\.[0-9]+){0,2}).*$/\1/')"
 
-echo "==> version ${VERSION} (installer version ${APP_VERSION})"
+# normalized machine architecture for artifact names (macOS says arm64
+# where Linux says aarch64); deb/rpm carry their own arch fields, but
+# msi/dmg/AppImage names need it to keep multi-arch releases collision-free
+ARCH="$(uname -m)"
+case "$ARCH" in
+	arm64) ARCH=aarch64 ;;
+	amd64) ARCH=x86_64 ;;
+esac
+
+echo "==> version ${VERSION} (installer version ${APP_VERSION}, arch ${ARCH})"
 
 # --- shaded jar -------------------------------------------------------------
 if [ "${JLS_SKIP_BUILD:-0}" != "1" ]; then
@@ -110,13 +119,19 @@ package() {
 		"$@"
 }
 
-# --- AppImage (Linux x86_64 only) -------------------------------------------
+# --- AppImage (Linux x86_64 / aarch64) --------------------------------------
 # jpackage --type app-image lays out launcher + bundled runtime; appimagetool
 # folds that tree into one self-mounting executable that runs on any distro
 # (including ones the deb/rpm cannot target).  appimagetool itself is pinned
-# by version and sha256, matching the release pipeline's supply-chain posture.
-APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage"
-APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
+# by version and sha256 per architecture, matching the release pipeline's
+# supply-chain posture.
+APPIMAGETOOL_VERSION="1.9.1"
+case "$ARCH" in
+	x86_64) APPIMAGETOOL_SHA256="ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0" ;;
+	aarch64) APPIMAGETOOL_SHA256="f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158" ;;
+	*) APPIMAGETOOL_SHA256="" ;;
+esac
+APPIMAGETOOL_URL="https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${ARCH}.AppImage"
 
 build_appimage() {
 	# app-image is the raw launcher tree: installer-only flags such as
@@ -155,7 +170,7 @@ build_appimage() {
 	local tool="${APPIMAGETOOL:-}"
 	if [ -z "$tool" ]; then
 		tool="$STAGE/appimagetool"
-		echo "==> fetching appimagetool 1.9.1"
+		echo "==> fetching appimagetool ${APPIMAGETOOL_VERSION} (${ARCH})"
 		curl -fsSL -o "$tool" "$APPIMAGETOOL_URL"
 		echo "${APPIMAGETOOL_SHA256}  ${tool}" | sha256sum -c -
 		chmod +x "$tool"
@@ -163,8 +178,8 @@ build_appimage() {
 	# --appimage-extract-and-run: appimagetool is itself an AppImage and
 	# would otherwise need FUSE, absent on CI runners and NixOS
 	echo "==> appimagetool"
-	ARCH=x86_64 "$tool" --appimage-extract-and-run \
-		"$appdir" "$DIST/JLS-${VERSION}-x86_64.AppImage"
+	ARCH="$ARCH" "$tool" --appimage-extract-and-run \
+		"$appdir" "$DIST/JLS-${VERSION}-${ARCH}.AppImage"
 }
 
 case "$(uname -s)" in
@@ -185,10 +200,10 @@ case "$(uname -s)" in
 		else
 			echo "==> rpmbuild not found; skipping --type rpm"
 		fi
-		if [ "$(uname -m)" = "x86_64" ]; then
+		if [ -n "$APPIMAGETOOL_SHA256" ]; then
 			build_appimage
 		else
-			echo "==> non-x86_64 Linux; skipping AppImage (tool pin is x86_64)"
+			echo "==> no appimagetool pin for ${ARCH}; skipping AppImage"
 		fi
 		;;
 	Darwin)
@@ -197,6 +212,9 @@ case "$(uname -s)" in
 			--icon resources/packaging/jls.icns \
 			--file-associations resources/packaging/jls-association-macos.properties \
 			--mac-package-identifier io.github.anadon.jls
+		# jpackage names the dmg JLS-<version>.dmg with no architecture;
+		# suffix it so Apple-silicon and Intel builds cannot collide
+		mv "$DIST/JLS-${APP_VERSION}.dmg" "$DIST/JLS-${APP_VERSION}-${ARCH}.dmg"
 		;;
 	MINGW* | MSYS* | CYGWIN*)
 		# Per-user install: no admin rights needed (student/lab machines);
@@ -207,6 +225,8 @@ case "$(uname -s)" in
 			--win-menu \
 			--win-shortcut \
 			--win-per-user-install
+		# same collision-proofing as the dmg
+		mv "$DIST/JLS-${APP_VERSION}.msi" "$DIST/JLS-${APP_VERSION}-${ARCH}.msi"
 		;;
 	*)
 		echo "unsupported platform: $(uname -s)" >&2


### PR DESCRIPTION
Adds ARM and RISC-V coverage across the distribution channels:

**Container** — `ghcr.io/anadon/jls` becomes a multi-arch manifest: `linux/amd64`, `linux/arm64`, `linux/riscv64`. Both Dockerfile stages move to `ubuntu:26.04` + OpenJDK 25, the only JDK-25-bearing base published for all three architectures (eclipse-temurin and liberica have no riscv64). That switch surfaced one subtlety: the archive JDK's native libs are unstripped, so `jlink --strip-debug` shells out to `objcopy` → binutils added to the build stage. arm64/riscv64 build under QEMU (`docker/setup-qemu-action`/buildx, SHA-pinned); dry-runs build all platforms without pushing.

**Installers** — new `ubuntu-24.04-arm` leg (aarch64 deb/rpm/AppImage, per-arch pinned appimagetool) and `windows-11-arm` leg (aarch64 msi), both experimental until checked on hardware, like their x86_64 predecessors were. msi/dmg names gain an arch suffix (`JLS-<v>-<arch>.msi`) and checksum assets become `SHA256SUMS-installers-<os>-<arch>` so same-OS legs can't overwrite each other. The macOS dmg was already ARM — macos-latest runners are Apple silicon.

**RISC-V** — no native installer is possible (no GitHub riscv64 runners; jpackage can't cross-compile its launcher), so riscv64 is served by the container image and the architecture-independent jar. Documented in README.

Verified locally: single-arch container build on the new base + smoke test. A release dry-run on this branch is exercising the ARM runner legs and the QEMU multi-arch build.

Also prepares v5.0.3 (pom, changelog; flake version was already 5.0.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)