### PR TITLE
Reopen development at 5.0.4-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
+## [Unreleased] — 5.0.4-SNAPSHOT
+
+*(Nothing yet.)*
+
 ## [5.0.3] — 2026-07-16
 
 ### Added

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             pname = "jls";
             # keep in sync with pom.xml; the base triple is enough — a
             # -SNAPSHOT suffix between releases changes nothing here
-            version = "5.0.3";
+            version = "5.0.4";
             src = self;
 
             # fingerprint of the Maven dependency closure. Refresh after

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.3</version>
+  <version>5.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>


### PR DESCRIPTION
Post-release housekeeping after v5.0.3: pom back to a SNAPSHOT, fresh Unreleased changelog section, flake version in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)