### PR TITLE
Sign and attest the container image (#133); prepare v5.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # keyless cosign signing + OCI provenance attestation (#133)
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -185,6 +188,37 @@ jobs:
           PLATFORMS: linux/amd64,linux/arm64,linux/riscv64
           PUSH: ${{ github.event_name == 'push' && '1' || '0' }}
         run: bash scripts/build-container.sh
+
+      # Signature and provenance go on the manifest-list DIGEST, not a
+      # tag — tags are mutable (#133).  Publications, so tag pushes only.
+      - name: Read pushed digest
+        if: github.event_name == 'push'
+        id: digest
+        run: echo "digest=$(cat target/container/digest)" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        if: github.event_name == 'push'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless: the signature binds to this workflow's OIDC identity;
+      # verify with
+      #   cosign verify ghcr.io/anadon/jls:<version> \
+      #     --certificate-identity-regexp='^https://github.com/anadon/JLS/' \
+      #     --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+      - name: Sign the image (keyless cosign)
+        if: github.event_name == 'push'
+        run: cosign sign --yes "ghcr.io/anadon/jls@${{ steps.digest.outputs.digest }}"
+
+      # Same provenance statement the jar and installers get (#44),
+      # attached to the image in the registry:
+      #   gh attestation verify oci://ghcr.io/anadon/jls:<version> --repo anadon/JLS
+      - name: Attest build provenance
+        if: github.event_name == 'push'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/anadon/jls
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true
 
   # Self-contained installers with a bundled jlink-trimmed runtime and the
   # .jls file association (#82).  The whole recipe lives in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to JLS are documented here. The format follows
 [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) from
 4.3.0 onward. A release is made by pushing a `v<version>` tag.
 
-## [Unreleased] — 5.0.4-SNAPSHOT
+## [5.0.4] — 2026-07-16
 
-*(Nothing yet.)*
+### Added
+- The container image is signed and attested (#133): tag pushes sign
+  the multi-arch manifest digest with keyless cosign (bound to the
+  release workflow's OIDC identity — no maintainer-held keys) and
+  attach the same build-provenance attestation the jar and installers
+  carry, pushed to the registry. Verification commands are in the
+  README; dry-runs neither sign nor push. Signing goes on the digest,
+  never a tag.
 
 ## [5.0.3] — 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   one tag. The image is headless by construction (no display stack);
   use an installer or the jar for the GUI editor.
 
+  Images are signed (keyless cosign, bound to this repository's release
+  workflow) and carry build-provenance attestations:
+
+  ```sh
+  cosign verify ghcr.io/anadon/jls:<version> \
+    --certificate-identity-regexp='^https://github.com/anadon/JLS/' \
+    --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+  gh attestation verify oci://ghcr.io/anadon/jls:<version> --repo anadon/JLS
+  ```
+
 - **Command-line options:** `java -jar jls-<version>.jar -h` prints the full
   list, including batch mode (`-b`), test-input files (`-t`), simulation time
   limits (`-d`), VCD waveform export (`-vcd`, for GTKWave/Surfer and

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>jls</artifactId>
   <!-- v5.0.0: major bump because the (never-reachable) plugin mechanism
        was removed, a feature removal by policy (issue #80) -->
-  <version>5.0.4-SNAPSHOT</version>
+  <version>5.0.4</version>
   <packaging>jar</packaging>
 
   <name>JLS - Java Logic Simulator</name>

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -63,7 +63,15 @@ if [ -n "${PLATFORMS:-}" ]; then
 		echo "==> PLATFORMS without PUSH=1: build-only, results stay in the buildx cache"
 	fi
 	echo "==> $DOCKER buildx build --platform ${PLATFORMS}"
-	"$DOCKER" buildx build --platform "$PLATFORMS" "${tags[@]}" "${push_flag[@]}" "$STAGE"
+	# --metadata-file: surfaces the manifest-list digest; on PUSH=1 the
+	# workflow signs and attests by digest (tags are mutable, #133)
+	"$DOCKER" buildx build --platform "$PLATFORMS" "${tags[@]}" "${push_flag[@]}" \
+		--metadata-file "$STAGE/metadata.json" "$STAGE"
+	if [ "${PUSH:-0}" = "1" ]; then
+		DIGEST="$(sed -n 's/.*"containerimage.digest": *"\([^"]*\)".*/\1/p' "$STAGE/metadata.json" | head -1)"
+		echo "==> pushed digest: ${DIGEST}"
+		printf '%s' "$DIGEST" > "$STAGE/digest"
+	fi
 else
 	echo "==> $DOCKER build"
 	"$DOCKER" build "${tags[@]}" "$STAGE"


### PR DESCRIPTION
Implements #133 §7 (Method):

- `scripts/build-container.sh` surfaces the pushed manifest-list digest via buildx `--metadata-file` (written to `target/container/digest` when `PUSH=1`).
- The `container-image` job gains `id-token: write` + `attestations: write`, a SHA-pinned `sigstore/cosign-installer`, keyless `cosign sign --yes ghcr.io/anadon/jls@<digest>`, and `attest-build-provenance` with `subject-digest` + `push-to-registry: true` — all gated `if: github.event_name == 'push'`, so dry-runs neither sign nor push (P3).
- Signing/attestation bind to the **digest**, never a tag (§10, Threats to Validity).
- README documents both verification commands next to the `docker run` example.

§2 (Observations) re-verified this session before starting: `cosign verify ghcr.io/anadon/jls:5.0.3` → `no signatures found`; `gh attestation verify JLS-5.0.3-aarch64.msi --repo anadon/JLS` → exit 0.

Local evidence: buildx `--metadata-file` digest extraction verified against a real single-arch build and synthetic input. P1/P2 verification happens against the v5.0.4 tag after merge; outputs will be recorded here per §8 (Data Collection & Analysis).

Also prepares v5.0.4 (pom, changelog; flake version already 5.0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)