### PR TITLE
Fix Save As spuriously rejecting the circuit's own name (#117)

### DIFF
--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.JFileChooser;
 import javax.swing.JTabbedPane;
@@ -121,17 +123,16 @@ public final class Editor extends SimpleEditor {
 
 		// make sure name is not already used in some other editor
 		String name = fileName.replaceAll("\\.jls$","");
+		List<Circuit> edited = new ArrayList<Circuit>();
 		for (Component edit : tabbedParent.getComponents()) {
 			if (!(edit instanceof Editor))
 				continue;
-			Editor otherEditor = (Editor)edit;
-			if (otherEditor.getCircuit().isImported())
-				continue;
-			if (name.equals(otherEditor.getCircuit().getName())) {
-				TellUser.error(JLSInfo.frame,
-				"Circuit with this name already being edited", "Error");
-				return;
-			}
+			edited.add(((Editor)edit).getCircuit());
+		}
+		if (nameUsedByAnotherEditor(name,circuit,edited)) {
+			TellUser.error(JLSInfo.frame,
+			"Circuit with this name already being edited", "Error");
+			return;
 		}
 
 		// change name in tab
@@ -160,6 +161,35 @@ public final class Editor extends SimpleEditor {
 			cancelCheckpoint(oldName);
 		}
 	} // end of saveAs method
+
+	/**
+	 * See if a proposed circuit name is already used by a circuit open in
+	 * some other editor.  The circuit being saved is skipped (a circuit
+	 * doesn't collide with itself, so Save As under the current name is
+	 * allowed), as are imported circuits, which can't be saved anyway.
+	 *
+	 * @param name The proposed circuit name (no .jls extension).
+	 * @param self The circuit being saved.
+	 * @param edited The circuits open in sibling editors, including self.
+	 *
+	 * @return true if another editor's circuit already has the name.
+	 */
+	static boolean nameUsedByAnotherEditor(String name, Circuit self,
+			Iterable<Circuit> edited) {
+
+		for (Circuit other : edited) {
+
+			// don't compare the circuit being saved with itself
+			if (other == self)
+				continue;
+
+			if (other.isImported())
+				continue;
+			if (name.equals(other.getName()))
+				return true;
+		}
+		return false;
+	} // end of nameUsedByAnotherEditor method
 
 	/**
 	 * Close this editor window, save circuit if necessary and ok with user.

--- a/test/jls/edit/SaveAsNameCheckTest.java
+++ b/test/jls/edit/SaveAsNameCheckTest.java
@@ -1,0 +1,96 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.elem.SubCircuit;
+
+/**
+ * Save As duplicate-name predicate tests (issue #117). saveAs used to
+ * scan every sibling editor tab without skipping the editor being
+ * saved, so saving a circuit under its own current name collided with
+ * itself and was refused with "Circuit with this name already being
+ * edited". The predicate is now extracted to
+ * {@link Editor#nameUsedByAnotherEditor(String, Circuit, Iterable)}
+ * with the same self-exclusion the import-menu loop in saveAs already
+ * had; these tests pin the issue's P1 (self is not a collision) and P2
+ * (a genuine duplicate still is).
+ */
+class SaveAsNameCheckTest {
+
+	/**
+	 * P1: Save As keeping the circuit's own current name is not a
+	 * duplicate, whether it is the only circuit open or one of several.
+	 */
+	@Test
+	void savingUnderOwnCurrentNameIsNotACollision() {
+		Circuit foo = new Circuit("foo");
+		assertFalse(Editor.nameUsedByAnotherEditor("foo", foo,
+				Collections.singletonList(foo)),
+				"a circuit must not collide with itself");
+
+		Circuit bar = new Circuit("bar");
+		assertFalse(Editor.nameUsedByAnotherEditor("foo", foo,
+				Arrays.asList(foo, bar)),
+				"siblings with different names must not block a "
+						+ "save under the current name");
+	}
+
+	/**
+	 * P2: with foo and bar open, Save As on bar choosing the name foo
+	 * is still refused.
+	 */
+	@Test
+	void savingUnderAnotherEditorsNameIsACollision() {
+		Circuit foo = new Circuit("foo");
+		Circuit bar = new Circuit("bar");
+		List<Circuit> edited = Arrays.asList(foo, bar);
+		assertTrue(Editor.nameUsedByAnotherEditor("foo", bar, edited),
+				"another editor's name must still be refused");
+		assertTrue(Editor.nameUsedByAnotherEditor("bar", foo, edited),
+				"...in either direction");
+	}
+
+	/**
+	 * The exclusion is by identity, not by name: a distinct sibling
+	 * circuit that happens to share the saved circuit's name is a
+	 * genuine duplicate and must still be refused.
+	 */
+	@Test
+	void distinctSiblingWithSameNameIsStillACollision() {
+		Circuit self = new Circuit("foo");
+		Circuit other = new Circuit("foo");
+		assertTrue(Editor.nameUsedByAnotherEditor("foo", self,
+				Arrays.asList(self, other)));
+	}
+
+	/**
+	 * Pre-existing behavior kept by the extraction: imported circuits
+	 * (open subcircuit views, which can't be saved) never count as
+	 * duplicates.
+	 */
+	@Test
+	void importedCircuitsAreSkipped() {
+		Circuit self = new Circuit("bar");
+		Circuit imported = new Circuit("foo");
+		imported.setImported(new SubCircuit(imported));
+		assertFalse(Editor.nameUsedByAnotherEditor("foo", self,
+				Arrays.asList(self, imported)));
+	}
+
+	/** An unused name is never a collision. */
+	@Test
+	void unusedNameIsNotACollision() {
+		Circuit foo = new Circuit("foo");
+		Circuit bar = new Circuit("bar");
+		assertFalse(Editor.nameUsedByAnotherEditor("baz", foo,
+				Arrays.asList(foo, bar)));
+	}
+}


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #117 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 305 tests; new jls.edit.SaveAsNameCheckTest 5/5, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
