### PR TITLE
Fix timing-trace tic-label overprint and keep full trace history scrollable (#121)

### DIFF
--- a/src/jls/sim/InteractiveSimulator.java
+++ b/src/jls/sim/InteractiveSimulator.java
@@ -977,6 +977,12 @@ public final class InteractiveSimulator extends Simulator {
 		private java.util.List<Trace> newList = new LinkedList<Trace>();
 		private int nameSpace;
 
+		// hard ceiling on how wide the trace panels may grow (issue
+		// #121): keeps a very long run at a tiny scale factor from
+		// demanding an absurd component width; the retained history
+		// is bounded by Trace.MAX_RETAINED_CHANGES anyway
+		private static final int MAX_PANEL_WIDTH = 4_000_000;
+
 		/**
 		 * Set up the window.
 		 */
@@ -1082,14 +1088,61 @@ public final class InteractiveSimulator extends Simulator {
 		} // end of getNameSpace method
 
 		/**
-		 * Repaint all the trace objects.
+		 * Repaint all the trace objects, first growing them to span the
+		 * whole retained run so the enclosing scroll pane can reach all
+		 * of it (issue #121).  Every call site is on the EDT except the
+		 * animate path, which reaches here from a java.util.Timer
+		 * thread (runSim() at animate start; a pre-existing off-EDT
+		 * path in the #49 series), so re-dispatch before touching the
+		 * component tree or the viewport.
 		 */
 		private void draw() {
+
+			if (!SwingUtilities.isEventDispatchThread()) {
+				SwingUtilities.invokeLater(new Runnable() {
+					public void run() {
+						draw();
+					}
+				});
+				return;
+			}
+
+			// width the run needs at the current scale factor, plus the
+			// name area; never smaller than the viewport so short runs
+			// still fill the window
+			JViewport port = (JViewport)SwingUtilities.getAncestorOfClass(
+					JViewport.class,this);
+			int viewWidth = port == null ? getWidth()
+					: port.getExtentSize().width;
+			long runWidth = now/scaleFactor+nameSpace+10;
+			final int target = (int)Math.min(
+					Math.max(runWidth,viewWidth),MAX_PANEL_WIDTH);
+
+			// keep following the newest activity unless the user has
+			// scrolled back into the history
+			boolean atEnd = port == null || port.getViewPosition().x
+					+port.getExtentSize().width >= getWidth()-5;
+			if (target != getWidth()) {
+				resize(target);
+				revalidate();
+			}
 
 			repaint();
 			for (Trace tr : traceList) {
 				tr.commit(now);
 				tr.repaint();
+			}
+
+			// after the revalidate has laid the new width out
+			if (atEnd && port != null) {
+				final JViewport p = port;
+				SwingUtilities.invokeLater(new Runnable() {
+					public void run() {
+						p.setViewPosition(new Point(
+								Math.max(0,target-p.getExtentSize().width),
+								p.getViewPosition().y));
+					}
+				});
 			}
 		} // end of draw method
 
@@ -1208,7 +1261,8 @@ public final class InteractiveSimulator extends Simulator {
 
 			super.paintComponent(g);
 			int width = getWidth()-parent.getNameSpace()-10;
-			long time = now-(width-sliderPos)*scaleFactor;
+			// long math: the panel can span the whole run (issue #121)
+			long time = now-(long)(width-sliderPos)*scaleFactor;
 			if (time >= 0 && time <= now) {
 				g.setColor(Color.gray);
 				g.drawString(time+"",sliderPos,2*HEIGHT/3);

--- a/src/jls/sim/InteractiveSimulator.java
+++ b/src/jls/sim/InteractiveSimulator.java
@@ -1100,6 +1100,7 @@ public final class InteractiveSimulator extends Simulator {
 
 			if (!SwingUtilities.isEventDispatchThread()) {
 				SwingUtilities.invokeLater(new Runnable() {
+					@Override
 					public void run() {
 						draw();
 					}
@@ -1137,6 +1138,7 @@ public final class InteractiveSimulator extends Simulator {
 			if (atEnd && port != null) {
 				final JViewport p = port;
 				SwingUtilities.invokeLater(new Runnable() {
+					@Override
 					public void run() {
 						p.setViewPosition(new Point(
 								Math.max(0,target-p.getExtentSize().width),

--- a/src/jls/sim/Trace.java
+++ b/src/jls/sim/Trace.java
@@ -241,7 +241,7 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 		}
 		double pos = width-(double)(now-when)/scaleFactor;
 		BitSet previousVal = ch > 0 ? snapshot.get(ch-1).value : null;
-		int leftEdge = Math.max(0,clipLo-2);
+		double leftEdge = Math.max(0,clipLo-2);
 
 		// draw until no longer visible
 		g.setColor(Color.black);

--- a/src/jls/sim/Trace.java
+++ b/src/jls/sim/Trace.java
@@ -16,6 +16,12 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	
 	// named constants
 	protected final int HEIGHT = 40;
+
+	// how many changes each trace retains for scrollback (issue #121).
+	// This is the display-side bound (distinct from #20's simulation
+	// state bounds): at ~136 bytes per change (Change object + cloned
+	// BitSet + linked-list node) it caps a trace at roughly 14 MB.
+	static final int MAX_RETAINED_CHANGES = 100_000;
 	
 	// structure to contain a change
 	private class Change {
@@ -127,9 +133,11 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 		ch.when = when;
 		pendingChanges.add(0,ch);
 		
-		// delete undisplayable values
-		// (test for when == 0 due to no width yet)
-		if (when != 0 && pendingChanges.size() > getWidth())
+		// retain a bounded scrollback history (issue #121): the cap
+		// used to be the panel width, which discarded everything a
+		// finished run could no longer display; the panel now grows
+		// with the run, so retention is a documented count instead
+		if (pendingChanges.size() > MAX_RETAINED_CHANGES)
 			pendingChanges.removeLast();
 	} // end of addValue method
 	
@@ -165,65 +173,84 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 		g.setColor(Color.black);
 		g.drawString(name,width+5,baseline);
 		
+		// take one snapshot of the committed changes so every phase
+		// below sees the same list even if a commit lands mid-paint
+		java.util.ArrayList<Change> snapshot = changes;
+
 		// set up for loop
 		int top = HEIGHT/2-10;
 		int bottom = HEIGHT/2+10;
 		int middle = (top+bottom)/2;
-		double pos = width;
 		long when = now;
 		int ch = 0;
-		
+
 		// draw a terminator line
 		g.setColor(Color.pink);
 		g.drawLine(width,0,width,HEIGHT);
-		
+
 		// draw tic marks,
-		// first compute tic increment
-		int t = 0;
-		int m = 1;
-		int inc = 0;
-		while (t < 50) {
-			inc = m*50;
-			t = inc/scaleFactor;
-			if (t < 50) {
-				inc = m*100;
-				t = inc/scaleFactor;
-			}
-			if (t < 50) {
-				inc = m*200;
-				t = inc/scaleFactor;
-			}
-			if (t < 50) {
-				inc = m*250;
-				t = inc/scaleFactor;
-			}
-			m *= 10;
-		}
-		
-		// then draw tics
-		double tpos = width-now/scaleFactor;
-		int value = 0;
-		while (tpos < width) {
+		// first compute tic increment (extracted for unit testing,
+		// issue #121)
+		int inc = TraceGeometry.ticIncrement(scaleFactor);
+
+		// the panel spans the whole retained run now (issue #121), so
+		// drawing is windowed to the clip: sweeping every tic and every
+		// change from time zero would be O(run length) per repaint
+		Rectangle clip = g.getClipBounds();
+		int clipLo = clip == null ? 0 : clip.x;
+		int clipHi = clip == null ? width : clip.x+clip.width;
+
+		// label only every stride-th tic so adjacent labels can never
+		// overlap (issue #121): bound every label's width by the digit
+		// count of the largest time value, measured in this font's
+		// metrics (metrics, never hard-coded pixels - issue #111)
+		double pitch = 1.0*inc/scaleFactor;
+		double tzero = width-now/scaleFactor;
+		long lastTic = Math.max(0,(long)Math.ceil((width-tzero)/pitch));
+		int digitWidth = fm.charWidth(' ');
+		for (char c = '0'; c <= '9'; c += 1)
+			digitWidth = Math.max(digitWidth,fm.charWidth(c));
+		int labelWidth = (String.valueOf(lastTic*inc).length()+1)*digitWidth;
+		int stride = TraceGeometry.labelStride(labelWidth,pitch);
+
+		// then draw tics, starting one label stride left of the clip
+		// so a label that begins off-clip still paints its tail
+		long firstTic = Math.max(0,
+				(long)Math.floor((clipLo-tzero)/pitch)-stride);
+		for (long tic = firstTic; ; tic += 1) {
+			double tpos = tzero+tic*pitch;
+			if (tpos >= width || tpos > clipHi)
+				break;
 			g.setColor(Color.lightGray);
 			g.drawLine((int)Math.rint(tpos), 0, (int)Math.rint(tpos), HEIGHT);
-			
+
 			// draw value if no changes (i.e., the header)
-			if (changes.isEmpty()) {
-				g.drawString(value+"", (int)Math.rint(tpos)+2, height);
+			if (snapshot.isEmpty() && tic % stride == 0) {
+				g.drawString((tic*inc)+"", (int)Math.rint(tpos)+2, height);
 			}
-			tpos += 1.0*inc/scaleFactor;
-			value += inc;
 		}
-		
+
+		// skip changes that lie entirely right of the clip: the first
+		// change at or before the time just right of the clip edge
+		// (2px slack for rounding) opens the visible window
+		if (!snapshot.isEmpty() && clipHi < width) {
+			long tClip = now-(long)(width-clipHi-2)*scaleFactor;
+			ch = firstChangeAtOrBefore(snapshot,tClip);
+			if (ch > 0)
+				when = snapshot.get(ch-1).when;
+		}
+		double pos = width-(double)(now-when)/scaleFactor;
+		BitSet previousVal = ch > 0 ? snapshot.get(ch-1).value : null;
+		int leftEdge = Math.max(0,clipLo-2);
+
 		// draw until no longer visible
 		g.setColor(Color.black);
-		BitSet previousVal = null;
-		while (pos > 0) {
-			
+		while (pos > leftEdge) {
+
 			// get the next change
-			if (ch >= changes.size())
+			if (ch >= snapshot.size())
 				break;
-			Change change = changes.get(ch);
+			Change change = snapshot.get(ch);
 			double len = ((double)(when-change.when)/scaleFactor);
 			int rpos = (int)Math.round(pos);
 			int rlen = (int)Math.round(len);
@@ -290,40 +317,89 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 				}
 			}
 			previousVal = change.value;
-			pos = pos-len;
+			// recompute the position from the change time rather than
+			// accumulate, so a windowed repaint puts every segment
+			// exactly where a full repaint would (issue #121)
+			pos = width-(double)(now-change.when)/scaleFactor;
 			when = change.when;
 			ch += 1;
 		}
-		
+
 		// draw slider
 		g.setColor(Color.gray);
 		g.drawLine(sliderPos,0,sliderPos,HEIGHT);
-		
+
 		// draw value at slider position
-		long stime = now-(width-sliderPos)*scaleFactor;
-		if (stime >= 0) {
-			Change lastChange = null;
-			for (Change chg : changes) {
-				lastChange = chg;
-				if (stime >= chg.when)
-					break;
+		// (don't draw value if no changes (e.g., the header))
+		long stime = now-(long)(width-sliderPos)*scaleFactor;
+		if (stime >= 0 && !snapshot.isEmpty()) {
+
+			// binary search: the retained history is no longer bounded
+			// by the panel width (issue #121)
+			int at = Math.min(firstChangeAtOrBefore(snapshot,stime),
+					snapshot.size()-1);
+			Change lastChange = snapshot.get(at);
+			String val = "HiZ";
+			if (!lastChange.value.equals(off)) {
+				val = BitSetUtils.ToString(lastChange.value,base);
 			}
-			
-			// don't draw value if no changes (e.g., the header)
-			if (lastChange != null) {
-				String val = "HiZ";
-				if (!lastChange.value.equals(off)) {
-					val = BitSetUtils.ToString(lastChange.value,base);
-				}
-				int w = fm.stringWidth(val);
-				g.setColor(Color.white);
-				g.fillRect(sliderPos-w-4,baseline-ascent,w+3,height);
-				g.setColor(Color.magenta);
-				g.drawString(val,sliderPos-w-1,baseline);
+			int w = fm.stringWidth(val);
+			g.setColor(Color.white);
+			g.fillRect(sliderPos-w-4,baseline-ascent,w+3,height);
+			g.setColor(Color.magenta);
+			g.drawString(val,sliderPos-w-1,baseline);
+
+			// the name at the right edge may be scrolled out of view,
+			// so label the cursor with the signal name too (issue
+			// #121; bsiever prior art)
+			if (!name.isEmpty()) {
+				int nw = fm.stringWidth(name);
+				g.setColor(Color.black);
+				g.drawString(name,sliderPos-nw-1,baseline+ascent+3);
 			}
 		}
-		
+
 	} // end of paintComponent method
+
+	/**
+	 * Find the first (newest) committed change at or before a given
+	 * time - the change whose value is in effect at that time.  The
+	 * list is ordered newest first; binary search keeps repaints from
+	 * scanning the whole retained history (issue #121).
+	 *
+	 * @param list The committed changes, newest first.
+	 * @param time The simulation time to look up.
+	 *
+	 * @return The smallest index whose change time is at or before
+	 *         time, or list.size() if every change is later.
+	 */
+	private static int firstChangeAtOrBefore(
+			java.util.ArrayList<Change> list, long time) {
+
+		int lo = 0;
+		int hi = list.size();
+		while (lo < hi) {
+			int mid = (lo+hi) >>> 1;
+			if (list.get(mid).when <= time)
+				hi = mid;
+			else
+				lo = mid+1;
+		}
+		return lo;
+	} // end of firstChangeAtOrBefore method
+
+	/**
+	 * Test seam for the search over the committed snapshot (issue
+	 * #121): package-private, used by TraceWindowingTest.
+	 *
+	 * @param time The simulation time to look up.
+	 *
+	 * @return See firstChangeAtOrBefore(list,time).
+	 */
+	int firstChangeAtOrBefore(long time) {
+
+		return firstChangeAtOrBefore(changes,time);
+	} // end of firstChangeAtOrBefore method
 	
 	/**
 	 * Called to tell this object that the trace window has been resized.
@@ -344,8 +420,9 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 * @param x The x-coordinate of the slider.
 	 */
 	public void mouseMoved(int x) {
-		
-		long time = now-(width-x)*scaleFactor;
+
+		// long math: the panel can now span the whole run (issue #121)
+		long time = now-(long)(width-x)*scaleFactor;
 		
 		// set slider pos
 		if (time > now)

--- a/src/jls/sim/TraceGeometry.java
+++ b/src/jls/sim/TraceGeometry.java
@@ -1,0 +1,76 @@
+package jls.sim;
+
+/**
+ * Pure display geometry for the timing-trace viewer (issue #121): the
+ * tic-increment and label-spacing computations extracted from
+ * Trace.paintComponent so their properties (minimum tic pitch, label
+ * non-overlap, label density) are unit-testable.  Deliberately free of
+ * AWT so it stays inside the headless core (HeadlessCoreRatchetTest).
+ *
+ * @author David A. Poplawski
+ */
+public final class TraceGeometry {
+
+	// minimum pixel gap between adjacent tic marks
+	public static final int MIN_TIC_GAP = 50;
+
+	/**
+	 * Never instantiated.
+	 */
+	private TraceGeometry() {
+	} // end of constructor
+
+	/**
+	 * Compute the simulation-time increment between tic marks: the
+	 * smallest of 50, 100, 200 or 250 times a power of ten whose pixel
+	 * pitch (increment / scaleFactor, integer division) is at least
+	 * MIN_TIC_GAP pixels.  Moved verbatim from Trace.paintComponent.
+	 *
+	 * @param scaleFactor Simulation time units per pixel (at least 1).
+	 *
+	 * @return The tic increment, in simulation time units.
+	 */
+	public static int ticIncrement(int scaleFactor) {
+
+		int t = 0;
+		int m = 1;
+		int inc = 0;
+		while (t < MIN_TIC_GAP) {
+			inc = m*50;
+			t = inc/scaleFactor;
+			if (t < MIN_TIC_GAP) {
+				inc = m*100;
+				t = inc/scaleFactor;
+			}
+			if (t < MIN_TIC_GAP) {
+				inc = m*200;
+				t = inc/scaleFactor;
+			}
+			if (t < MIN_TIC_GAP) {
+				inc = m*250;
+				t = inc/scaleFactor;
+			}
+			m *= 10;
+		}
+		return inc;
+	} // end of ticIncrement method
+
+	/**
+	 * How many tics apart time labels must be drawn so adjacent labels
+	 * can never overlap: the smallest stride whose pixel span
+	 * (stride * ticPitch) is at least the widest label's width.
+	 *
+	 * @param labelWidth The widest label's pixel width (from font
+	 *                   metrics, never hard-coded - issue #111).
+	 * @param ticPitch The pixel gap between adjacent tics (positive).
+	 *
+	 * @return The stride (at least 1) between labeled tics.
+	 */
+	public static int labelStride(int labelWidth, double ticPitch) {
+
+		if (labelWidth <= 0)
+			return 1;
+		return Math.max(1,(int)Math.ceil(labelWidth/ticPitch));
+	} // end of labelStride method
+
+} // end of TraceGeometry class

--- a/test/jls/sim/TraceGeometryTest.java
+++ b/test/jls/sim/TraceGeometryTest.java
@@ -1,0 +1,152 @@
+package jls.sim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Properties of the extracted trace-display geometry (issue #121):
+ * the tic increment keeps a minimum pixel pitch, and the label stride
+ * guarantees adjacent time labels can neither overlap (P1) nor thin
+ * out so far that a viewport shows none (the H1 falsification guard
+ * from section 9 of the issue).
+ */
+class TraceGeometryTest {
+
+	/**
+	 * Scale factors to sweep: 1..1000 exhaustively, then decades with
+	 * offsets up to 10^7.  (Above ~4*10^7 the increment search
+	 * overflows int; that defect predates #121 and is out of its
+	 * scope.)
+	 */
+	private static int[] scaleFactors() {
+
+		List<Integer> scales = new ArrayList<>();
+		for (int s = 1; s <= 1000; s++)
+			scales.add(s);
+		for (int decade = 10_000; decade <= 10_000_000; decade *= 10) {
+			scales.add(decade - 1);
+			scales.add(decade);
+			scales.add(decade + 7);
+		}
+		int[] out = new int[scales.size()];
+		for (int i = 0; i < out.length; i++)
+			out[i] = scales.get(i);
+		return out;
+	}
+
+	@Test
+	void ticPitchIsAtLeastFiftyPixelsAtEveryScaleFactor() {
+
+		for (int scale : scaleFactors()) {
+			int inc = TraceGeometry.ticIncrement(scale);
+			assertTrue(inc > 0, "increment must be positive at scale "
+					+ scale);
+			assertTrue(1.0 * inc / scale >= TraceGeometry.MIN_TIC_GAP,
+					"pitch below minimum at scale " + scale + " (inc="
+							+ inc + ")");
+		}
+	}
+
+	@Test
+	void ticIncrementMatchesTheInlineOriginal() {
+
+		// the extraction from Trace.paintComponent is verbatim; pin
+		// hand-computed values of the original loop
+		assertEquals(50, TraceGeometry.ticIncrement(1));
+		assertEquals(100, TraceGeometry.ticIncrement(2));
+		assertEquals(200, TraceGeometry.ticIncrement(3));
+		assertEquals(250, TraceGeometry.ticIncrement(5));
+		assertEquals(500, TraceGeometry.ticIncrement(10));
+		assertEquals(5_000_000, TraceGeometry.ticIncrement(100_000));
+	}
+
+	@Test
+	void adjacentLabelsNeverOverlap() {
+
+		// P1's post-fix half: consecutive drawn labels sit
+		// stride*pitch pixels apart, which must cover the label width
+		for (int scale : scaleFactors()) {
+			double pitch = 1.0 * TraceGeometry.ticIncrement(scale) / scale;
+			for (int labelWidth = 1; labelWidth <= 400; labelWidth++) {
+				int stride = TraceGeometry.labelStride(labelWidth, pitch);
+				assertTrue(stride >= 1);
+				assertTrue(stride * pitch >= labelWidth,
+						"overlap: scale " + scale + " labelWidth "
+								+ labelWidth + " stride " + stride
+								+ " pitch " + pitch);
+			}
+		}
+	}
+
+	@Test
+	void labeledTicsStayDense() {
+
+		// H1 falsification guard (section 9 of the issue): skipping
+		// may never leave a viewport without labels.  Since
+		// stride = ceil(labelWidth/pitch), consecutive labels are
+		// less than labelWidth + pitch apart, so any viewport at
+		// least labelWidth + 2*pitch wide contains a whole label.
+		for (int scale : scaleFactors()) {
+			double pitch = 1.0 * TraceGeometry.ticIncrement(scale) / scale;
+			for (int labelWidth = 1; labelWidth <= 400; labelWidth++) {
+				int stride = TraceGeometry.labelStride(labelWidth, pitch);
+				assertTrue(stride * pitch < labelWidth + pitch,
+						"labels too sparse: scale " + scale
+								+ " labelWidth " + labelWidth);
+			}
+		}
+	}
+
+	@Test
+	void realisticHeaderLabelsClearEachOtherInRealFontMetrics() {
+
+		// the same digit-count width bound Trace.paintComponent uses,
+		// with a real font (metrics, not hard-coded pixels - #111):
+		// every label drawn for a default-length run must fit inside
+		// the stride at every scale factor
+		FontMetrics fm = new BufferedImage(1, 1,
+				BufferedImage.TYPE_INT_RGB).createGraphics()
+						.getFontMetrics(
+								new Font(Font.DIALOG, Font.PLAIN, 12));
+		int digitWidth = fm.charWidth(' ');
+		for (char c = '0'; c <= '9'; c++)
+			digitWidth = Math.max(digitWidth, fm.charWidth(c));
+
+		long now = 100_000_000L; // the default run limit
+		for (int scale : new int[] { 1, 3, 7, 100, 999, 12_345,
+				1_000_000, 10_000_000 }) {
+			int inc = TraceGeometry.ticIncrement(scale);
+			double pitch = 1.0 * inc / scale;
+			long lastTic = now / inc + 1;
+			int labelWidth = (String.valueOf(lastTic * inc).length() + 1)
+					* digitWidth;
+			int stride = TraceGeometry.labelStride(labelWidth, pitch);
+
+			// check real rendered widths of a sample of the labels
+			// actually drawn (multiples of stride), including the
+			// widest ones at the end of the run
+			long[] sample = { 0, stride, 2L * stride,
+					(lastTic / stride / 2) * stride,
+					(lastTic / stride - 1) * stride,
+					(lastTic / stride) * stride };
+			for (long tic : sample) {
+				if (tic < 0)
+					continue;
+				int w = fm.stringWidth(String.valueOf(tic * inc));
+				assertTrue(w <= stride * pitch,
+						"label " + (tic * inc) + " overlaps its"
+								+ " neighbour at scale " + scale
+								+ ": width " + w + " > stride span "
+								+ stride * pitch);
+			}
+		}
+	}
+}

--- a/test/jls/sim/TraceRetentionTest.java
+++ b/test/jls/sim/TraceRetentionTest.java
@@ -1,0 +1,175 @@
+package jls.sim;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.BitSet;
+
+import org.junit.jupiter.api.Test;
+
+import jls.JLSInfo;
+
+/**
+ * History retention at the Trace model level (issue #121, O1/P2):
+ * values older than the panel width used to be discarded as they
+ * arrived ({@code pendingChanges.removeLast()}), so a finished run
+ * could not be scrolled back.  Post-fix a trace retains a documented
+ * count of changes independent of the panel width.
+ *
+ * <p>Deliberately written against the pre-#121 public surface
+ * (addValue/commit/paintComponent + pixels) so the same source
+ * compiles at the pre-change commit, where the first two tests fail
+ * (rule-3 regression evidence).</p>
+ */
+class TraceRetentionTest {
+
+	private static final int HEIGHT = 40;
+
+	/** The documented retention cap; literal (not a reference to
+	 *  Trace.MAX_RETAINED_CHANGES) so this file compiles at the
+	 *  pre-change commit. */
+	private static final int CAP = 100_000;
+
+	/**
+	 * A real Traces parent (nameSpace 0), built with the GUI-free
+	 * batch path so the test stays headless.
+	 */
+	private static InteractiveSimulator.Traces parent() {
+
+		boolean oldBatch = JLSInfo.batch;
+		JLSInfo.batch = true;
+		try {
+			return new InteractiveSimulator().new Traces();
+		}
+		finally {
+			JLSInfo.batch = oldBatch;
+		}
+	}
+
+	private static BitSet bit(boolean on) {
+
+		BitSet value = new BitSet(2);
+		if (on)
+			value.set(0);
+		return value;
+	}
+
+	private static BufferedImage paint(Trace trace, int width) {
+
+		BufferedImage image = new BufferedImage(width, HEIGHT,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = image.createGraphics();
+		g.setColor(Color.white);
+		g.fillRect(0, 0, width, HEIGHT);
+		trace.paintComponent(g);
+		g.dispose();
+		return image;
+	}
+
+	/** Any non-white pixel in columns [x0,x1]? */
+	private static boolean hasInk(BufferedImage image, int x0, int x1) {
+
+		int white = Color.white.getRGB();
+		for (int x = x0; x <= x1; x++)
+			for (int y = 0; y < image.getHeight(); y++)
+				if (image.getRGB(x, y) != white)
+					return true;
+		return false;
+	}
+
+	@Test
+	void historyBeyondThePanelWidthSurvivesForScrollback() {
+
+		// values arrive while the panel is 510px wide...
+		Trace trace = new Trace("sig", null, 1, 500, parent());
+		trace.setSize(510, HEIGHT);
+		int last = 5000;
+		for (int t = 1; t <= last; t++)
+			trace.addValue(bit(t % 2 == 0), t);
+		trace.commit(last);
+
+		// ...then the run is over and the viewer grows for scrollback
+		trace.setSize(last + 100, HEIGHT);
+		BufferedImage image = paint(trace, last + 100);
+
+		// drawing width w = 5090; time t sits at x = w-(5000-t) = 90+t,
+		// so x in [195,205] is t in [105,115] - early history.  The
+		// pre-#121 width cap kept only t >= 4491, leaving this blank.
+		// (Tic gridlines are at x = 90+50k: 190 and 240 both excluded.)
+		assertTrue(hasInk(image, 195, 205),
+				"activity at t~110 must still be drawn after a "
+						+ last + "-step run");
+
+		// sanity: recent history is drawn in both versions
+		assertTrue(hasInk(image, 4700, 4710),
+				"recent history must be drawn");
+	}
+
+	@Test
+	void retentionIsBoundedAtTheDocumentedCap() {
+
+		// a panel wider than the whole run: the pre-#121 width cap
+		// never binds, so at the pre-change commit everything is
+		// retained and the dropped-region assertion below fails
+		int total = CAP + 50;
+		int panel = total + 9960;
+		Trace trace = new Trace("sig", null, 1, 500, parent());
+		trace.setSize(panel, HEIGHT);
+		for (int t = 1; t <= total; t++)
+			trace.addValue(bit(t % 2 == 0), t);
+		trace.commit(total);
+
+		BufferedImage image = paint(trace, panel);
+
+		// drawing width w = panel-10; x(t) = w-(total-t) = 9950+t+...
+		int w = panel - 10;
+		int xOf1 = w - (total - 1);      // oldest added change
+		int xOf51 = w - (total - 51);    // oldest RETAINED change
+
+		// t in [1,50] was dropped by the cap: blank.  The checked
+		// columns [xOf1+4, xOf51-5] exclude the tic gridlines, which
+		// land at multiples of 50 from tzero = w-total.
+		assertFalse(hasInk(image, xOf1 + 4, xOf51 - 5),
+				"changes older than the retention cap must be dropped");
+
+		// t just inside the cap is drawn (columns chosen between tic
+		// gridlines so only signal ink can satisfy the assertion)
+		assertTrue(hasInk(image, xOf51 + 54, xOf51 + 69),
+				"changes inside the retention cap must be drawn");
+	}
+
+	@Test
+	void unchangedValuesAreStillDeduplicated() {
+
+		// pre-existing behavior kept: re-adding an equal value adds
+		// no change, so a constant signal costs one entry, not one
+		// per event
+		Trace trace = new Trace("sig", null, 1, 500, parent());
+		trace.setSize(1010, HEIGHT);
+		trace.addValue(bit(true), 1);
+		for (int t = 2; t <= 900; t++)
+			trace.addValue(bit(true), t);
+		trace.commit(900);
+		BufferedImage image = paint(trace, 1010);
+
+		// one long high segment, no transitions: the 'top' row (y=10)
+		// has black signal ink, the 'bottom' row (y=30) has none
+		// (tic gridlines are light gray, so checking for black keys
+		// on signal ink only)
+		boolean topInk = false;
+		boolean bottomInk = false;
+		int black = Color.black.getRGB();
+		for (int x = 0; x < 1000; x++) {
+			if (image.getRGB(x, 10) == black)
+				topInk = true;
+			if (image.getRGB(x, 30) == black)
+				bottomInk = true;
+		}
+		assertTrue(topInk, "the high level must be drawn");
+		assertFalse(bottomInk, "a constant-high signal must never "
+				+ "draw at the low level");
+	}
+}

--- a/test/jls/sim/TraceWindowingTest.java
+++ b/test/jls/sim/TraceWindowingTest.java
@@ -1,0 +1,221 @@
+package jls.sim;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import jls.JLSInfo;
+
+/**
+ * Windowed trace drawing (issue #121, H2/P3): with the panel spanning
+ * the whole retained run, paintComponent limits its work to the clip.
+ * These tests pin (a) that the clip-window fast-forward (a binary
+ * search over the committed changes) agrees with the linear scan it
+ * replaced, and (b) that a windowed repaint produces exactly the same
+ * pixels inside the clip as a full repaint - so the windowing is
+ * purely a cost optimization, never a rendering change.
+ */
+class TraceWindowingTest {
+
+	private static final int HEIGHT = 40;
+
+	private static InteractiveSimulator.Traces parent() {
+
+		boolean oldBatch = JLSInfo.batch;
+		JLSInfo.batch = true;
+		try {
+			return new InteractiveSimulator().new Traces();
+		}
+		finally {
+			JLSInfo.batch = oldBatch;
+		}
+	}
+
+	private static BitSet bits(int value, int width) {
+
+		BitSet out = new BitSet(width + 1);
+		for (int i = 0; i < width; i++)
+			if ((value >> i & 1) != 0)
+				out.set(i);
+		return out;
+	}
+
+	private static BufferedImage paint(Trace trace, int width,
+			Rectangle clip) {
+
+		BufferedImage image = new BufferedImage(width, HEIGHT,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = image.createGraphics();
+		g.setColor(Color.white);
+		g.fillRect(0, 0, width, HEIGHT);
+		if (clip != null)
+			g.clip(clip);
+		trace.paintComponent(g);
+		g.dispose();
+		return image;
+	}
+
+	/** Assert pixel equality of columns [x0,x0+w) and that the region
+	 *  is not trivially blank. */
+	private static void assertRegionEqualAndInked(BufferedImage full,
+			BufferedImage part, int x0, int w) {
+
+		int white = Color.white.getRGB();
+		boolean ink = false;
+		for (int x = x0; x < x0 + w; x++)
+			for (int y = 0; y < HEIGHT; y++) {
+				int expected = full.getRGB(x, y);
+				assertEquals(expected, part.getRGB(x, y),
+						"pixel mismatch at (" + x + "," + y
+								+ ") for clip x0=" + x0);
+				if (expected != white)
+					ink = true;
+			}
+		assertTrue(ink, "vacuous comparison: clip region at " + x0
+				+ " is entirely blank");
+	}
+
+	// ------------------------------------------------------------------
+	// binary search vs the linear scan it replaced
+	// ------------------------------------------------------------------
+
+	@Test
+	void firstChangeAtOrBeforeMatchesTheLinearScan() {
+
+		Trace trace = new Trace("sig", null, 4, 500, parent());
+		trace.setSize(4000, HEIGHT);
+
+		// deterministic times with duplicates (dt may be 0) and a
+		// value that always differs from its predecessor, so nothing
+		// is deduplicated away; track the retained order ourselves
+		Random random = new Random(42);
+		List<Long> whensNewestFirst = new ArrayList<>();
+		long t = 0;
+		for (int i = 0; i < 3000; i++) {
+			t += random.nextInt(3); // 0..2: duplicates happen
+			whensNewestFirst.add(0, t);
+			trace.addValue(bits(i % 3 + 1, 4), t);
+		}
+		trace.commit(t + 5);
+
+		// probe below, at, around and above every distinct time
+		List<Long> probes = new ArrayList<>();
+		probes.add(-5L);
+		probes.add(0L);
+		probes.add(t + 10);
+		for (int i = 0; i < whensNewestFirst.size(); i += 37) {
+			long when = whensNewestFirst.get(i);
+			probes.add(when - 1);
+			probes.add(when);
+			probes.add(when + 1);
+		}
+		for (long probe : probes) {
+			int expected = whensNewestFirst.size();
+			for (int i = 0; i < whensNewestFirst.size(); i++)
+				if (whensNewestFirst.get(i) <= probe) {
+					expected = i;
+					break;
+				}
+			assertEquals(expected, trace.firstChangeAtOrBefore(probe),
+					"probe time " + probe);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// windowed repaint == full repaint, inside the clip
+	// ------------------------------------------------------------------
+
+	@Test
+	void windowedRepaintMatchesFullRepaintForASingleBitTrace() {
+
+		Trace trace = new Trace("sig", null, 1, 500, parent());
+		Random random = new Random(7);
+		long t = 0;
+		boolean level = false;
+		for (int i = 0; i < 20_000; i++) {
+			t += 1 + random.nextInt(3);
+			level = !level;
+			trace.addValue(bits(level ? 1 : 0, 1), t);
+		}
+		long now = t + 5;
+		int width = (int) now + 10; // nameSpace is 0
+		trace.setSize(width, HEIGHT);
+		trace.commit(now);
+
+		BufferedImage full = paint(trace, width, null);
+		int clipWidth = 350;
+		for (int x0 : new int[] { 0, 137, width / 2,
+				width - clipWidth }) {
+			BufferedImage part = paint(trace, width,
+					new Rectangle(x0, 0, clipWidth, HEIGHT));
+			assertRegionEqualAndInked(full, part, x0, clipWidth);
+		}
+	}
+
+	@Test
+	void windowedRepaintMatchesFullRepaintForAMultiBitTrace() {
+
+		// multi-bit traces also draw value strings and HiZ segments
+		Trace trace = new Trace("bus", null, 4, 500, parent());
+		trace.setScaleFactor(3);
+		Random random = new Random(11);
+		long t = 0;
+		int previous = -1;
+		for (int i = 0; i < 20_000; i++) {
+			t += 1 + random.nextInt(9);
+			int value = random.nextInt(17); // 16 -> HiZ (off)
+			if (value == previous)
+				value = (value + 1) % 17;
+			previous = value;
+			if (value == 16)
+				trace.addValue(null, t); // null -> off (HiZ)
+			else
+				trace.addValue(bits(value, 4), t);
+		}
+		long now = t + 5;
+		int width = (int) (now / 3) + 10;
+		trace.setSize(width, HEIGHT);
+		trace.commit(now);
+
+		BufferedImage full = paint(trace, width, null);
+		int clipWidth = 400;
+		for (int x0 : new int[] { 0, 613, width / 3, width / 2,
+				width - clipWidth }) {
+			BufferedImage part = paint(trace, width,
+					new Rectangle(x0, 0, clipWidth, HEIGHT));
+			assertRegionEqualAndInked(full, part, x0, clipWidth);
+		}
+	}
+
+	@Test
+	void windowedRepaintMatchesFullRepaintForTheHeaderLabels() {
+
+		// a trace with no changes is the header: it draws the time
+		// labels, whose stride-skipping must also be clip-invariant
+		Trace header = new Trace("", null, 0, 500, parent());
+		header.setScaleFactor(250);
+		long now = 1_000_000;
+		int width = (int) (now / 250) + 10;
+		header.setSize(width, HEIGHT);
+		header.commit(now);
+
+		BufferedImage full = paint(header, width, null);
+		int clipWidth = 300;
+		for (int x0 : new int[] { 0, 41, width / 2,
+				width - clipWidth }) {
+			BufferedImage part = paint(header, width,
+					new Rectangle(x0, 0, clipWidth, HEIGHT));
+			assertRegionEqualAndInked(full, part, x0, clipWidth);
+		}
+	}
+}


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #121 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 296 tests; new jls.sim.TraceGeometryTest, TraceRetentionTest, TraceWindowingTest all green, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
