### PR TITLE
Add vertical wire-group splitters and bundlers (#124)

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -6,7 +6,8 @@
      this document; line numbers drift, symbol names do not). -->
 
 This document is the normative specification of the `.jls` circuit
-save format, **format version 1**. It is written so that a third party
+save format, up to and including **format version 2**. It is written
+so that a third party
 can implement a reader or writer from this document alone, without
 consulting the JLS source. Where the words MUST, MUST NOT, SHOULD and
 MAY appear, they are used as in RFC 2119.
@@ -109,7 +110,7 @@ numbers assume this layout.
 file          = format-line circuit-block
 
 format-line   = "FORMAT" version              ; §4; absent in legacy files
-version       = decimal integer               ; 1 in current files
+version       = decimal integer               ; 1 or 2 in current files
 
 circuit-block = "CIRCUIT" name { element } "ENDCIRCUIT"
 name          = token                         ; §3.1
@@ -167,7 +168,11 @@ Rules:
 - **Legacy files have no header** and are implicitly version 0. A
   reader MUST accept a file whose first token is `CIRCUIT` and treat
   it as version 0. Version 0 and version 1 differ *only* in the
-  header's presence.
+  header's presence. Version 2 differs from version 1 only in that
+  the `orient` attribute of `Binder` and `Splitter` elements may be
+  `UP` or `DOWN` as well as `LEFT`/`RIGHT` (issue #124) — a
+  version-1 reader would silently load such a group horizontal,
+  which is exactly the mis-load the header exists to prevent.
 - A reader MUST accept any declared version less than or equal to
   the newest it implements, and MUST refuse a greater one with an
   explicit "this file needs a newer reader" diagnostic — refusing is
@@ -180,7 +185,11 @@ Rules:
   reference reader rejects a `FORMAT` token inside an element body as
   an unknown item kind.
 - A writer MUST emit the header with the highest version whose
-  features it uses (currently always `FORMAT 1`).
+  features the file uses: `FORMAT 2` when any group in the file
+  (including inside nested subcircuit blocks) is vertically
+  oriented, otherwise `FORMAT 1` — so files that avoid newer
+  features stay readable by older JLS versions.
+  <!-- Circuit.formatVersionNeeded, Element.saveFormatVersion. -->
 
 ---
 
@@ -267,13 +276,13 @@ this table; a tag not in it (and not a documented later addition)
 MUST fail the load with a diagnostic naming the tag, and SHOULD
 suggest that the file may need a newer reader.
 
-Version-1 writers emit exactly these 32 tags:
+Version-1 and version-2 writers emit exactly these 32 tags:
 
 | tag | element | notes |
 |---|---|---|
 | `Adder` | ripple adder | |
 | `AndGate` | AND gate | |
-| `Binder` | wire bundler | `pair` items: (input index, bundle bit) |
+| `Binder` | wire bundler | `pair` items: (input index, bundle bit); `orient` values `UP`/`DOWN` require version 2 (§4) |
 | `Clock` | clock generator | |
 | `Constant` | constant driver | value is an `Int` item |
 | `Decoder` | decoder | |
@@ -294,7 +303,7 @@ Version-1 writers emit exactly these 32 tags:
 | `Register` | latch / D flip-flop | |
 | `ShiftRegister` | combinational barrel shifter | despite the name, stateless; tag and attributes match the bsiever-fork 4.6 element (issue #122) |
 | `SigGen` | signal generator | |
-| `Splitter` | wire unbundler | `pair` items: (output index, bundle bit) |
+| `Splitter` | wire unbundler | `pair` items: (output index, bundle bit); `orient` values `UP`/`DOWN` require version 2 (§4) |
 | `StateMachine` | finite state machine | state list encoded as ordered `String state`/`output`/`trans`/`next` items with interleaved `int`/`long` values; the item *sequence* is significant for this type only |
 | `Stop` | simulation stop control | |
 | `SubCircuit` | nested circuit instance | body contains one nested `CIRCUIT` block (no `FORMAT` line) |
@@ -365,6 +374,16 @@ Concretely:
 - A reader MUST keep accepting **all older versions** (including the
   headerless version 0) indefinitely; version support is only ever
   added, never removed.
+
+Version history:
+
+- **0**: headerless legacy files (everything before the header).
+- **1**: version 0 plus the `FORMAT` header itself; no other change.
+- **2**: version 1 plus vertical (`UP`/`DOWN`) `orient` values on
+  `Binder`/`Splitter` (issue #124). A version-1 reader silently
+  ignores the unknown value and loads the group horizontal — a
+  mis-load, hence the bump. Writers emit `FORMAT 2` only for files
+  that contain a vertical group (§4).
 
 **The silent-drop caveat** (issue #47): "no bump needed" trades
 compatibility for silent data loss in *pre-versioning* readers. The

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -81,13 +81,17 @@ public class Circuit implements Printable {
 	private static int lineNumber; // to report errors when reading circuit file
 
 	/**
-	 * The save-format version this JLS writes and the newest it can read
-	 * (issue #79). Headerless legacy files are implicitly version 0;
-	 * version 1 files begin with a "FORMAT 1" line ahead of the top-level
-	 * CIRCUIT line. Nested subcircuit blocks never carry a header - a
-	 * file states its format version exactly once, at the top.
+	 * The newest save-format version this JLS can read (issue #79).
+	 * Headerless legacy files are implicitly version 0; headered files
+	 * begin with a "FORMAT n" line ahead of the top-level CIRCUIT line.
+	 * Nested subcircuit blocks never carry a header - a file states its
+	 * format version exactly once, at the top. A writer emits the
+	 * highest version whose features the file actually uses (see
+	 * {@link #formatVersionNeeded()}), so files that avoid newer
+	 * features stay readable by older JLS versions. Version 2 adds
+	 * vertical (UP/DOWN) orientation for Binder/Splitter (issue #124).
 	 */
-	public static final int FORMAT_VERSION = 1;
+	public static final int FORMAT_VERSION = 2;
 
 	/**
 	 * Create a new, empty circuit.
@@ -376,7 +380,9 @@ public class Circuit implements Printable {
 	/**
 	 * Consume the optional FORMAT version header at the top of a file
 	 * (issue #79). Legacy files have no header and are implicitly format
-	 * version 0; current saves begin with "FORMAT 1". A version newer
+	 * version 0; current saves begin with a FORMAT line declaring the
+	 * version their features need (see
+	 * {@link #formatVersionNeeded()}). A version newer
 	 * than {@link #FORMAT_VERSION} is refused with an explicit
 	 * needs-a-newer-JLS error (#58 taxonomy) rather than a misparse.
 	 * Only the true top of a file may carry the header - nested
@@ -1057,7 +1063,7 @@ public class Circuit implements Printable {
 		if (isImported()) {
 			output.println("CIRCUIT " + subElement.getName());
 		} else {
-			output.println("FORMAT " + FORMAT_VERSION);
+			output.println("FORMAT " + formatVersionNeeded());
 			output.println("CIRCUIT " + name);
 		}
 
@@ -1076,6 +1082,24 @@ public class Circuit implements Printable {
 		// write trailer
 		output.println("ENDCIRCUIT");
 	} // end of save method
+
+	/**
+	 * The save-format version a save of this circuit must declare: the
+	 * highest version any of its elements (or, through SubCircuit,
+	 * nested circuits) requires - see the docs/file-format.md section 9
+	 * evolution policy. Files that use no post-version-1 feature keep
+	 * declaring "FORMAT 1" so older JLS versions can still read them.
+	 *
+	 * @return the format version a save of this circuit declares.
+	 */
+	public int formatVersionNeeded() {
+
+		int version = 1;
+		for (Element el : elements) {
+			version = Math.max(version, el.saveFormatVersion());
+		}
+		return version;
+	} // end of formatVersionNeeded method
 
 	/**
 	 * Draw the circuit by drawing every element. First the set of elements not

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -649,6 +649,20 @@ public class Element {
 	} // end of changeTiming method
 
 	/**
+	 * The save-format version this element's current state requires
+	 * (issue #79 evolution policy: a writer emits the highest version
+	 * whose features the file uses). Almost everything is expressible
+	 * in version 1; an element whose state older readers would
+	 * silently mis-load overrides this (issue #124: vertical groups).
+	 *
+	 * @return the minimum format version that can carry this element.
+	 */
+	public int saveFormatVersion()
+	{
+		return 1;
+	}
+
+	/**
 	 * Tells if an element is capable of rotatating, defaults to false.
 	 * This method may be overridden if an element supports rotation
 	 * @return True if an element supports rotation otherwise false

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -79,15 +79,28 @@ public abstract class Group extends LogicElement {
 		FontMetrics fm = g.getFontMetrics();
 		int s = JLSInfo.spacing;
 		int puts = ranges.size();
-		// determine width
-		width = 0;
+
+		// the size decomposes into an across axis (from the narrow puts
+		// to the bundle side, sized by the widest range label and
+		// snapped to the grid) and an along axis (one grid step per
+		// put); orientation decides which axis is which (issue #124,
+		// re-derived from AmityWilder's vertical-groups branch)
+		int across = 0;
 		for(Entry e : ranges) {
-			width = Math.max(width, fm.stringWidth(e.toCircuitString()));
+			across = Math.max(across, fm.stringWidth(e.toCircuitString()));
 		}
-		width = (width+2*s)/s*s;
-	
-		// determine height
-		height = (puts+1)*s;
+		across = (across+2*s)/s*s;
+		int along = (puts+1)*s;
+
+		if (orientation == JLSInfo.Orientation.LEFT
+				|| orientation == JLSInfo.Orientation.RIGHT) {
+			width = across;
+			height = along;
+		}
+		else {
+			width = along;
+			height = across;
+		}
 
 	} // end of init method
 	
@@ -150,14 +163,9 @@ public abstract class Group extends LogicElement {
 	public void setValue(String name, String value) {
 		
 		if (name.equals("orient")) {
-			if(value.equals("LEFT"))
-			{
-				orientation = JLSInfo.Orientation.LEFT;
-			}
-			else if(value.equals("RIGHT"))
-			{
-				orientation = JLSInfo.Orientation.RIGHT;
-			}
+			// unknown strings leave the orientation unchanged, matching
+			// the historical loaders (issue #124: all four orientations)
+			orientation = JLSInfo.Orientation.parse(value, orientation);
 		} else if(name.equals("noncontig")) {
 			if(value.equals("true")) noncontig = true;
 			else noncontig = false;
@@ -172,20 +180,45 @@ public abstract class Group extends LogicElement {
 	 */
 	public void flip(Graphics g)
 	{
-		if(orientation == JLSInfo.Orientation.LEFT)
+		orientation = orientation.flipped();
+		inputs.clear();
+		outputs.clear();
+		width = 0;
+		height = 0;
+	}
+
+	/**
+	 * This method will rotate the group a quarter turn (issue #124).
+	 * Subclasses re-run init to rebuild the puts on the new axes.
+	 * @param direction The direction to rotate
+	 * @param g The current graphics context for use in recalculating size
+	 */
+	public void rotate(JLSInfo.Orientation direction, Graphics g)
+	{
+		if(direction == JLSInfo.Orientation.LEFT)
 		{
-			orientation = JLSInfo.Orientation.RIGHT;
+			orientation = orientation.ccw();
 		}
-		else if(orientation == JLSInfo.Orientation.RIGHT)
+		else if(direction == JLSInfo.Orientation.RIGHT)
 		{
-			orientation = JLSInfo.Orientation.LEFT;
+			orientation = orientation.cw();
 		}
 		inputs.clear();
 		outputs.clear();
 		width = 0;
 		height = 0;
 	}
-	
+
+	/**
+	 * Tells if a Group is capable of rotating: the same no-attachments
+	 * constraint as flipping, since both rebuild every put.
+	 * @return False if any input or output has a wire attached, True otherwise
+	 */
+	public boolean canRotate()
+	{
+		return canFlip();
+	}
+
 	/**
 	 * Tells if a Group is capable of flippiing, can only flip when inputs or outputs have no attachments.
 	 * @return False if any input or output has a wire attached, True otherwise
@@ -301,6 +334,24 @@ public abstract class Group extends LogicElement {
 		}
 		output.println("END");
 	} // end of save method
+
+	/**
+	 * A vertically-oriented group is a format-version-2 feature: a
+	 * version-1 reader ignores the UP/DOWN orient value and silently
+	 * loads the group horizontal, so files that use it must declare
+	 * version 2 to be refused cleanly by older readers instead
+	 * (issue #124 per the docs/file-format.md section 9 policy).
+	 *
+	 * @return 2 if this group is vertical, 1 otherwise.
+	 */
+	public int saveFormatVersion() {
+
+		if (orientation == JLSInfo.Orientation.UP
+				|| orientation == JLSInfo.Orientation.DOWN) {
+			return 2;
+		}
+		return 1;
+	} // end of saveFormatVersion method
 	
 	/**
 	 * Copy values to new object.
@@ -336,6 +387,8 @@ public abstract class Group extends LogicElement {
 		private JRadioButton group = new JRadioButton("Group Bits");
 		private JRadioButton left = new JRadioButton("Left");
 		private JRadioButton right = new JRadioButton("Right", true);
+		private JRadioButton up = new JRadioButton("Up");
+		private JRadioButton down = new JRadioButton("Down");
 		private String type;
 		
 		/**
@@ -386,15 +439,25 @@ public abstract class Group extends LogicElement {
 			JLabel olbl = new JLabel("Orientation");
 			olbl.setAlignmentX(Component.CENTER_ALIGNMENT);
 			window.add(olbl);
-			JPanel orients = new JPanel(new GridLayout(1,3));
+			JPanel orients = new JPanel(new GridLayout(3,3));
+			orients.add(new JLabel(""));
+			orients.add(up);
+			orients.add(new JLabel(""));
 			orients.add(left);
 			orients.add(new JLabel(""));
 			orients.add(right);
+			orients.add(new JLabel(""));
+			orients.add(down);
+			orients.add(new JLabel(""));
 			left.setHorizontalAlignment(SwingConstants.CENTER);
 			right.setHorizontalAlignment(SwingConstants.CENTER);
+			up.setHorizontalAlignment(SwingConstants.CENTER);
+			down.setHorizontalAlignment(SwingConstants.CENTER);
 			ButtonGroup gr = new ButtonGroup();
 			gr.add(left);
 			gr.add(right);
+			gr.add(up);
+			gr.add(down);
 			window.add(orients);
 
 			confirmOnEnter(bitsField);
@@ -446,6 +509,14 @@ public abstract class Group extends LogicElement {
 			else if(right.isSelected())
 			{
 				orientation = JLSInfo.Orientation.RIGHT;
+			}
+			else if(up.isSelected())
+			{
+				orientation = JLSInfo.Orientation.UP;
+			}
+			else if(down.isSelected())
+			{
+				orientation = JLSInfo.Orientation.DOWN;
 			}
 			dispose();
 		} // end of validateAndAccept method

--- a/src/jls/elem/SubCircuit.java
+++ b/src/jls/elem/SubCircuit.java
@@ -333,6 +333,18 @@ public class SubCircuit extends LogicElement implements TriProp {
 		subCircuit.save(output);
 		output.println("END");
 	} // end of save method
+
+	/**
+	 * A subcircuit block needs whatever format version its nested
+	 * circuit needs - a file states its version once, at the top
+	 * (issue #79), so the requirement propagates up through here.
+	 *
+	 * @return the minimum format version for the nested circuit.
+	 */
+	public int saveFormatVersion() {
+
+		return subCircuit.formatVersionNeeded();
+	} // end of saveFormatVersion method
 	
 	/**
 	 * Set a String instance variable value (during a load).

--- a/test/jls/FileFormatSpecTest.java
+++ b/test/jls/FileFormatSpecTest.java
@@ -242,14 +242,16 @@ class FileFormatSpecTest {
 		String saved = save(load(fixture()));
 		String[] lines = saved.split("\n");
 
-		// §4: the FORMAT header is the first line, stating the version
-		// this JLS writes; the spec documents that same version
-		assertEquals("FORMAT " + Circuit.FORMAT_VERSION, lines[0],
+		// §4: the FORMAT header is the first line, stating the lowest
+		// version whose features the file uses (#124: this fixture's
+		// groups are horizontal, so it needs nothing past version 1);
+		// the spec documents the newest version the code implements
+		assertEquals("FORMAT 1", lines[0],
 				"the FORMAT header must be the first line");
 		assertTrue(spec().contains("**format version "
 						+ Circuit.FORMAT_VERSION + "**"),
-				"the spec must document the version the code writes ("
-						+ Circuit.FORMAT_VERSION + ")");
+				"the spec must document the newest version the code "
+						+ "implements (" + Circuit.FORMAT_VERSION + ")");
 		assertTrue(lines[1].startsWith("CIRCUIT "),
 				"the top-level CIRCUIT line must follow the header");
 		assertEquals("ENDCIRCUIT", lines[lines.length - 1],

--- a/test/jls/FormatHeaderTest.java
+++ b/test/jls/FormatHeaderTest.java
@@ -96,9 +96,10 @@ class FormatHeaderTest {
 
 	@Test
 	void newSavesBeginWithTheFormatHeader() throws Exception {
+		// the writer emits the lowest version whose features the file
+		// uses (#124); this fixture uses none past version 1
 		String saved = save(load(LEGACY_TEXT));
-		assertTrue(saved.startsWith("FORMAT " + Circuit.FORMAT_VERSION
-						+ "\nCIRCUIT "),
+		assertTrue(saved.startsWith("FORMAT 1\nCIRCUIT "),
 				"a save must start with the FORMAT header, got:\n" + saved);
 	}
 
@@ -111,13 +112,18 @@ class FormatHeaderTest {
 
 	@Test
 	void headeredTextLoads() throws Exception {
-		Circuit circuit = load("FORMAT 1\n" + LEGACY_TEXT);
-		assertEquals(1, circuit.getElements().size());
+		// every version up to the newest this JLS implements is readable
+		for (int version = 1; version <= Circuit.FORMAT_VERSION; version++) {
+			Circuit circuit = load("FORMAT " + version + "\n" + LEGACY_TEXT);
+			assertEquals(1, circuit.getElements().size());
+		}
 	}
 
 	@Test
 	void newerFormatVersionFailsAsNeedsNewerJls() {
-		for (String version : new String[] {"2", "999", "999999999999"}) {
+		for (String version : new String[] {
+				Integer.toString(Circuit.FORMAT_VERSION + 1),
+				"999", "999999999999"}) {
 			LoadError error =
 					failToLoad("FORMAT " + version + "\n" + LEGACY_TEXT);
 			assertSame(LoadError.Category.NEWER_FORMAT, error.getCategory(),
@@ -169,7 +175,7 @@ class FormatHeaderTest {
 		assertEquals(1, formatLines,
 				"a file states its format version exactly once, at the "
 						+ "top:\n" + saved);
-		assertTrue(saved.startsWith("FORMAT " + Circuit.FORMAT_VERSION + "\n"),
+		assertTrue(saved.startsWith("FORMAT 1\n"),
 				"the one FORMAT line must be the first line:\n" + saved);
 	}
 

--- a/test/jls/elem/GroupOrientationTest.java
+++ b/test/jls/elem/GroupOrientationTest.java
@@ -1,0 +1,309 @@
+package jls.elem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.JLSInfo;
+
+/**
+ * Vertical (UP/DOWN) orientation for wire groups - Binder and Splitter
+ * (issue #124). Groups were the last element family restricted to
+ * LEFT/RIGHT: the loader ignored vertical orient values, there was no
+ * rotate operation, and the size computation assumed a horizontal
+ * layout. These tests pin, headlessly against model state:
+ *
+ * <ul>
+ * <li>P1: vertical orient values load, and rotate cycles a group
+ *     through all four orientations (the geometry uses the across/along
+ *     decomposition, both axes grid-snapped);</li>
+ * <li>P2: horizontal files are untouched - they round-trip to the same
+ *     bytes and keep declaring save-format version 1;</li>
+ * <li>P3: a vertical group round-trips to the same bytes, and the file
+ *     declares save-format version 2 so that older readers refuse it
+ *     cleanly instead of silently loading the group horizontal
+ *     (docs/file-format.md section 9 evolution policy).</li>
+ * </ul>
+ *
+ * Geometry note: a group's across size is metrics-driven (widest range
+ * label) but grid-snapped; the labels here are single digits, so the
+ * expected sizes hold for any font whose digit advance is under one
+ * grid unit (12px), the same stability argument as the orientation
+ * geometry baseline.
+ */
+class GroupOrientationTest {
+
+	private static final int S = JLSInfo.spacing;
+
+	/** One bundler/unbundler of 2 single bits at the given orientation. */
+	private static String groupText(String type, String orient) {
+		return "CIRCUIT grp\n"
+				+ "ELEMENT " + type + "\n"
+				+ " int id 0\n int x 240\n int y 240\n"
+				+ " int bits 2\n"
+				+ " String orient \"" + orient + "\"\n"
+				+ " String noncontig \"true\"\n"
+				+ " int tristate 0\n"
+				+ " pair 0 0\n pair 1 1\n"
+				+ "END\n"
+				+ "ENDCIRCUIT\n";
+	}
+
+	/** Load a circuit and finish it with a real (image) graphics. */
+	private static Circuit load(String text) {
+		Circuit circuit = new Circuit("grp");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		BufferedImage img =
+				new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		try {
+			assertTrue(circuit.finishLoad(g),
+					() -> "finishLoad failed: " + JLSInfo.loadError);
+		} catch (Exception ex) {
+			throw new AssertionError("finishLoad threw", ex);
+		} finally {
+			g.dispose();
+		}
+		return circuit;
+	}
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString().replace(System.lineSeparator(), "\n");
+	}
+
+	private static Group group(Circuit circuit) {
+		for (Element el : circuit.getElements()) {
+			if (el instanceof Group) {
+				return (Group) el;
+			}
+		}
+		throw new AssertionError("no group in circuit");
+	}
+
+	/** The group's puts as sorted "name@relX,relY" strings. */
+	private static List<String> puts(Element el) {
+		List<String> puts = new ArrayList<>();
+		for (Put p : el.getAllPuts()) {
+			puts.add(p.getName() + "@" + (p.getX() - el.getX()) + ","
+					+ (p.getY() - el.getY()));
+		}
+		java.util.Collections.sort(puts);
+		return puts;
+	}
+
+	// ------------------------------------------------------------------
+	// P1: vertical orientations load with vertical geometry
+	// ------------------------------------------------------------------
+
+	@Test
+	void verticalSplitterLoadsWithVerticalGeometry() {
+		Group up = group(load(groupText("Splitter", "UP")));
+		// along the horizontal axis: one grid step per put plus one;
+		// across the vertical axis: the snapped label width
+		assertEquals(3 * S, up.getRect().width, "width must be the along size");
+		assertEquals(2 * S, up.getRect().height, "height must be the across size");
+		assertEquals(List.of("0@12,0", "1@24,0", "input@12,24"), puts(up),
+				"UP splitter: outputs across the top, input at the bottom");
+
+		Group down = group(load(groupText("Splitter", "DOWN")));
+		assertEquals(List.of("0@12,24", "1@24,24", "input@12,0"), puts(down),
+				"DOWN splitter: outputs across the bottom, input at the top");
+	}
+
+	@Test
+	void verticalBinderLoadsWithVerticalGeometry() {
+		Group up = group(load(groupText("Binder", "UP")));
+		assertEquals(3 * S, up.getRect().width);
+		assertEquals(2 * S, up.getRect().height);
+		assertEquals(List.of("0@12,24", "1@24,24", "output@12,0"), puts(up),
+				"UP binder: inputs across the bottom, output at the top");
+
+		Group down = group(load(groupText("Binder", "DOWN")));
+		assertEquals(List.of("0@12,0", "1@24,0", "output@12,24"), puts(down),
+				"DOWN binder: inputs across the top, output at the bottom");
+	}
+
+	@Test
+	void horizontalGeometryIsUnchanged() {
+		// the pre-#124 layout, pinned so the across/along rewrite cannot
+		// move existing puts (wires attach to these coordinates)
+		Group right = group(load(groupText("Binder", "RIGHT")));
+		assertEquals(2 * S, right.getRect().width);
+		assertEquals(3 * S, right.getRect().height);
+		assertEquals(List.of("0@0,12", "1@0,24", "output@24,12"), puts(right));
+
+		Group left = group(load(groupText("Splitter", "LEFT")));
+		assertEquals(List.of("0@0,12", "1@0,24", "input@24,12"), puts(left));
+	}
+
+	// ------------------------------------------------------------------
+	// P1: rotate cycles the four orientations
+	// ------------------------------------------------------------------
+
+	/** The saved orient value of the (re-inited) group. */
+	private static String orientOf(Group group) {
+		group.setID(0);
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			group.save(writer);
+		}
+		String saved = out.toString();
+		int at = saved.indexOf("String orient \"");
+		assertTrue(at >= 0, "no orient in save:\n" + saved);
+		int from = at + "String orient \"".length();
+		return saved.substring(from, saved.indexOf('"', from));
+	}
+
+	@Test
+	void rotateCyclesAllFourOrientations() {
+		Circuit circuit = load(groupText("Binder", "RIGHT"));
+		Group group = group(circuit);
+		String savedBefore = save(circuit);
+		assertTrue(group.canRotate(),
+				"an unattached group must be rotatable");
+
+		BufferedImage img =
+				new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		try {
+			List<String> seen = new ArrayList<>();
+			for (int i = 0; i < 4; i++) {
+				group.rotate(JLSInfo.Orientation.RIGHT, g);
+				seen.add(orientOf(group));
+			}
+			assertEquals(List.of("DOWN", "LEFT", "UP", "RIGHT"), seen,
+					"clockwise rotation must cycle all four orientations");
+			assertEquals(savedBefore, save(circuit),
+					"four quarter-turns must restore the identical save");
+
+			group.rotate(JLSInfo.Orientation.LEFT, g);
+			assertEquals("UP", orientOf(group),
+					"counterclockwise from RIGHT is UP");
+		} finally {
+			g.dispose();
+		}
+	}
+
+	@Test
+	void flipTogglesVerticalOrientations() {
+		Circuit circuit = load(groupText("Splitter", "UP"));
+		Group group = group(circuit);
+		assertTrue(group.canFlip());
+
+		BufferedImage img =
+				new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		try {
+			// Splitter.flip re-runs init itself
+			group.flip(g);
+			assertEquals("DOWN", orientOf(group));
+			group.flip(g);
+			assertEquals("UP", orientOf(group));
+		} finally {
+			g.dispose();
+		}
+	}
+
+	@Test
+	void attachedGroupRefusesRotateAndFlip() {
+		StringBuilder text = new StringBuilder("CIRCUIT grp\n");
+		text.append("ELEMENT Binder\n int id 0\n int x 240\n int y 240\n")
+				.append(" int bits 2\n String orient \"RIGHT\"\n")
+				.append(" String noncontig \"true\"\n int tristate 0\n")
+				.append(" pair 0 0\n pair 1 1\nEND\n");
+		text.append("ELEMENT OutputPin\n int id 1\n int x 360\n int y 240\n")
+				.append(" String name \"out\"\n int bits 2\n int watch 0\n")
+				.append(" String orient \"RIGHT\"\nEND\n");
+		text.append("ELEMENT WireEnd\n int id 2\n int x 264\n int y 252\n")
+				.append(" String put \"output\"\n ref attach 0\n ref wire 3\nEND\n");
+		text.append("ELEMENT WireEnd\n int id 3\n int x 360\n int y 252\n")
+				.append(" String put \"input\"\n ref attach 1\n ref wire 2\nEND\n");
+		text.append("ENDCIRCUIT\n");
+
+		Group group = group(load(text.toString()));
+		assertFalse(group.canRotate(),
+				"a group with an attached wire must not rotate");
+		assertFalse(group.canFlip(),
+				"a group with an attached wire must not flip");
+	}
+
+	// ------------------------------------------------------------------
+	// P2/P3: persistence
+	// ------------------------------------------------------------------
+
+	@Test
+	void verticalGroupRoundTripsAndDeclaresFormat2() {
+		String savedOnce = save(load(groupText("Splitter", "UP")));
+		assertTrue(savedOnce.startsWith("FORMAT 2\n"),
+				"a vertical group is a version-2 feature; older readers "
+						+ "must refuse the file, not load it horizontal:\n"
+						+ savedOnce);
+		assertTrue(savedOnce.contains(" String orient \"UP\"\n"),
+				"the vertical orientation must be saved:\n" + savedOnce);
+		assertEquals(savedOnce, save(load(savedOnce)),
+				"save -> load -> save must be a fixed point");
+	}
+
+	@Test
+	void horizontalGroupRoundTripsAndKeepsFormat1() {
+		String savedOnce = save(load(groupText("Binder", "LEFT")));
+		assertTrue(savedOnce.startsWith("FORMAT 1\n"),
+				"a horizontal-groups-only file must stay readable by "
+						+ "older JLS versions:\n" + savedOnce);
+		assertTrue(savedOnce.contains(" String orient \"LEFT\"\n"));
+		assertEquals(savedOnce, save(load(savedOnce)),
+				"save -> load -> save must be a fixed point");
+	}
+
+	@Test
+	void verticalGroupInsideASubcircuitBumpsTheFileHeader() {
+		// a file states its format version once, at the top (#79), so a
+		// version-2 feature inside a nested block must surface there
+		StringBuilder text = new StringBuilder("CIRCUIT outer\n");
+		text.append("ELEMENT SubCircuit\n String orient \"RIGHT\"\n")
+				.append(" int id 0\n int x 120\n int y 120\n")
+				.append(" int width 48\n int height 48\n")
+				.append(" String name \"inner\"\n")
+				.append("CIRCUIT inner\n")
+				.append("ELEMENT Binder\n int id 0\n int x 240\n int y 240\n")
+				.append(" int bits 2\n String orient \"UP\"\n")
+				.append(" String noncontig \"true\"\n int tristate 0\n")
+				.append(" pair 0 0\n pair 1 1\nEND\n")
+				.append("ENDCIRCUIT\n")
+				.append("END\n")
+				.append("ENDCIRCUIT\n");
+		String savedOnce = save(load(text.toString()));
+		assertTrue(savedOnce.startsWith("FORMAT 2\n"),
+				"a nested vertical group must bump the top-level header:\n"
+						+ savedOnce);
+		assertEquals(1, savedOnce.split("FORMAT ", -1).length - 1,
+				"the FORMAT header must still appear exactly once:\n"
+						+ savedOnce);
+		assertEquals(savedOnce, save(load(savedOnce)),
+				"save -> load -> save must be a fixed point");
+	}
+
+	@Test
+	void unknownOrientValueStillFallsBackToTheDefault() {
+		// the historical loader ignored unknown orient strings; that
+		// permissiveness must survive the four-orientation extension
+		Group group = group(load(groupText("Binder", "BANANA")));
+		assertEquals("RIGHT", orientOf(group));
+	}
+}

--- a/test/jls/elem/OrientationGeometryTest.java
+++ b/test/jls/elem/OrientationGeometryTest.java
@@ -126,6 +126,17 @@ class OrientationGeometryTest {
 						+ " String iOrient \"" + go + "\"\n String sOrient \"" + co + "\"\n"));
 			}
 		}
+		// wire groups gained UP/DOWN in #124; their across size is
+		// metrics-driven but grid-snapped, and the labels here are
+		// single digits, so the entries are stable for any font whose
+		// digit advance is under one grid unit
+		for (String o : ORIENTS) {
+			String groupAttrs = " int bits 2\n String orient \"" + o
+					+ "\"\n String noncontig \"true\"\n int tristate 0\n"
+					+ " pair 0 0\n pair 1 1\n";
+			lines.add(describe("Binder " + o, "Binder", groupAttrs));
+			lines.add(describe("Splitter " + o, "Splitter", groupAttrs));
+		}
 		return String.join("\n", lines) + "\n";
 	}
 

--- a/test/resources/orientation-geometry.txt
+++ b/test/resources/orientation-geometry.txt
@@ -62,3 +62,11 @@ ShiftRegister I=DOWN S=UP rect=0,0,24,24 puts=amount@12,0;input@12,0;output@12,2
 TriState G=DOWN C=DOWN finishLoadError=invalid element
 Mux I=DOWN S=DOWN rect=0,0,60,24 puts=input0@12,0;input1@24,0;input2@36,0;input3@48,0;output@24,24;select@12,24
 ShiftRegister I=DOWN S=DOWN rect=0,0,24,24 puts=amount@12,24;input@12,0;output@12,24
+Binder LEFT rect=0,0,24,36 puts=0@24,12;1@24,24;output@0,12
+Splitter LEFT rect=0,0,24,36 puts=0@0,12;1@0,24;input@24,12
+Binder RIGHT rect=0,0,24,36 puts=0@0,12;1@0,24;output@24,12
+Splitter RIGHT rect=0,0,24,36 puts=0@24,12;1@24,24;input@0,12
+Binder UP rect=0,0,36,24 puts=0@12,24;1@24,24;output@12,0
+Splitter UP rect=0,0,36,24 puts=0@12,0;1@24,0;input@12,24
+Binder DOWN rect=0,0,36,24 puts=0@12,0;1@24,0;output@12,24
+Splitter DOWN rect=0,0,36,24 puts=0@12,24;1@24,24;input@12,0


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #124 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 294 tests; new jls.elem.GroupOrientationTest green, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
