### PR TITLE
Let wire drawing start without first clearing the selection (#126)

### DIFF
--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -433,8 +433,86 @@ public abstract class SimpleEditor extends JPanel {
 	} // end of close method
 
 	// can't be in EditWindow, but should be
-	private enum State {idle, chosen, placing, moving, selecting, selected, option,
+	// (package-private so the gesture decision below is testable: #126)
+	enum State {idle, chosen, placing, moving, selecting, selected, option,
 		startwire, drawire};
+
+	/**
+	 * What the ctrl-W shortcut does, as a pure function of editor state
+	 * and selection size, so the dispatch is unit-testable headless
+	 * (issue #126; the injected-facts pattern of ToolkitPolicy).
+	 */
+	enum CtrlW {START_WIRE, TOGGLE_WATCH, NONE};
+
+	/**
+	 * Decide the ctrl-W gesture. From idle the shortcut always starts a
+	 * wire — before #126 it also required an empty selection, so the
+	 * hover selection that idle mouse motion maintains made the shortcut
+	 * toggle watch, or do nothing, until the cursor left every element.
+	 * Watch toggling remains reachable from every non-idle state with a
+	 * single selected element (e.g. after a select-rectangle).
+	 *
+	 * @param state The current editor state.
+	 * @param selectionSize The number of currently selected elements.
+	 * @return the gesture to perform.
+	 */
+	static CtrlW ctrlWGesture(State state, int selectionSize) {
+
+		if (state == State.idle)
+			return CtrlW.START_WIRE;
+		if (selectionSize == 1)
+			return CtrlW.TOGGLE_WATCH;
+		return CtrlW.NONE;
+	} // end of ctrlWGesture method
+
+	/**
+	 * Result of starting the wire-drawing gesture: the initial wire end,
+	 * and whether a selection had to be cleared to start it. The flag is
+	 * captured before the clear — keyed off the selection afterwards it
+	 * would always be true, because the new wire end becomes the
+	 * selection (the pitfall AmityWilder/JLS@b1f1573 fixed).
+	 */
+	static final class WireStart {
+		final WireEnd end;
+		final boolean hadSelection;
+		WireStart(WireEnd end, boolean hadSelection) {
+			this.end = end;
+			this.hadSelection = hadSelection;
+		}
+	} // end of WireStart class
+
+	/**
+	 * The model half of the idle-state wire-start gesture (#126): clear
+	 * the (hover) selection, create the initial wire end at (x,y), add
+	 * it to the circuit and to the selection, and give it a fresh wire
+	 * net. Swing-free so it is unit-testable headless; the caller owns
+	 * the GUI half (state transition, overlap feedback, repaint).
+	 *
+	 * @param circuit The circuit being edited.
+	 * @param selected The current selection; cleared, then left holding
+	 *        only the new wire end.
+	 * @param x The x-coordinate for the wire end.
+	 * @param y The y-coordinate for the wire end.
+	 * @return the new wire end and the pre-clear selection state.
+	 */
+	static WireStart startWireGesture(Circuit circuit, Set<Element> selected,
+			int x, int y) {
+
+		boolean hadSelection = !selected.isEmpty();
+		for (Element el : selected) {
+			el.setHighlight(false);
+		}
+		selected.clear();
+		WireEnd end = new WireEnd(circuit);
+		end.setXY(x,y);
+		end.init(circuit);
+		circuit.addElement(end);
+		selected.add(end);
+		WireNet net = new WireNet();
+		net.add(end);
+		end.setNet(net);
+		return new WireStart(end,hadSelection);
+	} // end of startWireGesture method
 
 		/**
 		 * The window the circuit is displayed and edited in.
@@ -582,28 +660,42 @@ public abstract class SimpleEditor extends JPanel {
 						if (!enabled)
 							return;
 
-						// if nothing selected and current state is idle
-						if (selected.size() == 0 && currentState == State.idle) {
+						// decide what the shortcut does here (#126)
+						CtrlW gesture = ctrlWGesture(currentState,selected.size());
+
+						// if current state is idle, start a wire, superseding
+						// any hover selection (#126)
+						if (gesture == CtrlW.START_WIRE) {
 
 							// start a wire
 							Point p = getMousePosition();
 							if (p == null)
 								return; // not in drawing window
 							setState(State.startwire);
-							wireEnd = new WireEnd(circuit);
 							x = p.x;
 							y = p.y;
-							wireEnd.setXY(x,y);
-							wireEnd.init(circuit);
-							circuit.addElement(wireEnd);
-							selected.add(wireEnd);
+							WireStart start =
+									startWireGesture(circuit,selected,x,y);
+							wireEnd = start.end;
 							wire = null;
-							net = new WireNet();
-							net.add(wireEnd);
-							wireEnd.setNet(net);
+							net = wireEnd.getNet();
+
+							// a cleared selection was under the cursor, so
+							// report the (likely) overlap the same way wire
+							// dragging does
+							if (start.hadSelection) {
+								if (overlap()) {
+									info.setText(overlapMessage);
+									info.setForeground(Color.red);
+								}
+								else {
+									info.setText("");
+									info.setForeground(Color.black);
+								}
+							}
 							repaint();
 						}
-						else if (selected.size() == 1){
+						else if (gesture == CtrlW.TOGGLE_WATCH) {
 
 							// watch/unwatch
 							Element el = (Element)selected.toArray()[0];

--- a/test/jls/edit/CtrlWGestureTest.java
+++ b/test/jls/edit/CtrlWGestureTest.java
@@ -1,0 +1,188 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.edit.SimpleEditor.CtrlW;
+import jls.edit.SimpleEditor.State;
+import jls.edit.SimpleEditor.WireStart;
+import jls.elem.Constant;
+import jls.elem.Element;
+import jls.elem.WireEnd;
+
+/**
+ * Regression tests for issue #126: an idle-state ctrl-W starts a wire
+ * regardless of the current (hover) selection, clearing that selection
+ * as part of the gesture.
+ *
+ * <p>The gesture is pinned at two seams SimpleEditor exposes for exactly
+ * this purpose: the pure dispatch function
+ * {@link SimpleEditor#ctrlWGesture} and the Swing-free model half
+ * {@link SimpleEditor#startWireGesture}. This is the compensating
+ * control for the key-press-to-pixels path (the ToolkitPolicyTest
+ * pattern): the editor itself cannot be constructed under the suite's
+ * {@code -Djava.awt.headless=true}, because EditWindow's constructor
+ * calls {@code Toolkit.getMenuShortcutKeyMaskEx()}, which throws
+ * HeadlessException without a display.</p>
+ */
+class CtrlWGestureTest {
+
+	/** A one-constant circuit, loaded headless like the other edit tests. */
+	private static Circuit oneConstant() throws Exception {
+		String text = "CIRCUIT one\n"
+				+ "ELEMENT Constant\n int id 0\n int x 60\n int y 60\n"
+				+ " int width 24\n int height 24\n Int value 1\n int base 10\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ENDCIRCUIT\n";
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/** The circuit's constant, hover-selected the way idle mouse motion
+	 * does it: highlighted and in the selection set. */
+	private static Element hoverSelect(Circuit circuit, Set<Element> selected) {
+		Element constant = null;
+		for (Element el : circuit.getElements()) {
+			if (el instanceof Constant)
+				constant = el;
+		}
+		assertNotNull(constant, "fixture must contain the constant");
+		constant.setHighlight(true);
+		selected.add(constant);
+		return constant;
+	}
+
+	// ------------------------------------------------------------------
+	// dispatch: the #126 gate itself
+	// ------------------------------------------------------------------
+
+	/** P1's dispatch half: with an element hover-selected, idle ctrl-W
+	 * must start a wire. Pre-#126 the empty-selection gate sent this to
+	 * the watch toggle instead. */
+	@Test
+	void idleStartsWireDespiteSingleSelection() {
+		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 1));
+	}
+
+	/** Pre-#126, an idle multi-selection (overlapping hover) fell through
+	 * to nothing at all. */
+	@Test
+	void idleStartsWireDespiteMultiSelection() {
+		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 3));
+	}
+
+	/** The original gesture — idle, nothing selected — is unchanged. */
+	@Test
+	void idleStartsWireWithEmptySelection() {
+		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 0));
+	}
+
+	/** P2's sibling-gesture pin: the watch toggle is still reachable with
+	 * one element selected outside idle (e.g. after a select-rectangle,
+	 * State.selected). */
+	@Test
+	void watchToggleStillReachableFromSelectedState() {
+		assertEquals(CtrlW.TOGGLE_WATCH,
+				SimpleEditor.ctrlWGesture(State.selected, 1));
+	}
+
+	/** Everything else stays a no-op, exactly as before. */
+	@Test
+	void otherStatesDoNothing() {
+		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.selected, 0));
+		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.selected, 2));
+		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.drawire, 0));
+		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.moving, 4));
+	}
+
+	// ------------------------------------------------------------------
+	// model half: what starting the wire does to circuit and selection
+	// ------------------------------------------------------------------
+
+	/** P1's model half: starting a wire over a hover selection clears it
+	 * (including its highlight) and leaves the new wire end, at the
+	 * requested spot, as the sole selection, in the circuit, on a fresh
+	 * net. */
+	@Test
+	void startWireClearsSelectionAndSelectsNewEnd() throws Exception {
+		Circuit circuit = oneConstant();
+		Set<Element> selected = new HashSet<Element>();
+		Element constant = hoverSelect(circuit, selected);
+
+		WireStart start = SimpleEditor.startWireGesture(circuit, selected,
+				120, 60);
+
+		// the old selection is gone, unhighlighted
+		assertFalse(selected.contains(constant),
+				"hover selection must be cleared");
+		assertFalse(circuit.getHighlighted().contains(constant),
+				"hover highlight must be cleared");
+
+		// the new wire end is the selection, in the circuit, where asked
+		assertEquals(1, selected.size(), "wire end must be sole selection");
+		assertTrue(selected.contains(start.end));
+		assertTrue(circuit.getElements().contains(start.end),
+				"wire end must be added to the circuit");
+		assertEquals(120, start.end.getX());
+		assertEquals(60, start.end.getY());
+
+		// and it is on a fresh net of its own
+		assertNotNull(start.end.getNet(), "wire end must get a net");
+		assertEquals(Set.of(start.end), start.end.getNet().getAllEnds());
+	}
+
+	/** The overlap-feedback key must reflect the selection before the
+	 * clear. Keyed off the selection afterwards it would always be true
+	 * (the new wire end becomes the selection) — the exact pitfall the
+	 * fork fixed in AmityWilder/JLS@b1f1573. */
+	@Test
+	void overlapFeedbackKeyedOffPreClearSelection() throws Exception {
+		Circuit circuit = oneConstant();
+
+		// with a hover selection: feedback wanted
+		Set<Element> selected = new HashSet<Element>();
+		hoverSelect(circuit, selected);
+		assertTrue(SimpleEditor.startWireGesture(circuit, selected, 60, 60)
+				.hadSelection, "a cleared selection must request feedback");
+
+		// without one: no feedback, even though the selection is
+		// non-empty (it holds the new wire end) after the call
+		Set<Element> empty = new HashSet<Element>();
+		WireStart start = SimpleEditor.startWireGesture(circuit, empty,
+				180, 60);
+		assertTrue(empty.contains(start.end));
+		assertFalse(start.hadSelection,
+				"an empty selection must not request feedback");
+	}
+
+	/** Starting a wire from empty selection behaves byte-for-byte like
+	 * the pre-#126 code path: end created, selected, netted. */
+	@Test
+	void startWireFromEmptySelectionMatchesOldBehavior() throws Exception {
+		Circuit circuit = oneConstant();
+		Set<Element> selected = new HashSet<Element>();
+
+		WireStart start = SimpleEditor.startWireGesture(circuit, selected,
+				240, 120);
+
+		assertEquals(1, selected.size());
+		assertTrue(selected.contains(start.end));
+		assertTrue(circuit.getElements().contains(start.end));
+		assertTrue(start.end instanceof WireEnd);
+		assertEquals(Set.of(start.end), start.end.getNet().getAllEnds());
+	}
+}


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #126 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 308 tests; new jls.edit.CtrlWGestureTest 8/8, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
