### PR TITLE
Bind Backspace and Cmd-Backspace as element-delete keys (#127)

### DIFF
--- a/src/jls/edit/DeleteKeyPolicy.java
+++ b/src/jls/edit/DeleteKeyPolicy.java
@@ -1,0 +1,88 @@
+package jls.edit;
+
+import java.awt.event.KeyEvent;
+import java.util.List;
+import java.util.Locale;
+
+import javax.swing.KeyStroke;
+
+/**
+ * Key-binding policy for deleting selected elements (issue #127).
+ *
+ * Deletion was bound only to forward-<kbd>Delete</kbd> ({@code VK_DELETE}),
+ * a key Apple laptop and compact keyboards do not have — Mac users could
+ * not delete from the keyboard at all. Two fork lineages patched this
+ * independently (jwetzell 2016, bsiever 2024/25).
+ *
+ * The policy, decided from the issue #127 Backspace-consumer census
+ * (no other Backspace consumer exists in the editor's canvas focus
+ * context, and the canvas bindings live in the WHEN_FOCUSED input map,
+ * so focused text components keep their own Backspace):
+ * <ul>
+ * <li>the editor canvas binds <em>both</em> plain <kbd>Delete</kbd> and
+ *     plain <kbd>⌫</kbd> Backspace to the delete action, on every
+ *     platform ({@link #canvasBindings()});</li>
+ * <li>a menu item can display only one accelerator, so the popup shows
+ *     the key the platform's keyboards actually have: Backspace on
+ *     macOS, Delete everywhere else ({@link #menuAccelerator(String)}).
+ *     Both keys work everywhere regardless of what is displayed.</li>
+ * </ul>
+ *
+ * Like {@code jls.ToolkitPolicy}, the decision is a pure function of an
+ * injected {@code os.name} value, so the whole matrix is unit-testable
+ * headless (the surefire JVM runs with {@code java.awt.headless=true},
+ * where the editor itself cannot be constructed).
+ */
+final class DeleteKeyPolicy {
+
+	private DeleteKeyPolicy() {
+		// static use only
+	}
+
+	/**
+	 * The keystrokes the editor canvas binds to the delete action, on
+	 * every platform: plain forward-Delete and plain Backspace, no
+	 * modifiers.
+	 *
+	 * @return the canvas delete bindings.
+	 */
+	static List<KeyStroke> canvasBindings() {
+
+		return List.of(
+				KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0),
+				KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0));
+	} // end of canvasBindings method
+
+	/**
+	 * The single accelerator the delete menu item displays: Backspace on
+	 * macOS (whose keyboards have no forward-Delete key), forward-Delete
+	 * everywhere else.
+	 *
+	 * @param osName value of the os.name system property (null-safe).
+	 *
+	 * @return the accelerator to display.
+	 */
+	static KeyStroke menuAccelerator(String osName) {
+
+		if (isMac(osName))
+			return KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0);
+		return KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0);
+	} // end of menuAccelerator method
+
+	/**
+	 * Whether an os.name value names macOS. Apple has used "Mac OS X",
+	 * "OS X", and "macOS" over the years; all contain "mac" or "os x".
+	 *
+	 * @param osName value of the os.name system property, or null.
+	 *
+	 * @return true for macOS.
+	 */
+	static boolean isMac(String osName) {
+
+		if (osName == null)
+			return false;
+		String os = osName.toLowerCase(Locale.ROOT);
+		return os.contains("mac") || os.contains("os x");
+	} // end of isMac method
+
+} // end of DeleteKeyPolicy class

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -518,7 +518,7 @@ public abstract class SimpleEditor extends JPanel {
 				copy.setToolTipText("copy all selected elements to clipboard");
 				copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
 				delete.setToolTipText("delete all selected elements");
-				delete.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,0));
+				delete.setAccelerator(DeleteKeyPolicy.menuAccelerator(System.getProperty("os.name")));
 				lock.setToolTipText("make selected elements uneditable (cannot be undone)");
 				lock.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
 
@@ -801,7 +801,8 @@ public abstract class SimpleEditor extends JPanel {
 						}
 					}
 				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,0),"do delete");
+				for (KeyStroke stroke : DeleteKeyPolicy.canvasBindings())
+					getInputMap().put(stroke,"do delete");
 				getActionMap().put("do delete", deleteKey);
 
 				// set up cut key binding

--- a/test/jls/edit/DeleteKeyPolicyTest.java
+++ b/test/jls/edit/DeleteKeyPolicyTest.java
@@ -1,0 +1,131 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.swing.KeyStroke;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the delete key-binding policy (issue #127): deletion must be
+ * reachable from keyboards without a forward-Delete key (every Apple
+ * laptop and compact keyboard), so the editor canvas binds plain
+ * Backspace alongside plain Delete on every platform, and the popup
+ * menu displays the key the platform actually has.
+ *
+ * The editor itself cannot be constructed under surefire's
+ * {@code java.awt.headless=true} (EditWindow queries
+ * {@code getMenuShortcutKeyMaskEx()}, which throws HeadlessException),
+ * so the policy is a pure function tested directly, and the wiring is
+ * pinned by reading SimpleEditor's source from the repo tree — the
+ * same compensating-control pattern as ToolkitPolicyTest and
+ * HeadlessCoreRatchetTest.
+ */
+class DeleteKeyPolicyTest {
+
+	private static final KeyStroke PLAIN_DELETE =
+			KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0);
+	private static final KeyStroke PLAIN_BACKSPACE =
+			KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0);
+
+	// ---- the canvas bindings (issue #127 H1, P1, P3) ----
+
+	/** P3: forward-Delete keeps working everywhere it does today. */
+	@Test
+	void canvasBindsPlainDelete() {
+		assertTrue(DeleteKeyPolicy.canvasBindings().contains(PLAIN_DELETE),
+				"plain Delete must remain bound (P3)");
+	}
+
+	/** P1: Backspace deletes the selection — the Mac-keyboard fix. */
+	@Test
+	void canvasBindsPlainBackspace() {
+		assertTrue(DeleteKeyPolicy.canvasBindings().contains(PLAIN_BACKSPACE),
+				"plain Backspace must be bound (P1)");
+	}
+
+	/** Exactly the two unmodified keys — no modifier chords, so the
+	 *  binding cannot silently depend on the platform menu mask. */
+	@Test
+	void canvasBindingsAreExactlyTheTwoUnmodifiedKeys() {
+		List<KeyStroke> bindings = DeleteKeyPolicy.canvasBindings();
+		assertEquals(2, bindings.size(), bindings.toString());
+		for (KeyStroke stroke : bindings)
+			assertEquals(0, stroke.getModifiers(),
+					"delete bindings carry no modifiers: " + stroke);
+	}
+
+	// ---- the displayed accelerator, per platform ----
+
+	/** macOS keyboards have no forward-Delete key: show Backspace. */
+	@Test
+	void macMenuShowsBackspace() {
+		assertEquals(PLAIN_BACKSPACE,
+				DeleteKeyPolicy.menuAccelerator("Mac OS X"));
+		assertEquals(PLAIN_BACKSPACE,
+				DeleteKeyPolicy.menuAccelerator("macOS"));
+	}
+
+	/** Everywhere else the Delete key exists: keep showing it. */
+	@Test
+	void otherPlatformsMenuShowsDelete() {
+		assertEquals(PLAIN_DELETE, DeleteKeyPolicy.menuAccelerator("Linux"));
+		assertEquals(PLAIN_DELETE,
+				DeleteKeyPolicy.menuAccelerator("Windows 11"));
+		assertEquals(PLAIN_DELETE, DeleteKeyPolicy.menuAccelerator(null));
+	}
+
+	// ---- os.name recognition ----
+
+	@Test
+	void isMacRecognizesAppleOsNames() {
+		assertTrue(DeleteKeyPolicy.isMac("Mac OS X"));
+		assertTrue(DeleteKeyPolicy.isMac("macOS"));
+		assertTrue(DeleteKeyPolicy.isMac("OS X"));
+		assertFalse(DeleteKeyPolicy.isMac("Linux"));
+		assertFalse(DeleteKeyPolicy.isMac("Windows 11"));
+		assertFalse(DeleteKeyPolicy.isMac(null));
+	}
+
+	// ---- the wiring in SimpleEditor ----
+
+	/**
+	 * SimpleEditor must consume the policy rather than hard-coding
+	 * VK_DELETE: the delete menu item's accelerator and the canvas
+	 * input-map bindings both go through DeleteKeyPolicy, and no
+	 * literal VK_DELETE keystroke construction remains. This is the
+	 * regression pin for the wiring the headless JVM cannot exercise
+	 * (constructing the editor throws HeadlessException); it fails on
+	 * pre-#127 SimpleEditor, which bound
+	 * {@code KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,0)} directly.
+	 */
+	@Test
+	void simpleEditorDelegatesDeleteBindingsToThePolicy()
+			throws IOException {
+		Path source = Path.of(System.getProperty("user.dir"),
+				"src/jls/edit/SimpleEditor.java");
+		assertTrue(Files.isRegularFile(source),
+				"run from the repo root (maven sets user.dir there): "
+						+ source);
+		String text = Files.readString(source, StandardCharsets.UTF_8);
+
+		assertTrue(text.contains(
+				"delete.setAccelerator(DeleteKeyPolicy.menuAccelerator("),
+				"the delete menu accelerator must come from the policy");
+		assertTrue(text.contains("DeleteKeyPolicy.canvasBindings()"),
+				"the canvas delete bindings must come from the policy");
+		assertFalse(text.contains("VK_DELETE"),
+				"no hard-coded VK_DELETE binding may remain in "
+						+ "SimpleEditor (issue #127 O1)");
+	}
+
+} // end of DeleteKeyPolicyTest class


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #127 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 307 tests; new jls.edit.DeleteKeyPolicyTest 7/7, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
