### PR TITLE
Add opt-in plain-text saves and a -savetext CLI flag (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ All notable changes to JLS are documented here. The format follows
 
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
-*(Nothing yet.)*
+### Added
+- Opt-in plain-text saves (#129): the Save As dialog offers a
+  plain-text file type, and the new `-savetext out.jls circuit.jls`
+  flag rewrites an existing circuit file uncompressed. Plain-text
+  `.jls` files diff cleanly in version control and open in JLS forks
+  that removed the XZ reader; saves stay XZ-compressed by default,
+  and the loader has always accepted both.
 
 ## [5.0.4] — 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   default, or pass an output path such as `-i out.jpg` for JPEG),
   Verilog export (`-export out.v circuit.jls` writes the drawn circuit
   as a structural Verilog-2005 module — a deployment bridge, not an HDL
-  tutorial; note JLS's two-state-plus-HiZ semantics), and
+  tutorial; note JLS's two-state-plus-HiZ semantics),
+  plain-text re-save (`-savetext out.jls circuit.jls` rewrites the
+  circuit uncompressed, for version-control diffs and for JLS forks
+  without an XZ reader — see "Circuit file compatibility" below), and
   printing (`-p`/`-v`/`-r`).
   Diagnostics go to stderr as one `jls: error: ...` line; exit status is
   0 on success, 1 on runtime failure, and 2 on a usage error.
@@ -227,13 +230,18 @@ JLS saves circuits as `.jls` files. **The extension has meant different
 container formats over time**, and the loader accepts all of them by
 sniffing the actual content:
 
-- **XZ-compressed text** — what current versions of JLS write when saving.
-  Despite the plain `.jls` name, these files are XZ data (they start with the
-  `ý7zXZ` magic bytes) wrapping a line-oriented text description of the
-  circuit.
+- **XZ-compressed text** — what current versions of JLS write by default
+  when saving. Despite the plain `.jls` name, these files are XZ data (they
+  start with the `ý7zXZ` magic bytes) wrapping a line-oriented text
+  description of the circuit.
 - **Zip archive** — the original JLS format: a zip containing a single
   `JLSCircuit` entry with the same text description.
-- **Plain text** — the uncompressed circuit description itself.
+- **Plain text** — the uncompressed circuit description itself. Current JLS
+  writes it on request: choose the plain-text file type in File > Save As,
+  or run `jls -savetext out.jls circuit.jls` to rewrite an existing file.
+  Plain-text saves diff cleanly in version control and open in JLS forks
+  that dropped the XZ reader (the 4.6–4.10 fork lineage); saves stay
+  XZ-compressed unless you opt in.
 
 Inside whichever container, circuit text written by current JLS begins with
 a `FORMAT 1` version line ahead of the top-level `CIRCUIT` line; files from

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -42,7 +42,7 @@ fails when this document and the code drift apart.
 A `.jls` file is one of three containers, distinguished by **content
 sniffing, never by file name**. A reader MUST try, in order:
 
-1. **XZ-compressed text** — what current JLS writes. The file is a
+1. **XZ-compressed text** — what current JLS writes by default. The file is a
    standard XZ stream (magic bytes `FD 37 7A 58 5A 00`, "ý7zXZ")
    whose decompressed payload is the circuit text.
 2. **Zip archive** — the original JLS container: a zip holding the
@@ -53,8 +53,12 @@ sniffing, never by file name**. A reader MUST try, in order:
 
 The circuit text is UTF-8 in every container.
 
-A conformant writer MUST write the XZ container (a writer producing
-files only for its own consumption MAY use plain text; JLS reads it).
+A conformant writer MUST write either the XZ container or the
+plain-text container; the zip container is read-only legacy. JLS
+writes XZ by default and plain text on explicit request (the Save As
+file-type choice or the `-savetext` flag, issue #129) — plain text is
+the interchange form for version control and for readers without an
+XZ decoder.
 Writes go to a temporary file that is atomically renamed over the
 target, so a crash mid-write never leaves a truncated file where a
 complete one used to be; readers therefore MAY assume a file is

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -60,6 +60,8 @@ public class Circuit implements Printable {
 															// can be unique
 	private SortedMap<String, JumpStart> starts = new TreeMap<String, JumpStart>(); // jumpstarts
 	private boolean changed = false;
+	private FileAbstractor.Container saveContainer =
+			FileAbstractor.Container.XZ; // on-disk container saves use (#129)
 
 	private final SpatialIndex index = new SpatialIndex(); // grid index over
 															// element bounds
@@ -145,6 +147,31 @@ public class Circuit implements Printable {
 
 		this.name = name;
 	} // end of setName method
+
+	/**
+	 * Get the on-disk container this circuit's saves are written in.
+	 * XZ unless the user opted into plain text (issue #129).
+	 *
+	 * @return the save container.
+	 */
+	public FileAbstractor.Container getSaveContainer() {
+
+		return saveContainer;
+	} // end of getSaveContainer method
+
+	/**
+	 * Change the on-disk container this circuit's saves are written in.
+	 * Set from the Save As file-type choice (issue #129); the choice
+	 * sticks for later plain Saves of the same circuit, so re-saving
+	 * cannot silently re-wrap a version-controlled plain-text file.
+	 *
+	 * @param container
+	 *            The container future saves will use.
+	 */
+	public void setSaveContainer(FileAbstractor.Container container) {
+
+		this.saveContainer = container;
+	} // end of setSaveContainer method
 
 	/**
 	 * Check if circuit has changed.

--- a/src/jls/FileAbstractor.java
+++ b/src/jls/FileAbstractor.java
@@ -30,11 +30,23 @@ import org.tukaani.xz.XZOutputStream;
  * format probe rejected the file in {@link JLSInfo#loadError} instead of
  * silently returning null.
  *
- * Writing produces the current save format (XZ-compressed UTF-8 text) via
- * a temp file and atomic rename, so a crash mid-write can never leave a
- * truncated file where a complete one used to be.
+ * Writing produces the current save format (XZ-compressed UTF-8 text) by
+ * default, or the identical text uncompressed when the caller opts in
+ * (issue #129) -- either way via a temp file and atomic rename, so a
+ * crash mid-write can never leave a truncated file where a complete one
+ * used to be.
  */
 public final class FileAbstractor {
+
+	/**
+	 * The on-disk container a save is written in. XZ is the default
+	 * (issue #21 chose it for size); PLAIN_TEXT is the opt-in interchange
+	 * form (issue #129): the same circuit text minus the compression
+	 * wrapper, so version control gets meaningful diffs and readers
+	 * without an XZ decoder (the 4.6-4.10 fork lineage) can open the
+	 * file. Reading needs no counterpart: openCircuit sniffs both.
+	 */
+	public enum Container { XZ, PLAIN_TEXT }
 
 	/**
 	 * Upper bound on the circuit text a container may expand to. Circuit
@@ -142,10 +154,30 @@ public final class FileAbstractor {
 	 */
 	public static void writeCircuit(File target, String circuitText) throws IOException {
 
+		writeCircuit(target, circuitText, Container.XZ);
+	}
+
+	/**
+	 * Write circuit text to the target file in the named container:
+	 * Container.XZ is the standard save format, Container.PLAIN_TEXT the
+	 * opt-in uncompressed form (issue #129). Both containers share the
+	 * temp-file/atomic-rename machinery, so the previous complete file
+	 * survives a crash mid-write either way.
+	 *
+	 * @param target      The file to (re)place.
+	 * @param circuitText The complete circuit text, as produced by Circuit.save.
+	 * @param container   The on-disk container to wrap the text in.
+	 */
+	public static void writeCircuit(File target, String circuitText,
+			Container container) throws IOException {
+
 		File temp = new File(target.getPath() + ".tmp");
 		try {
 			try (Writer out = new OutputStreamWriter(
-					new XZOutputStream(new FileOutputStream(temp), new LZMA2Options()),
+					container == Container.XZ
+							? new XZOutputStream(new FileOutputStream(temp),
+									new LZMA2Options())
+							: new FileOutputStream(temp),
 					StandardCharsets.UTF_8)) {
 				out.write(circuitText);
 			}

--- a/src/jls/JLSInfo.java
+++ b/src/jls/JLSInfo.java
@@ -62,6 +62,7 @@ public final class JLSInfo {
 	public static boolean printTrace = false;			// print signal trace
 	public static boolean imgexport = false;			// export image from command line
 	public static boolean hdlexport = false;			// export HDL from command line (#60)
+	public static boolean textsave = false;				// re-save as plain text from command line (#129)
 	public enum Orientation { UP, DOWN, LEFT, RIGHT;
 
 		/**

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.math.BigInteger;
 import java.net.URL;
 import java.nio.file.FileSystems;
@@ -76,6 +78,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private static String imageFile = null;
 	private static String vcdFile = null;
 	private static String exportFile = null;
+	private static String textSaveFile = null;
 	private static boolean printCircuit = false;
 	private static boolean printCircuitTop;
 	private static String printer = null;
@@ -357,6 +360,39 @@ public class JLSStart extends JFrame implements ChangeListener {
 			}
 		}
 
+		else if (JLSInfo.textsave) {
+
+			// plain-text re-save (issue #129) is headless like batch mode
+			System.setProperty("java.awt.headless", "true");
+
+			if (startFile == null) {
+				System.err.println("jls: error: plain-text save requires a circuit file");
+				System.exit(1);
+			}
+			Circuit circ = loadCircuitHeadless(startFile);
+
+			// like Save As, the circuit takes the output file's name, so
+			// the file name and its CIRCUIT line cannot disagree
+			circ.setName(Util.isValidFileName(
+					textSaveFile.replaceAll("\\.jls$", "")));
+
+			// serialize and write uncompressed; writeCircuit keeps the
+			// temp-file/atomic-rename guarantee of ordinary saves
+			StringWriter text = new StringWriter();
+			try (PrintWriter output = new PrintWriter(text)) {
+				circ.save(output);
+			}
+			try {
+				FileAbstractor.writeCircuit(new File(textSaveFile),
+						text.toString(),
+						FileAbstractor.Container.PLAIN_TEXT);
+			} catch (IOException e) {
+				System.err.println("jls: error: can't write " + textSaveFile
+						+ ": " + e.getMessage());
+				System.exit(1);
+			}
+		}
+
 		else {
 
 			// start up GUI
@@ -556,6 +592,8 @@ public class JLSStart extends JFrame implements ChangeListener {
 				"write watched-signal waveforms to the named VCD file (batch mode)"),
 		new FlagSpec("export", Arity.REQUIRED, "file", "an output file",
 				"export the circuit as Verilog-2005 (.v) or VHDL (.vhd/.vhdl), chosen by the file extension"),
+		new FlagSpec("savetext", Arity.REQUIRED, "file", "an output file",
+				"re-save the circuit to the named .jls file as plain (uncompressed) text"),
 	};
 
 	/**
@@ -686,7 +724,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		return !(printCircuit && startFile != null)
 				&& !JLSInfo.batch && !JLSInfo.imgexport
-				&& !JLSInfo.hdlexport;
+				&& !JLSInfo.hdlexport && !JLSInfo.textsave;
 	} // end of guiSessionRequested method
 
 	/**
@@ -766,6 +804,23 @@ public class JLSStart extends JFrame implements ChangeListener {
 			}
 			JLSInfo.hdlexport = true;
 			exportFile = opnd;
+			break;
+		case "savetext":
+			// the output must reopen by the same rules as any other
+			// circuit file, so its name is validated up front (#129):
+			// a .jls suffix on a valid circuit name
+			// (-savetext is Arity.REQUIRED, so opnd cannot be null; the
+			// guard keeps that invariant locally checkable)
+			String textName = opnd == null ? "" : opnd;
+			if (!textName.endsWith(".jls")
+					|| Util.isValidFileName(
+							textName.replaceAll("\\.jls$", "")) == null) {
+				usageError("option -savetext output file must be a .jls "
+						+ "file named like a circuit (letters, digits and "
+						+ "underscores, starting with a letter): " + opnd);
+			}
+			JLSInfo.textsave = true;
+			textSaveFile = opnd;
 			break;
 		default:
 			// unreachable: parseCommandLine only passes table flags

--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -64,7 +64,10 @@ public final class Editor extends SimpleEditor {
 			circuit.save(output);
 		}
 		try {
-			FileAbstractor.writeCircuit(new File(fileName), text.toString());
+			// the circuit remembers its container: XZ by default, plain
+			// text if the user chose it in Save As (issue #129)
+			FileAbstractor.writeCircuit(new File(fileName), text.toString(),
+					circuit.getSaveContainer());
 		} catch (IOException ex) {
 			TellUser.error(getTopLevelAncestor(),
 					"Can't write to " + fileName + ": " + ex.getMessage(), "Error");
@@ -97,17 +100,31 @@ public final class Editor extends SimpleEditor {
 		// get name from user
 		String oldName = circuit.getDirectory() + "/" + circuit.getName() + ".jls~";
 		JFileChooser chooser = new JFileChooser(Util.defaultDirectory());
+		// the file-type choice picks the on-disk container (issue #129):
+		// XZ (the default) or plain text for version control and for JLS
+		// forks without an XZ reader; both save under the .jls name
 		javax.swing.filechooser.FileFilter filter =
 			new javax.swing.filechooser.FileFilter() {
 			public boolean accept(File f) {
 				return f.getName().endsWith(".jls") || f.isDirectory();
 			}
 			public String getDescription() {
-				return "JLS Circuit Files";
+				return "JLS Circuit Files (XZ compressed, the default)";
 			}
 		};
+		javax.swing.filechooser.FileFilter textFilter =
+			new javax.swing.filechooser.FileFilter() {
+			public boolean accept(File f) {
+				return f.getName().endsWith(".jls") || f.isDirectory();
+			}
+			public String getDescription() {
+				return "JLS Circuit Files (plain text: diffable, fork-readable)";
+			}
+		};
+		chooser.addChoosableFileFilter(filter);
+		chooser.addChoosableFileFilter(textFilter);
 		chooser.setFileFilter(filter);
-		if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION) 
+		if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
 			return;
 		String fileName = chooser.getSelectedFile().getName().trim();
 		if (fileName == null || fileName.equals(""))
@@ -153,6 +170,11 @@ public final class Editor extends SimpleEditor {
 		}
 		circuit.setName(name);
 		circuit.setDirectory(chooser.getCurrentDirectory().toString());
+		// remember the chosen container so plain Save keeps it (#129);
+		// "All Files" or the default filter both mean the XZ default
+		circuit.setSaveContainer(chooser.getFileFilter() == textFilter
+				? FileAbstractor.Container.PLAIN_TEXT
+				: FileAbstractor.Container.XZ);
 
 		// save circuit
 		if (save()) {

--- a/test/jls/CircuitRoundTripTest.java
+++ b/test/jls/CircuitRoundTripTest.java
@@ -8,9 +8,6 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Scanner;
 
 import org.junit.jupiter.api.Test;
@@ -83,41 +80,12 @@ class CircuitRoundTripTest {
 		// Elements live in a HashSet, so block order and the ids assigned
 		// at save time are not stable across load instances; compare the
 		// order-independent, id-free canonical form instead.
-		assertEquals(canonicalize(savedOnce), canonicalize(savedTwice),
+		assertEquals(FileFormatSupport.canonicalize(savedOnce),
+				FileFormatSupport.canonicalize(savedTwice),
 				"saving a reloaded circuit must reproduce the same content");
-		assertEquals(canonicalize(CIRCUIT_TEXT), canonicalize(savedOnce),
+		assertEquals(FileFormatSupport.canonicalize(CIRCUIT_TEXT),
+				FileFormatSupport.canonicalize(savedOnce),
 				"a loaded circuit must save back to its original content");
-	}
-
-	/**
-	 * Reduce a saved circuit file to a canonical form: ELEMENT..END blocks
-	 * sorted, save-order-dependent id lines removed.
-	 */
-	private static String canonicalize(String saved) {
-		List<String> blocks = new ArrayList<>();
-		StringBuilder current = null;
-		StringBuilder header = new StringBuilder();
-		for (String line : saved.split("\n")) {
-			if (line.startsWith("FORMAT ")) {
-				// the version header (issue #79) is byte-pinned by
-				// FormatHeaderTest; this suite compares circuit content
-				continue;
-			}
-			if (line.startsWith("ELEMENT")) {
-				current = new StringBuilder();
-			}
-			if (current == null) {
-				header.append(line).append('\n');
-			} else if (!line.startsWith(" int id ")) {
-				current.append(line).append('\n');
-			}
-			if (line.equals("END") && current != null) {
-				blocks.add(current.toString());
-				current = null;
-			}
-		}
-		Collections.sort(blocks);
-		return header + String.join("", blocks);
 	}
 
 	@Test

--- a/test/jls/CliTextSaveTest.java
+++ b/test/jls/CliTextSaveTest.java
@@ -1,0 +1,210 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests of the headless plain-text re-save (issue #129):
+ * -savetext loads a circuit file in any container and rewrites it as
+ * uncompressed circuit text, so upstream-authored files can be opened by
+ * fork lineages without an XZ reader and diffed under version control.
+ * The output is validated as a real circuit file: it must reload to an
+ * equivalent circuit, and re-converting it must not change its content.
+ */
+class CliTextSaveTest {
+
+	@TempDir
+	Path tmp;
+
+	private static final class Result {
+		final int exit;
+		final String stderr;
+
+		Result(int exit, String stderr) {
+			this.exit = exit;
+			this.stderr = stderr;
+		}
+	}
+
+	private Result run(String... args) throws Exception {
+		String java = System.getProperty("java.home")
+				+ File.separator + "bin" + File.separator + "java";
+		List<String> cmd = new ArrayList<>();
+		cmd.add(java);
+		cmd.add("-Djava.awt.headless=true");
+		cmd.add("-cp");
+		cmd.add(System.getProperty("java.class.path"));
+		cmd.add("jls.JLS");
+		for (String a : args) {
+			cmd.add(a);
+		}
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.directory(tmp.toFile());
+		pb.environment().remove("JAVA_TOOL_OPTIONS");
+		Process p = pb.start();
+		p.getOutputStream().close();
+		String stderr = drain(p.getErrorStream());
+		drain(p.getInputStream());
+		assertTrue(p.waitFor(60, TimeUnit.SECONDS), "CLI run timed out");
+		return new Result(p.exitValue(), stderr);
+	}
+
+	private static String drain(InputStream in) throws Exception {
+		return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * A minimal circuit in the on-disk text form. Wire-free, so content
+	 * comparisons can use FileFormatSupport.canonicalize (ref lines
+	 * change with the unstable save-time ids).
+	 */
+	private static String circuitText(String name) {
+		return "CIRCUIT " + name + "\n"
+				+ "ELEMENT Constant\n"
+				+ " int id 0\n int x 60\n int y 60\n"
+				+ " int width 24\n int height 24\n"
+				+ " Int value 5\n int base 10\n"
+				+ " String orient \"RIGHT\"\n"
+				+ "END\n"
+				+ "ELEMENT Constant\n"
+				+ " int id 1\n int x 120\n int y 96\n"
+				+ " int width 24\n int height 24\n"
+				+ " Int value 255\n int base 16\n"
+				+ " String orient \"LEFT\"\n"
+				+ "END\n"
+				+ "ENDCIRCUIT\n";
+	}
+
+	@Test
+	void anXZSaveIsRewrittenAsPlainText() throws Exception {
+		// the input is what a default (XZ) save produces -- exactly the
+		// file the fork lineage cannot open (issue #129, P1)
+		FileFormatSupport.writeXZ(tmp.resolve("in.jls").toFile(),
+				circuitText("in"));
+
+		Result r = run("-savetext", "out.jls", "in.jls");
+		assertEquals(0, r.exit, r.stderr);
+
+		byte[] out = Files.readAllBytes(tmp.resolve("out.jls"));
+		assertFalse(out.length >= 1 && (out[0] & 0xFF) == 0xFD,
+				"the output must not be an XZ stream");
+		String text = new String(out, StandardCharsets.UTF_8);
+		// writers declare the minimal version the circuit needs
+		// (Circuit.formatVersionNeeded()), and this fixture uses no
+		// version-2 features, so the header must say 1 even while
+		// Circuit.FORMAT_VERSION is newer
+		assertTrue(text.startsWith("FORMAT 1\nCIRCUIT out\n"),
+				"the output must be bare circuit text named after the "
+						+ "output file, got: "
+						+ text.substring(0, Math.min(40, text.length())));
+		assertTrue(text.endsWith("ENDCIRCUIT\n"), "truncated output");
+	}
+
+	@Test
+	void theConvertedFileHoldsTheSameCircuit() throws Exception {
+		// same base name in a subdirectory, so the input text and the
+		// converted output are comparable including the CIRCUIT line
+		Files.createDirectory(tmp.resolve("sub"));
+		FileFormatSupport.writeXZ(tmp.resolve("sub/in.jls").toFile(),
+				circuitText("in"));
+
+		Result r = run("-savetext", "in.jls", "sub/in.jls");
+		assertEquals(0, r.exit, r.stderr);
+
+		assertEquals(FileFormatSupport.canonicalize(circuitText("in")),
+				FileFormatSupport.canonicalize(
+						Files.readString(tmp.resolve("in.jls"))),
+				"the plain-text save must hold the identical circuit");
+
+		// and it reloads through the real sniffer/loader stack
+		Scanner input = FileAbstractor.openCircuit(
+				tmp.resolve("in.jls").toString());
+		assertTrue(input != null, () -> "converted file must reopen: "
+				+ JLSInfo.loadError);
+		Circuit circ = new Circuit("in");
+		assertTrue(circ.load(input), () -> "load failed: " + JLSInfo.loadError);
+		input.close();
+		assertTrue(circ.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		assertEquals(2, circ.getElements().size());
+	}
+
+	@Test
+	void reConvertingThePlainTextOutputChangesNothing() throws Exception {
+		FileFormatSupport.writeXZ(tmp.resolve("in.jls").toFile(),
+				circuitText("in"));
+		assertEquals(0, run("-savetext", "out.jls", "in.jls").exit);
+		String first = Files.readString(tmp.resolve("out.jls"));
+
+		// converting the output onto itself must preserve the content
+		// (canonicalized: element order and ids are not stable per load)
+		Result r = run("-savetext", "out.jls", "out.jls");
+		assertEquals(0, r.exit, r.stderr);
+		assertEquals(FileFormatSupport.canonicalize(first),
+				FileFormatSupport.canonicalize(
+						Files.readString(tmp.resolve("out.jls"))),
+				"plain-text re-save of a plain-text save must hold the "
+						+ "same circuit");
+	}
+
+	@Test
+	void attachedOperandWinsOverTheDashSPrefix() throws Exception {
+		// "-savetextout.jls" must resolve to -savetext with the attached
+		// operand, never to -s with the operand "avetextout.jls"
+		FileFormatSupport.writeXZ(tmp.resolve("in.jls").toFile(),
+				circuitText("in"));
+		Result r = run("-savetextout.jls", "in.jls");
+		assertEquals(0, r.exit, r.stderr);
+		assertTrue(Files.exists(tmp.resolve("out.jls")),
+				"the attached operand must name the output file");
+	}
+
+	@Test
+	void missingOperandIsAUsageError() throws Exception {
+		Result r = run("-savetext");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("option -savetext requires"), r.stderr);
+	}
+
+	@Test
+	void nonJlsOutputIsAUsageError() throws Exception {
+		FileFormatSupport.writeXZ(tmp.resolve("in.jls").toFile(),
+				circuitText("in"));
+		Result r = run("-savetext", "out.txt", "in.jls");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("-savetext"), r.stderr);
+		assertFalse(Files.exists(tmp.resolve("out.txt")));
+	}
+
+	@Test
+	void invalidCircuitNameOutputIsAUsageError() throws Exception {
+		// the output must reopen later, so it obeys circuit-file naming
+		FileFormatSupport.writeXZ(tmp.resolve("in.jls").toFile(),
+				circuitText("in"));
+		Result r = run("-savetext", "9bad.jls", "in.jls");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("-savetext"), r.stderr);
+		assertFalse(Files.exists(tmp.resolve("9bad.jls")));
+	}
+
+	@Test
+	void withoutACircuitFileIsARuntimeError() throws Exception {
+		Result r = run("-savetext", "out.jls");
+		assertEquals(1, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("jls: error:"), r.stderr);
+	}
+}

--- a/test/jls/FileAbstractorTest.java
+++ b/test/jls/FileAbstractorTest.java
@@ -1,6 +1,7 @@
 package jls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,6 +86,101 @@ class FileAbstractorTest {
 		Scanner scanner = FileAbstractor.openCircuit(file.getAbsolutePath());
 		assertNotNull(scanner);
 		assertEquals("CIRCUIT newer\nENDCIRCUIT\n", FileFormatSupport.drain(scanner));
+		assertEquals(0, tmp.toFile().listFiles((d, n) -> n.endsWith(".tmp")).length,
+				"temp file must not survive a successful write");
+	}
+
+	// ------------------------------------------------------------------
+	// opt-in plain-text container (issue #129)
+	// ------------------------------------------------------------------
+
+	/** The XZ stream magic bytes (spec docs/file-format.md section 1). */
+	private static final byte[] XZ_MAGIC =
+			{(byte) 0xFD, '7', 'z', 'X', 'Z', 0};
+
+	private static boolean startsWithXZMagic(File file) throws Exception {
+		byte[] head = Files.readAllBytes(file.toPath());
+		if (head.length < XZ_MAGIC.length) {
+			return false;
+		}
+		for (int i = 0; i < XZ_MAGIC.length; i++) {
+			if (head[i] != XZ_MAGIC[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Test
+	void aFreshCircuitDefaultsToTheXZContainer() {
+		// issue #129 P3: the GUI save path takes its container from the
+		// circuit, so the circuit's default pins the default save format
+		assertEquals(FileAbstractor.Container.XZ,
+				new Circuit("fresh").getSaveContainer(),
+				"a circuit must default to the XZ save container");
+	}
+
+	@Test
+	void defaultWriteIsStillXZCompressed() throws Exception {
+		// issue #129 P3: the default container must not change
+		File file = tmp.resolve("dflt.jls").toFile();
+		FileAbstractor.writeCircuit(file, "CIRCUIT dflt\nENDCIRCUIT\n");
+		assertTrue(startsWithXZMagic(file),
+				"a default save must still be an XZ stream");
+	}
+
+	@Test
+	void plainTextWriteIsTheBareCircuitText() throws Exception {
+		// issue #129 H1: the plain-text container is the identical text
+		// payload minus the XZ wrapper -- byte-for-byte on disk
+		String content = "CIRCUIT plain\nENDCIRCUIT\n";
+		File file = tmp.resolve("plain.jls").toFile();
+		FileAbstractor.writeCircuit(file, content,
+				FileAbstractor.Container.PLAIN_TEXT);
+
+		assertEquals(content, Files.readString(file.toPath()),
+				"the file must hold the bare UTF-8 circuit text");
+		Scanner scanner = FileAbstractor.openCircuit(file.getAbsolutePath());
+		assertNotNull(scanner, "plain-text save must reopen: " + JLSInfo.loadError);
+		assertEquals(content, FileFormatSupport.drain(scanner));
+		assertEquals(0, tmp.toFile().listFiles((d, n) -> n.endsWith(".tmp")).length,
+				"temp file must not survive a successful write");
+	}
+
+	@Test
+	void bothContainersLoadTheSameCircuitText() throws Exception {
+		// cross-container equivalence: the same circuit saved both ways
+		// loads identically through the sniffer
+		String content = "CIRCUIT both\nENDCIRCUIT\n";
+		File xz = tmp.resolve("both_xz.jls").toFile();
+		File text = tmp.resolve("both_text.jls").toFile();
+		FileAbstractor.writeCircuit(xz, content, FileAbstractor.Container.XZ);
+		FileAbstractor.writeCircuit(text, content,
+				FileAbstractor.Container.PLAIN_TEXT);
+
+		assertTrue(startsWithXZMagic(xz), "XZ save must be an XZ stream");
+		assertFalse(startsWithXZMagic(text),
+				"plain-text save must not be an XZ stream");
+		Scanner fromXz = FileAbstractor.openCircuit(xz.getAbsolutePath());
+		Scanner fromText = FileAbstractor.openCircuit(text.getAbsolutePath());
+		assertNotNull(fromXz);
+		assertNotNull(fromText);
+		assertEquals(FileFormatSupport.drain(fromXz),
+				FileFormatSupport.drain(fromText),
+				"both containers must yield the same circuit text");
+	}
+
+	@Test
+	void plainTextWriteReplacesAnXZFileAtomically() throws Exception {
+		// re-saving an XZ file as plain text is the interop conversion
+		// (issue #129); it must go through the same temp/rename machinery
+		File file = tmp.resolve("convert.jls").toFile();
+		FileAbstractor.writeCircuit(file, "CIRCUIT old\nENDCIRCUIT\n");
+		FileAbstractor.writeCircuit(file, "CIRCUIT convert\nENDCIRCUIT\n",
+				FileAbstractor.Container.PLAIN_TEXT);
+
+		assertEquals("CIRCUIT convert\nENDCIRCUIT\n",
+				Files.readString(file.toPath()));
 		assertEquals(0, tmp.toFile().listFiles((d, n) -> n.endsWith(".tmp")).length,
 				"temp file must not survive a successful write");
 	}

--- a/test/jls/FileFormatSupport.java
+++ b/test/jls/FileFormatSupport.java
@@ -69,4 +69,38 @@ final class FileFormatSupport {
 		scanner.close();
 		return sb.toString();
 	}
+
+	/**
+	 * Reduce a saved circuit file to a canonical form: ELEMENT..END blocks
+	 * sorted, save-order-dependent id lines removed, the FORMAT header
+	 * (byte-pinned by FormatHeaderTest) dropped. Elements live in a
+	 * HashSet, so block order and the ids assigned at save time are not
+	 * stable across load instances; comparisons of saved circuit content
+	 * must use this form. Only sound for circuits without id
+	 * cross-references (ref lines), since those change with the ids.
+	 */
+	static String canonicalize(String saved) {
+		java.util.List<String> blocks = new java.util.ArrayList<String>();
+		StringBuilder current = null;
+		StringBuilder header = new StringBuilder();
+		for (String line : saved.split("\n")) {
+			if (line.startsWith("FORMAT ")) {
+				continue;
+			}
+			if (line.startsWith("ELEMENT")) {
+				current = new StringBuilder();
+			}
+			if (current == null) {
+				header.append(line).append('\n');
+			} else if (!line.startsWith(" int id ")) {
+				current.append(line).append('\n');
+			}
+			if (line.equals("END") && current != null) {
+				blocks.add(current.toString());
+				current = null;
+			}
+		}
+		java.util.Collections.sort(blocks);
+		return header + String.join("", blocks);
+	}
 }


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #129 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 297 tests; new plain-text round-trip suite green, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
