### PR TITLE
Seed file choosers from user.home instead of user.dir (#130)

### DIFF
--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -1348,7 +1348,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		// create circuit and set up editor
 		Circuit circ = new Circuit(name);
-		circ.setDirectory(System.getProperty("user.dir"));
+		circ.setDirectory(Util.defaultDirectory());
 		exHandler.setCircuit(circ);
 		setupEditor(circ,name);
 	} // end of newCircuit method
@@ -1368,7 +1368,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		// get circuit name from user if parameter is null
 		if (filePath == null) {
-			prevOpenDir = prevOpenDir.equals("") ? System.getProperty("user.dir") : prevOpenDir;
+			prevOpenDir = Util.seedDirectory(prevOpenDir);
 			JFileChooser chooser = new JFileChooser( prevOpenDir );
 			
 			javax.swing.filechooser.FileFilter filter =
@@ -1393,7 +1393,11 @@ public class JLSStart extends JFrame implements ChangeListener {
 			dir = prevOpenDir;
 		}else {
 			file = new File(filePath);
-			// a bare relative filename has no parent
+			// a bare relative filename has no parent; it was resolved
+			// against the working directory (this branch only runs for a
+			// command-line start file), so user.dir - not user.home - IS
+			// the file's real directory.  Deliberately kept on user.dir;
+			// see issue #130's H1 exclusion.
 			String parent = file.getParent();
 			prevOpenDir = (parent == null || parent.equals(""))
 					? System.getProperty("user.dir") : parent;
@@ -1575,7 +1579,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 					"no circuit to import into", "Error");
 			return;
 		}
-		JFileChooser chooser = new JFileChooser(System.getProperty("user.dir"));
+		JFileChooser chooser = new JFileChooser(Util.defaultDirectory());
 		javax.swing.filechooser.FileFilter filter =
 			new javax.swing.filechooser.FileFilter() {
 			public boolean accept(File f) {
@@ -2060,7 +2064,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 			return;
 
 		// get name from user
-		JFileChooser chooser = new JFileChooser(System.getProperty("user.dir"));
+		JFileChooser chooser = new JFileChooser(Util.defaultDirectory());
 		javax.swing.filechooser.FileFilter filter =
 			new javax.swing.filechooser.FileFilter() {
 			public boolean accept(File f) {

--- a/src/jls/Util.java
+++ b/src/jls/Util.java
@@ -249,7 +249,42 @@ public final class Util {
 		}
 		
 	} // end of isValidFileName method
-	
+
+	/**
+	 * The directory used to seed file choosers and new-circuit
+	 * directories when nothing better is remembered.  This is the
+	 * user's home directory, not the process working directory:
+	 * a desktop-launched session (deb/rpm/msi/dmg/AppImage, issue #82)
+	 * inherits whatever directory the launcher happened to run in -
+	 * commonly the filesystem root, the install directory, or an
+	 * AppImage mount point - none of which is anywhere a user keeps
+	 * circuits (issue #130).
+	 *
+	 * @return the user's home directory.
+	 */
+	public static String defaultDirectory() {
+
+		return System.getProperty("user.home");
+	} // end of defaultDirectory method
+
+	/**
+	 * Pick the directory a file chooser should open in: a remembered
+	 * directory when one exists, otherwise the default directory
+	 * (issue #130).
+	 *
+	 * @param remembered A previously-used directory, or null/empty if
+	 * none has been recorded yet.
+	 *
+	 * @return remembered if non-null and non-empty, otherwise
+	 * defaultDirectory().
+	 */
+	public static String seedDirectory(String remembered) {
+
+		if (remembered == null || remembered.equals(""))
+			return defaultDirectory();
+		return remembered;
+	} // end of seedDirectory method
+
 	/**
 	 * Convert value to a string in the given base.
 	 * 

--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -94,7 +94,7 @@ public final class Editor extends SimpleEditor {
 
 		// get name from user
 		String oldName = circuit.getDirectory() + "/" + circuit.getName() + ".jls~";
-		JFileChooser chooser = new JFileChooser(System.getProperty("user.dir"));
+		JFileChooser chooser = new JFileChooser(Util.defaultDirectory());
 		javax.swing.filechooser.FileFilter filter =
 			new javax.swing.filechooser.FileFilter() {
 			public boolean accept(File f) {

--- a/test/jls/SeedDirectoryTest.java
+++ b/test/jls/SeedDirectoryTest.java
@@ -1,0 +1,50 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The seed-directory decision for file choosers and new-circuit
+ * directories (issue #130): desktop-launched sessions (deb/rpm/msi/dmg/
+ * AppImage, issue #82) inherit a meaningless working directory from the
+ * launcher, so nothing GUI-facing may seed from {@code user.dir} - the
+ * baseline is the user's home directory, and a remembered directory
+ * wins over it where one exists ({@code prevOpenDir}).
+ *
+ * <p>These tests pin the extracted helper's contract; the companion
+ * {@link UserDirSeedTest} pins that the GUI call sites actually route
+ * through it rather than reading {@code user.dir} directly.</p>
+ */
+class SeedDirectoryTest {
+
+	/** The baseline seed is the user's home directory, never the
+	 *  process working directory. */
+	@Test
+	void defaultDirectoryIsUserHome() {
+		assertEquals(System.getProperty("user.home"),
+				Util.defaultDirectory(),
+				"chooser seeds must fall back to user.home (issue #130)");
+	}
+
+	/** No remembered directory yet (the empty-string sentinel that
+	 *  prevOpenDir starts with) falls back to the default. */
+	@Test
+	void emptyRememberedFallsBackToDefault() {
+		assertEquals(Util.defaultDirectory(), Util.seedDirectory(""));
+	}
+
+	/** Null is treated the same as "nothing remembered". */
+	@Test
+	void nullRememberedFallsBackToDefault() {
+		assertEquals(Util.defaultDirectory(), Util.seedDirectory(null));
+	}
+
+	/** A remembered directory always wins over the default (the
+	 *  prevOpenDir behavior from issue #34 is preserved - P3 of
+	 *  issue #130). */
+	@Test
+	void rememberedDirectoryWins() {
+		assertEquals("/tmp/circuits", Util.seedDirectory("/tmp/circuits"));
+	}
+} // end of SeedDirectoryTest class

--- a/test/jls/UserDirSeedTest.java
+++ b/test/jls/UserDirSeedTest.java
@@ -1,0 +1,77 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins issue #130's fix at the call sites: no GUI code may seed a file
+ * chooser or a directory fallback from {@code System.getProperty
+ * ("user.dir")} - the process working directory is meaningless in a
+ * desktop-launched session (deb/rpm/msi/dmg/AppImage, issue #82).
+ * GUI paths go through {@link Util#defaultDirectory()} /
+ * {@link Util#seedDirectory(String)} instead.
+ *
+ * <p>Exactly one production read of {@code user.dir} is allowed, in
+ * {@code JLSStart.open(String)}: when a start file is named on the
+ * command line as a bare relative filename, it was resolved against
+ * the working directory, so the working directory IS the file's real
+ * parent - that site is CWD-load-bearing and excluded by issue #130's
+ * H1. If you add a new {@code user.dir} read, either route it through
+ * the Util helpers (GUI seeding) or extend ALLOWED with a comment
+ * saying why the working directory is genuinely meaningful there.</p>
+ *
+ * <p>Like HeadlessCoreRatchetTest, sources are read straight from the
+ * repo tree relative to user.dir, which maven sets to the module base
+ * directory - the repository root.</p>
+ */
+class UserDirSeedTest {
+
+	/** Files allowed to read user.dir, with the exact occurrence
+	 *  count each is allowed. */
+	private static final Map<String, Integer> ALLOWED = Map.of(
+			// the CLI start-file parent fallback in open(String)
+			"src/jls/JLSStart.java", 1);
+
+	@Test
+	void guiCodeDoesNotSeedFromUserDir() throws IOException {
+
+		Path srcRoot = Path.of("src");
+		assertTrue(Files.isDirectory(srcRoot),
+				"expected to run from the repository root");
+
+		Map<String, Integer> found = new TreeMap<>();
+		try (Stream<Path> files = Files.walk(srcRoot)) {
+			files.filter(p -> p.toString().endsWith(".java"))
+					.forEach(p -> {
+						String text;
+						try {
+							text = Files.readString(p, StandardCharsets.UTF_8);
+						} catch (IOException e) {
+							throw new RuntimeException(e);
+						}
+						int count = 0;
+						int at = -1;
+						while ((at = text.indexOf("\"user.dir\"", at + 1)) != -1)
+							count += 1;
+						if (count > 0)
+							found.put(p.toString().replace('\\', '/'), count);
+					});
+		}
+
+		assertEquals(new TreeMap<>(ALLOWED), found,
+				"user.dir reads outside the allowed set - GUI chooser "
+						+ "seeds and directory fallbacks must use "
+						+ "Util.defaultDirectory()/seedDirectory() "
+						+ "(issue #130)");
+	}
+} // end of UserDirSeedTest class


### PR DESCRIPTION
Applies the adversarially-reviewed provisional diff posted on #130 (the issue's latest comment carries the full derivation, verification commands, and declared limits).

Verified on this branch: `mvn -B verify` green in the flake dev shell (JDK 25) — 308 tests; new jls.SeedDirectoryTest 4/4 and jls.UserDirSeedTest 1/1, 0 failures, 0 errors (the usual 2 GHDL/Icarus tool-availability skips).

Fixes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
