### PR TITLE
Scope release workflow tokens to the jobs that publish (#68)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,20 @@ on:
   # steps are gated on the push event below.
   workflow_dispatch:
 
+# Least privilege (#68): the workflow token is read-only by default and
+# each publishing job elevates only what it uses.
 permissions:
-  # create the release and upload assets
-  contents: write
-  # sign the provenance attestation (OIDC)
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      # create the release and upload assets
+      contents: write
+      # sign the provenance attestation (OIDC)
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -265,6 +269,12 @@ jobs:
             experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
+    permissions:
+      # append installer assets to the release
+      contents: write
+      # sign the per-installer provenance attestations (OIDC)
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
Moves release.yml to least-privilege workflow tokens: top-level contents: read, with job-level elevation in the release and installers jobs (contents: write + id-token/attestations for provenance), matching the existing maven-registry and container-image job blocks. This was the Token-Permissions: 0 finding in the post-ruleset Scorecard run (issue #68; also flagged in the #67 CodeQL/Scorecard triage).

Every publish-path grant is mapped: softprops release upload needs contents: write in both jobs; attest-build-provenance needs id-token + attestations in both. A workflow_dispatch dry-run after merge exercises all build legs under the read-only default.

Part of #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJf6qxESKN6xLjUm9Kj1Hy
