### PR TITLE
Close the remaining O(N) holes in the drag/drop hot path (#3, #17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,27 @@ jobs:
               print(f"| {c.get('type')} | {cov} | {mis} | {pct:.1f}% |")
           EOF
 
+  # Machine-checked proofs (proofs/README.md): the Agda development in
+  # proofs/ verifies the spatial-index query-parity and draw-culling
+  # theorems the drag/drop hot path relies on; a non-zero exit means a
+  # proof no longer checks. ProofBridgeTest (in the build job) pins the
+  # proof's modelling assumptions to the Java implementation.
+  proofs:
+    name: Verify Agda proofs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Agda
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends agda agda-stdlib
+
+      # the stdlib is copied somewhere writable because Agda refreshes
+      # .agdai interface files beside the sources while checking
+      - name: Check proofs
+        run: |
+          cp -r /usr/share/agda-stdlib "$RUNNER_TEMP/agda-stdlib"
+          LC_ALL=C.UTF-8 agda -i "$RUNNER_TEMP/agda-stdlib" -i proofs proofs/SpatialIndexCorrectness.agda
+
   # First-light Wayland GUI lane (issue #101): boots the JLS GUI on
   # JetBrains Runtime's experimental WLToolkit (Project Wakefield)
   # against a headless sway compositor - no X11 anywhere - and captures

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Thumbs.db
 # nix build output symlinks
 result
 result-*
+
+# Agda interface files (proofs/)
+*.agdai

--- a/proofs/README.md
+++ b/proofs/README.md
@@ -1,0 +1,55 @@
+# Machine-checked correctness proofs
+
+This directory contains Agda proofs of the two correctness claims behind
+the editor's drag/drop collision detection and repaint culling
+(issues #3, #17):
+
+| Theorem | Claim | Java it covers | Empirical twin |
+|---|---|---|---|
+| **THEOREM 1** `query-parity` | A uniform-grid index query (collect elements from every cell the query rectangle covers, keep those whose bounds touch it) returns **exactly** what a brute-force scan over all elements returns — the grid can never miss an element. | `jls.SpatialIndex` (`insert`/`query`/`boundsTouch`), used by `Circuit.elementsNear`/`elementsAt` for hover hit-testing, selection, and the drag overlap checks in `SimpleEditor.overlap()`/`connect()` | `SpatialIndexTest` |
+| **THEOREM 2** `culling-parity` | Enumerating repaint candidates through the index with the clip grown by the draw margin, then applying the exact visibility predicate, selects **exactly** the elements a full `mayBeVisible` scan selects — index-driven dirty-region repaints are pixel-identical to full scans. | `jls.Circuit.draw` + `mayBeVisible` + `DRAW_MARGIN` | `DrawCullingParityTest` |
+
+## How the proof connects to the Java
+
+The proofs are stated over an idealized model (closed integer intervals,
+an abstract monotone cell function). They apply to the real code exactly
+to the extent the model describes it, so every modelling assumption is
+named in the proof file's header — (A1) through (A5) — and each one is
+pinned to the implementation by a correspondingly named test in
+`test/jls/ProofBridgeTest.java`:
+
+- **(A1)** index intervals are non-empty (`Math.max(width, 0)` clamp),
+- **(A2)** `Math.floorDiv(_, CELL)` is monotone — the only property of
+  the bucketing the completeness proof uses,
+- **(A3)** `SpatialIndex.boundsTouch` is closed-interval overlap,
+- **(A4)** `Rectangle.grow`/`Rectangle.intersects` are the model's
+  interval grow and strict overlap,
+- **(A5)** the draw margin is non-negative and `Circuit.mayBeVisible`
+  computes the model's `MayBeVisible` formula.
+
+Proof obligations the theorems discharge, versus what stays empirical:
+
+- **Proven for all geometries:** no false negatives (a touching element
+  always shares a grid cell with the query — `query-complete`; a visible
+  element always survives the margin-grown query — `culling-complete`),
+  no false positives (`query-sound`), and the resulting list-level
+  filter equalities (`query-parity`, `culling-parity`).
+- **Pinned by tests, not proven:** that the Java loops implement the
+  modelled cell enumeration (the `Visits` reading — exercised
+  end-to-end by the parity tests above), the assumptions (A1)–(A5), and
+  everything about mutation (incremental `update` vs `rebuild`, covered
+  by `SpatialIndexTest.staysExactAfterMovesAndInvalidation`).
+
+## Checking the proofs
+
+The development has **no postulates and no holes**; if `agda` exits 0,
+the theorems are verified.
+
+```sh
+# Ubuntu/Debian: sudo apt-get install agda agda-stdlib
+agda -i /usr/share/agda-stdlib -i proofs proofs/SpatialIndexCorrectness.agda
+```
+
+Checked with Agda 2.6.3 and the agda-stdlib packaged for Ubuntu 24.04
+(v1.7.x). CI runs this check in the `proofs` job of
+`.github/workflows/ci.yml`.

--- a/proofs/SpatialIndexCorrectness.agda
+++ b/proofs/SpatialIndexCorrectness.agda
@@ -1,0 +1,339 @@
+------------------------------------------------------------------------
+-- Machine-checked correctness proofs for JLS's drag/drop collision
+-- detection and repaint culling (issues #3, #17).
+--
+-- What is proven here, and where the corresponding Java lives:
+--
+--   THEOREM 1 (query-parity): a uniform-grid spatial index query --
+--   "collect the elements stored in every cell the query rectangle
+--   covers, then keep those whose bounds touch the rectangle" --
+--   returns EXACTLY the elements a brute-force scan over all elements
+--   would return. In particular the grid can never miss an element
+--   (no false negatives), so the exact-predicate filter afterwards
+--   makes the result identical to the full scan.
+--     Java: jls.SpatialIndex.insert/query/boundsTouch, used by
+--     jls.Circuit.elementsNear/elementsAt for hover hit-testing,
+--     rubber-band selection, and the drag overlap (collision) checks
+--     in jls.edit.SimpleEditor.overlap()/connect().
+--
+--   THEOREM 2 (culling-parity): enumerating repaint candidates
+--   through the index with the clip grown by the draw margin, then
+--   applying the exact visibility predicate, draws EXACTLY the
+--   elements the old full scan drew. So index-driven dirty-region
+--   repaints during a drag are pixel-identical to full scans.
+--     Java: jls.Circuit.draw's candidate query (clip grown by
+--     DRAW_MARGIN) followed by mayBeVisible.
+--
+-- Modelling assumptions, each pinned to the implementation by
+-- test/jls/ProofBridgeTest.java:
+--
+--   (A1) Index intervals are non-empty (lo <= hi): SpatialIndex clamps
+--        widths with Math.max(w, 0) on insert/remove/query.
+--   (A2) The cell function is monotone: Math.floorDiv(_, CELL) with
+--        CELL > 0 satisfies i <= j -> floorDiv(i) <= floorDiv(j).
+--   (A3) boundsTouch(a, b) is the closed-interval overlap test
+--        (a.x <= b.x + b.width && b.x <= a.x + a.width, same in y),
+--        i.e. Touch below, per axis.
+--   (A4) Rectangle.intersects on non-degenerate rectangles is the
+--        open-interval overlap test (strict <), i.e. Cross below, and
+--        Rectangle.grow(m, m) maps [lo, hi] to [lo - m, hi + m].
+--   (A5) The draw margin is non-negative (DRAW_MARGIN = 8 * spacing).
+--
+-- An element is inserted into every grid cell its bounds cover, and a
+-- query visits every cell the query rectangle covers (SpatialIndex
+-- loops cx1..cx2 x cy1..cy2 on both sides), so "the cell loops find
+-- element e" is exactly "e's cell range and the query's cell range
+-- overlap on both axes" -- Visits below; lemma visits⇔shared checks
+-- that reading against the shared-cell formulation.
+--
+-- Checked with: Agda 2.6.3, agda-stdlib as packaged for Ubuntu 24.04
+-- (v1.7.3). Run: agda -i /usr/share/agda-stdlib -i proofs \
+--                     proofs/SpatialIndexCorrectness.agda
+------------------------------------------------------------------------
+
+module SpatialIndexCorrectness where
+
+open import Data.Empty using (⊥-elim)
+open import Data.Integer.Base using (ℤ; _+_; _-_; -_; _≤_; _<_; 0ℤ)
+open import Data.Integer.Properties
+  using (≤-refl; ≤-trans; ≤-total; <⇒≤; _≤?_; _<?_;
+         +-monoˡ-≤; +-monoʳ-≤; +-monoˡ-<; neg-mono-≤;
+         +-assoc; +-inverseˡ; +-inverseʳ; +-identityʳ)
+open import Data.List.Base using (List; []; _∷_; filter)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; ∃-syntax)
+open import Data.Sum.Base using (inj₁; inj₂)
+open import Function.Base using (_∘_)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; sym; trans; cong; subst)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary.Product using (_×-dec_)
+
+------------------------------------------------------------------------
+-- Part 0: integer arithmetic helpers
+------------------------------------------------------------------------
+
+-- (i - m) + m ≡ i
+-+-cancel : ∀ i m → (i - m) + m ≡ i
+-+-cancel i m =
+  trans (+-assoc i (- m) m)
+        (trans (cong (i +_) (+-inverseˡ m)) (+-identityʳ i))
+
+-- (i + m) - m ≡ i
++--cancel : ∀ i m → (i + m) - m ≡ i
++--cancel i m =
+  trans (+-assoc i m (- m))
+        (trans (cong (i +_) (+-inverseʳ m)) (+-identityʳ i))
+
+-- a strict bound on a value shifted down by m weakens to a closed
+-- bound with m moved to the other side: i - m < j  →  i ≤ j + m
+unshift-lo : ∀ {i j} m → i - m < j → i ≤ j + m
+unshift-lo {i} {j} m lt =
+  <⇒≤ (subst (_< j + m) (-+-cancel i m) (+-monoˡ-< m lt))
+
+-- and symmetrically: i < j + m  →  i - m ≤ j
+unshift-hi : ∀ {i j} m → i < j + m → i - m ≤ j
+unshift-hi {i} {j} m lt =
+  <⇒≤ (subst (i - m <_) (+--cancel j m) (+-monoˡ-< (- m) lt))
+
+------------------------------------------------------------------------
+-- Part 1: intervals (one axis of a rectangle)
+------------------------------------------------------------------------
+
+-- A non-empty closed interval [lo, hi]. Non-emptiness models the
+-- Math.max(width, 0) clamp in SpatialIndex (assumption A1).
+record Ival : Set where
+  constructor ival
+  field
+    lo hi : ℤ
+    sane  : lo ≤ hi
+open Ival
+
+-- SpatialIndex.boundsTouch, one axis (assumption A3): closed-interval
+-- overlap, counting zero-area contact.
+Touch : Ival → Ival → Set
+Touch a b = (lo a ≤ hi b) × (lo b ≤ hi a)
+
+-- java.awt.Rectangle.intersects, one axis (assumption A4): strict.
+Cross : Ival → Ival → Set
+Cross a b = (lo a < hi b) × (lo b < hi a)
+
+Touch? : ∀ a b → Dec (Touch a b)
+Touch? a b = (lo a ≤? hi b) ×-dec (lo b ≤? hi a)
+
+Cross? : ∀ a b → Dec (Cross a b)
+Cross? a b = (lo a <? hi b) ×-dec (lo b <? hi a)
+
+-- c lies within interval r
+In : ℤ → Ival → Set
+In c r = (lo r ≤ c) × (c ≤ hi r)
+
+-- two touching intervals share a point (the larger of the two los)
+common : ∀ p q → Touch p q → ∃[ c ] (In c p × In c q)
+common p q (p≤q , q≤p) with ≤-total (lo p) (lo q)
+... | inj₁ lp≤lq = lo q , (lp≤lq , q≤p) , (≤-refl , sane q)
+... | inj₂ lq≤lp = lo p , (≤-refl , sane p) , (lq≤lp , p≤q)
+
+------------------------------------------------------------------------
+-- Part 2: rectangles
+------------------------------------------------------------------------
+
+record Rect : Set where
+  constructor rect
+  field
+    rx ry : Ival
+open Rect
+
+-- SpatialIndex.boundsTouch on rectangles (assumption A3)
+TouchR : Rect → Rect → Set
+TouchR a b = Touch (rx a) (rx b) × Touch (ry a) (ry b)
+
+TouchR? : ∀ a b → Dec (TouchR a b)
+TouchR? a b = Touch? (rx a) (rx b) ×-dec Touch? (ry a) (ry b)
+
+------------------------------------------------------------------------
+-- Part 3: list filtering machinery for the set-equality statements
+------------------------------------------------------------------------
+
+module _ {A : Set} where
+
+  -- pointwise-equivalent decidable predicates filter identically
+  filter-ext : {P Q : A → Set}
+               (P? : ∀ x → Dec (P x)) (Q? : ∀ x → Dec (Q x)) →
+               (∀ x → P x → Q x) → (∀ x → Q x → P x) →
+               ∀ xs → filter P? xs ≡ filter Q? xs
+  filter-ext P? Q? p⇒q q⇒p [] = refl
+  filter-ext P? Q? p⇒q q⇒p (x ∷ xs) with P? x | Q? x
+  ... | yes p | yes q = cong (x ∷_) (filter-ext P? Q? p⇒q q⇒p xs)
+  ... | yes p | no ¬q = ⊥-elim (¬q (p⇒q x p))
+  ... | no ¬p | yes q = ⊥-elim (¬p (q⇒p x q))
+  ... | no ¬p | no ¬q = filter-ext P? Q? p⇒q q⇒p xs
+
+  -- pre-filtering by a weaker predicate changes nothing
+  filter-subsume : {P Q : A → Set}
+                   (P? : ∀ x → Dec (P x)) (Q? : ∀ x → Dec (Q x)) →
+                   (∀ x → P x → Q x) →
+                   ∀ xs → filter P? (filter Q? xs) ≡ filter P? xs
+  filter-subsume P? Q? p⇒q [] = refl
+  filter-subsume P? Q? p⇒q (x ∷ xs) with Q? x
+  ... | yes q with P? x
+  ...   | yes p = cong (x ∷_) (filter-subsume P? Q? p⇒q xs)
+  ...   | no ¬p = filter-subsume P? Q? p⇒q xs
+  filter-subsume P? Q? p⇒q (x ∷ xs) | no ¬q with P? x
+  ...   | yes p = ⊥-elim (¬q (p⇒q x p))
+  ...   | no ¬p = filter-subsume P? Q? p⇒q xs
+
+------------------------------------------------------------------------
+-- Part 4: the uniform grid (jls.SpatialIndex)
+--
+-- Parameterised over the cell function; Math.floorDiv(_, CELL) is one
+-- (assumption A2, monotonicity pinned by ProofBridgeTest).
+------------------------------------------------------------------------
+
+module Grid (cellOf      : ℤ → ℤ)
+            (cellOf-mono : ∀ {i j} → i ≤ j → cellOf i ≤ cellOf j) where
+
+  -- the (contiguous) range of cell coordinates an interval covers:
+  -- cx1..cx2 in SpatialIndex.insert/query
+  cells : Ival → Ival
+  cells a = ival (cellOf (lo a)) (cellOf (hi a)) (cellOf-mono (sane a))
+
+  -- "the query's double cell loop finds element b": their cell ranges
+  -- overlap on both axes
+  Visits : Rect → Rect → Set
+  Visits b r = Touch (cells (rx b)) (cells (rx r))
+             × Touch (cells (ry b)) (cells (ry r))
+
+  Visits? : ∀ b r → Dec (Visits b r)
+  Visits? b r = Touch? (cells (rx b)) (cells (rx r))
+          ×-dec Touch? (cells (ry b)) (cells (ry r))
+
+  -- a grid cell, and membership of a cell in a rectangle's cell set
+  Cell : Set
+  Cell = ℤ × ℤ
+
+  InCells : Cell → Rect → Set
+  InCells (cx , cy) r = In cx (cells (rx r)) × In cy (cells (ry r))
+
+  -- sanity of the Visits reading: cell ranges overlap on both axes
+  -- exactly when some concrete grid cell holds both rectangles --
+  -- which is what "insert stored b in that cell and the query loop
+  -- reaches that cell" means
+  visits⇒shared : ∀ b r → Visits b r → ∃[ c ] (InCells c b × InCells c r)
+  visits⇒shared b r (tx , ty)
+    with common (cells (rx b)) (cells (rx r)) tx
+       | common (cells (ry b)) (cells (ry r)) ty
+  ... | cx , inbx , inrx | cy , inby , inry =
+      (cx , cy) , (inbx , inby) , (inrx , inry)
+
+  shared⇒visits : ∀ b r → ∃[ c ] (InCells c b × InCells c r) → Visits b r
+  shared⇒visits b r ((cx , cy) , (inbx , inby) , (inrx , inry)) =
+      (≤-trans (proj₁ inbx) (proj₂ inrx) , ≤-trans (proj₁ inrx) (proj₂ inbx))
+    , (≤-trans (proj₁ inby) (proj₂ inry) , ≤-trans (proj₁ inry) (proj₂ inby))
+
+  -- membership in the query result: the cell loops found b AND the
+  -- exact boundsTouch filter kept it (SpatialIndex.query's inner if)
+  QueryHit : Rect → Rect → Set
+  QueryHit b r = TouchR b r × Visits b r
+
+  QueryHit? : ∀ b r → Dec (QueryHit b r)
+  QueryHit? b r = TouchR? b r ×-dec Visits? b r
+
+  -- no false positives: everything returned really touches
+  query-sound : ∀ b r → QueryHit b r → TouchR b r
+  query-sound b r = proj₁
+
+  -- no false negatives: touching rectangles share a grid cell, because
+  -- the monotone cell function maps each touching pair of interval
+  -- endpoints to a touching pair of cell ranges
+  query-complete : ∀ b r → TouchR b r → QueryHit b r
+  query-complete b r t@(tx , ty) =
+    t , (cellOf-mono (proj₁ tx) , cellOf-mono (proj₂ tx))
+      , (cellOf-mono (proj₁ ty) , cellOf-mono (proj₂ ty))
+
+  --------------------------------------------------------------------
+  -- THEOREM 1. Grid query parity: over any element list, the index
+  -- query equals the brute-force boundsTouch scan. This is the
+  -- contract SpatialIndexTest.queriesMatchBruteForceOnWiredCircuit
+  -- checks empirically, here established for ALL geometries.
+  --------------------------------------------------------------------
+  query-parity : {E : Set} (bounds : E → Rect) (r : Rect) →
+                 ∀ els → filter (λ e → QueryHit? (bounds e) r) els
+                       ≡ filter (λ e → TouchR?  (bounds e) r) els
+  query-parity bounds r =
+    filter-ext (λ e → QueryHit? (bounds e) r)
+               (λ e → TouchR? (bounds e) r)
+               (λ e → query-sound (bounds e) r)
+               (λ e → query-complete (bounds e) r)
+
+  ----------------------------------------------------------------------
+  -- Part 5: draw culling (jls.Circuit.draw + mayBeVisible)
+  --
+  -- m is the draw margin (DRAW_MARGIN = 8 * spacing >= 0, assumptions
+  -- A4/A5).
+  ----------------------------------------------------------------------
+
+  module Culling (m : ℤ) (0≤m : 0ℤ ≤ m) where
+
+    -- java.awt.Rectangle.grow(m, m), one axis: [lo, hi] to
+    -- [lo - m, hi + m]; non-negative m keeps the interval sane
+    grow : Ival → Ival
+    grow a = ival (lo a - m) (hi a + m) sane′
+      where
+      -- - m ≤ 0 (from 0 ≤ m), so growing only widens
+      lo-m≤lo : lo a - m ≤ lo a
+      lo-m≤lo = subst (lo a - m ≤_) (+-identityʳ (lo a))
+                      (+-monoʳ-≤ (lo a) (neg-mono-≤ 0≤m))
+      sane′ : lo a - m ≤ hi a + m
+      sane′ = ≤-trans lo-m≤lo
+              (≤-trans (sane a)
+                (subst (_≤ hi a + m) (+-identityʳ (hi a))
+                       (+-monoʳ-≤ (hi a) 0≤m)))
+
+    -- Circuit.mayBeVisible: element bounds grown by the margin,
+    -- strictly intersected with the clip (assumption A4)
+    MayBeVisible : Rect → Rect → Set
+    MayBeVisible b clip = Cross (grow (rx b)) (rx clip)
+                        × Cross (grow (ry b)) (ry clip)
+
+    MayBeVisible? : ∀ b clip → Dec (MayBeVisible b clip)
+    MayBeVisible? b clip = Cross? (grow (rx b)) (rx clip)
+                     ×-dec Cross? (grow (ry b)) (ry clip)
+
+    -- the clip as Circuit.draw's candidate query grows it
+    growR : Rect → Rect
+    growR (rect x y) = rect (grow x) (grow y)
+
+    -- KEY LEMMA: the margin transfers -- if the grown element bounds
+    -- strictly cross the clip, the raw bounds (closed-)touch the grown
+    -- clip, so the index query over the grown clip cannot cull a
+    -- visible element
+    margin-touch : ∀ a c → Cross (grow a) c → Touch a (grow c)
+    margin-touch a c (l< , <h) = unshift-lo m l< , unshift-hi m <h
+
+    margin-touchR : ∀ b clip → MayBeVisible b clip → TouchR b (growR clip)
+    margin-touchR b clip (vx , vy) =
+      margin-touch (rx b) (rx clip) vx , margin-touch (ry b) (ry clip) vy
+
+    -- every possibly-visible element is a candidate
+    culling-complete : ∀ b clip → MayBeVisible b clip →
+                       QueryHit b (growR clip)
+    culling-complete b clip v =
+      query-complete b (growR clip) (margin-touchR b clip v)
+
+    --------------------------------------------------------------------
+    -- THEOREM 2. Draw-culling parity: filtering the index candidates
+    -- (clip grown by the margin) with the exact visibility predicate
+    -- selects exactly the elements a full scan selects -- the pixels
+    -- drawn are unchanged. This is the contract
+    -- DrawCullingParityTest.culledCandidatesMatchFullScan checks
+    -- empirically, here established for ALL geometries.
+    --------------------------------------------------------------------
+    culling-parity : {E : Set} (bounds : E → Rect) (clip : Rect) →
+      ∀ els →
+        filter (λ e → MayBeVisible? (bounds e) clip)
+               (filter (λ e → QueryHit? (bounds e) (growR clip)) els)
+      ≡ filter (λ e → MayBeVisible? (bounds e) clip) els
+    culling-parity bounds clip =
+      filter-subsume (λ e → MayBeVisible? (bounds e) clip)
+                     (λ e → QueryHit? (bounds e) (growR clip))
+                     (λ e → culling-complete (bounds e) clip)

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1173,7 +1173,10 @@ public class Circuit implements Printable {
 		// repaint during a drag costs O(visible), not O(circuit); the
 		// query pads the clip by the same margin mayBeVisible allows
 		// for labels, so its exact check below accepts the same
-		// elements a full scan would.
+		// elements a full scan would. That parity is machine-checked:
+		// THEOREM 2 (culling-parity) in
+		// proofs/SpatialIndexCorrectness.agda, with the margin/grow/
+		// intersects assumptions pinned by jls.ProofBridgeTest.
 		Rectangle clip = g.getClipBounds();
 		java.util.Collection<Element> candidates;
 		if (clip == null) {

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1168,13 +1168,26 @@ public class Circuit implements Printable {
 		// scans (#27 S3): wires under non-wires, the second (selected)
 		// set on top of both. Elements far outside the clip cannot be
 		// visible and are skipped, so a scrolled view pays for what it
-		// shows, not for the whole circuit (#17).
+		// shows, not for the whole circuit (#17). The candidates come
+		// from the spatial index, not a full scan, so a dirty-region
+		// repaint during a drag costs O(visible), not O(circuit); the
+		// query pads the clip by the same margin mayBeVisible allows
+		// for labels, so its exact check below accepts the same
+		// elements a full scan would.
 		Rectangle clip = g.getClipBounds();
+		java.util.Collection<Element> candidates;
+		if (clip == null) {
+			candidates = elements;
+		} else {
+			Rectangle query = new Rectangle(clip);
+			query.grow(DRAW_MARGIN, DRAW_MARGIN);
+			candidates = elementsNear(query);
+		}
 		java.util.List<Element> wires = new java.util.ArrayList<Element>();
 		java.util.List<Element> parts = new java.util.ArrayList<Element>();
 		java.util.List<Element> secondWires = new java.util.ArrayList<Element>();
 		java.util.List<Element> secondParts = new java.util.ArrayList<Element>();
-		for (Element el : elements) {
+		for (Element el : candidates) {
 			if (clip != null && !mayBeVisible(el, clip)) {
 				continue;
 			}
@@ -1199,13 +1212,20 @@ public class Circuit implements Printable {
 	} // end of draw method
 
 	/**
+	 * How far outside its index bounds an element may draw (labels and
+	 * similar decorations). Draw culling pads by this margin on both the
+	 * index query and the exact visibility check.
+	 */
+	private static final int DRAW_MARGIN = 8 * JLSInfo.spacing;
+
+	/**
 	 * Whether an element could draw inside the clip. The margin generously
 	 * covers labels drawn near (but outside) an element's bounds.
 	 */
 	private static boolean mayBeVisible(Element el, Rectangle clip) {
 
 		Rectangle b = el.getIndexBounds();
-		b.grow(8 * JLSInfo.spacing, 8 * JLSInfo.spacing);
+		b.grow(DRAW_MARGIN, DRAW_MARGIN);
 		return b.intersects(clip);
 	} // end of mayBeVisible method
 

--- a/src/jls/SpatialIndex.java
+++ b/src/jls/SpatialIndex.java
@@ -28,6 +28,13 @@ import jls.elem.Element;
  * per-mouse-event drag path keeps it incrementally up to date via
  * {@link #update(Element)}, which is what turns O(S x N) drag work into
  * O(S).
+ *
+ * Query correctness -- that this grid scheme returns exactly the elements
+ * a brute-force boundsTouch scan would, so the exact-predicate callers
+ * behave identically to full scans -- is machine-checked: THEOREM 1
+ * (query-parity) in proofs/SpatialIndexCorrectness.agda, whose modelling
+ * assumptions (interval clamping, floorDiv monotonicity, the boundsTouch
+ * formula) are pinned to this class by jls.ProofBridgeTest.
  */
 public final class SpatialIndex {
 

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -259,6 +259,61 @@ public abstract class SimpleEditor extends JPanel {
 	} // end of mixesTriStateAndNormal method
 
 	/**
+	 * See if a wire hanging off the moving selection collides with
+	 * anything along its span: a stationary wire end it lands on, or a
+	 * stationary non-wire element its body sweeps across.
+	 *
+	 * The element check closes a drag-direction asymmetry: dragging an
+	 * element into a wire has always been an overlap (the main overlap()
+	 * loop calls sel.intersects(wire)), but dragging the wire so its
+	 * body crossed a stationary element was never checked, so the same
+	 * forbidden geometry could be created from one direction and not the
+	 * other. The element predicate here is elm.intersects(wire) - the
+	 * exact call the reverse direction makes - so the two directions
+	 * cannot disagree. Consequences preserved from both directions:
+	 * wire-over-wire crossings stay legal (schematic wires cross
+	 * freely), and a wire never collides with an element an end of it
+	 * sits on (Wire.intersects excludes wires whose endpoint is inside
+	 * the rectangle), so attached wires do not collide with their own
+	 * element. Elements in the selected set move rigidly with the wire
+	 * and are skipped, as in the main overlap() loop.
+	 *
+	 * Queries the spatial index around the wire's own bounds (#3, #17);
+	 * one query serves both the wire-end and the element checks.
+	 *
+	 * @param circuit The circuit being edited.
+	 * @param selected The moving selection.
+	 * @param sel The selected element the wire hangs off.
+	 * @param wire The wire to check.
+	 *
+	 * @return true if the wire collides along its span.
+	 */
+	static boolean wireCollidesAlongSpan(Circuit circuit,
+			Set<Element> selected, Element sel, Wire wire) {
+
+		Rectangle span = wire.getIndexBounds();
+		span.grow(JLSInfo.pointDiameter,JLSInfo.pointDiameter);
+		for (Element elm : circuit.elementsNear(span)) {
+			if (sel == elm)
+				continue;
+			if (elm instanceof WireEnd) {
+				if (wire.touches((WireEnd)elm)) {
+					return true;
+				}
+				continue;
+			}
+			if (elm instanceof Wire)
+				continue;
+			if (selected.contains(elm))
+				continue;
+			if (elm.intersects(wire)) {
+				return true;
+			}
+		}
+		return false;
+	} // end of wireCollidesAlongSpan method
+
+	/**
 	 * Create new editor.
 	 * 
 	 * @param pane The tabbed pane this editor is in.
@@ -3217,12 +3272,15 @@ public abstract class SimpleEditor extends JPanel {
 
 							// wires hanging off a moved wire end, or off a
 							// wire end attached to one of sel's puts, must
-							// not land on other wire ends anywhere along
-							// their span; these checks depend only on sel
+							// not land on other wire ends or sweep across
+							// stationary elements anywhere along their span
+							// (wireCollidesAlongSpan; the element predicate
+							// is the same one the reverse drag direction
+							// uses); these checks depend only on sel
 							if (sel instanceof WireEnd) {
 								WireEnd end = (WireEnd)sel;
 								for (Wire wire : end.getWires()) {
-									if (wireLandsOnWireEnd(sel,wire)) {
+									if (wireCollidesAlongSpan(circuit,selected,sel,wire)) {
 										overlapMessage = "overlap";
 										untouchAll();
 										return true;
@@ -3232,7 +3290,7 @@ public abstract class SimpleEditor extends JPanel {
 							for (Put p : sel.getAllPuts()) {
 								if (p.isAttached()) {
 									Wire wire = p.getWireEnd().getOnlyWire();
-									if (wireLandsOnWireEnd(sel,wire)) {
+									if (wireCollidesAlongSpan(circuit,selected,sel,wire)) {
 										overlapMessage = "overlap";
 										untouchAll();
 										return true;
@@ -3637,34 +3695,6 @@ public abstract class SimpleEditor extends JPanel {
 						put.setTouching(true);
 						touchedPuts.add(put);
 					} // end of touch method
-
-					/**
-					 * See if a wire attached to a selected element has been
-					 * dragged onto some wire end along its span. Queries the
-					 * spatial index around the wire's own bounds (#3, #17).
-					 *
-					 * @param sel The selected element the wire hangs off.
-					 * @param wire The wire to check.
-					 *
-					 * @return true if the wire lands on a wire end.
-					 */
-					private boolean wireLandsOnWireEnd(Element sel, Wire wire) {
-
-						Rectangle span = wire.getIndexBounds();
-						span.grow(JLSInfo.pointDiameter,JLSInfo.pointDiameter);
-						for (Element elm : circuit.elementsNear(span)) {
-							if (sel == elm)
-								continue;
-							if (!(elm instanceof WireEnd)) {
-								continue;
-							}
-							WireEnd otherEnd = (WireEnd)elm;
-							if (wire.touches(otherEnd)) {
-								return true;
-							}
-						}
-						return false;
-					} // end of wireLandsOnWireEnd method
 
 					/**
 					 * Copy all selected elements to the clipboard.

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -1821,8 +1821,10 @@ public abstract class SimpleEditor extends JPanel {
 					// if left button...
 					if (leftButton) {
 
-						// see if cursor is on an element
-						for (Element el : circuit.getElements()) {
+						// see if cursor is on an element, asking the spatial
+						// index for the few elements near the cursor instead
+						// of scanning the whole circuit (#3, #17)
+						for (Element el : circuit.elementsAt(x,y)) {
 							if (el.contains(x,y)) {
 
 								// do nothing if editor is disabled
@@ -1872,8 +1874,9 @@ public abstract class SimpleEditor extends JPanel {
 					// if right button show menu
 					else if (rightButton) {
 
-						// see if cursor is on an element
-						for (Element el : circuit.getElements()) {
+						// see if cursor is on an element, via the spatial
+						// index as in the left-button path (#3, #17)
+						for (Element el : circuit.elementsAt(x,y)) {
 							if (el.contains(x,y)) {
 
 								// can't display menu on attached wire end
@@ -2187,8 +2190,9 @@ public abstract class SimpleEditor extends JPanel {
 
 				if (currentState == State.idle && rightButton) {
 
-					// see if cursor is on an element
-					for (Element el : circuit.getElements()) {
+					// see if cursor is on an element, via the spatial index
+					// as in mousePressed (#3, #17)
+					for (Element el : circuit.elementsAt(x,y)) {
 						if (el.contains(x,y)) {
 
 							// can't display menu on attached wire end
@@ -3428,6 +3432,10 @@ public abstract class SimpleEditor extends JPanel {
 						// check every element in the selected set
 						for (Element sel : selected) {
 
+							// whether this element actually made a connection
+							// (only then can the index have gone stale)
+							boolean connected = false;
+
 							// check against every element near the selection
 							// (grown so edge-touching put alignments are
 							// included), as in overlap() (#3, #17)
@@ -3455,6 +3463,7 @@ public abstract class SimpleEditor extends JPanel {
 											// wire end to wire end
 											WireEnd otherEnd = (WireEnd)el;
 											WireEnd endLeft = connect(end,otherEnd);
+											connected = true;
 											if (currentState == State.startwire) {
 												wireEnd = endLeft;
 												net = endLeft.getNet();
@@ -3466,6 +3475,7 @@ public abstract class SimpleEditor extends JPanel {
 											// wire end to wire
 											Wire wire = (Wire)el;
 											WireEnd it = connect(end,wire);
+											connected = true;
 											if (currentState == State.startwire) {
 												wireEnd = it;
 												net = it.getNet();
@@ -3491,6 +3501,7 @@ public abstract class SimpleEditor extends JPanel {
 												continue;
 											}
 											connect(end,put);
+											connected = true;
 											ok = true;
 										}
 									}
@@ -3526,6 +3537,7 @@ public abstract class SimpleEditor extends JPanel {
 											}
 
 											connect(end,put);
+											connected = true;
 											ok = true;
 										}
 									}
@@ -3556,6 +3568,7 @@ public abstract class SimpleEditor extends JPanel {
 
 											// put to put
 											connect(p1,p2);
+											connected = true;
 										}
 									}
 								}
@@ -3563,8 +3576,13 @@ public abstract class SimpleEditor extends JPanel {
 
 							// connections made for this element may have
 							// moved wires and merged ends; rebuild before
-							// the next element queries the index
-							circuit.invalidateIndex();
+							// the next element queries the index. When
+							// nothing connected, nothing moved, so the
+							// common no-connection drop stays O(selected)
+							// instead of paying a rebuild per element
+							if (connected) {
+								circuit.invalidateIndex();
+							}
 						}
 
 						// add any new wires created by connecting puts to puts

--- a/test/jls/DrawCullingParityTest.java
+++ b/test/jls/DrawCullingParityTest.java
@@ -1,0 +1,150 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.Element;
+
+/**
+ * Parity tests for index-driven draw culling (issues #3, #17): repaints
+ * enumerate clip candidates through the spatial index instead of scanning
+ * every element, so a dirty-region repaint during a drag costs O(visible),
+ * not O(circuit). The contract: for any clip, the index query (clip padded
+ * by the draw margin) plus the exact mayBeVisible predicate accepts exactly
+ * the elements a full scan would, so the pixels drawn are unchanged.
+ */
+class DrawCullingParityTest {
+
+	/** Deterministic seed: failures must reproduce. */
+	private static final long SEED = 20260717L;
+
+	/** Mirrors Circuit's draw margin (labels drawn outside bounds). */
+	private static final int MARGIN = 8 * JLSInfo.spacing;
+
+	/** Mirrors Circuit.mayBeVisible: the exact culling predicate. */
+	private static boolean mayBeVisible(Element el, Rectangle clip) {
+
+		Rectangle b = el.getIndexBounds();
+		b.grow(MARGIN, MARGIN);
+		return b.intersects(clip);
+	}
+
+	/**
+	 * For any clip, filtering index candidates (clip grown by the margin)
+	 * with the exact predicate must select the same elements as filtering
+	 * the whole circuit -- including after drag-style moves keep the index
+	 * current incrementally.
+	 */
+	@Test
+	void culledCandidatesMatchFullScan() throws Exception {
+
+		Circuit circuit = SpatialIndexTest.loadWired();
+		Random random = new Random(SEED);
+
+		for (int round = 0; round < 10; round += 1) {
+			for (int i = 0; i < 200; i += 1) {
+				Rectangle clip = new Rectangle(random.nextInt(700) - 50,
+						random.nextInt(400) - 50,
+						random.nextInt(300) + 1, random.nextInt(300) + 1);
+
+				Set<Element> expected = new HashSet<Element>();
+				for (Element el : circuit.getElements()) {
+					if (mayBeVisible(el, clip)) {
+						expected.add(el);
+					}
+				}
+
+				Rectangle query = new Rectangle(clip);
+				query.grow(MARGIN, MARGIN);
+				Set<Element> actual = new HashSet<Element>();
+				for (Element el : circuit.elementsNear(query)) {
+					if (mayBeVisible(el, clip)) {
+						actual.add(el);
+					}
+				}
+
+				assertEquals(expected, actual,
+						"culling must match full scan for clip " + clip);
+			}
+
+			// move a subset the way a drag does and re-check
+			Set<Element> moved = new HashSet<Element>();
+			for (Element el : circuit.getElements()) {
+				if (random.nextBoolean()) {
+					el.move(JLSInfo.spacing * (random.nextInt(5) - 2),
+							JLSInfo.spacing * (random.nextInt(5) - 2));
+					moved.add(el);
+				}
+			}
+			circuit.reindexAfterMove(moved);
+		}
+	}
+
+	/**
+	 * End-to-end pixel parity: drawing the circuit through many small
+	 * clipped draws (as dirty-region repaints do) must produce the same
+	 * image as one full-canvas draw. The circuit is a grid of constants
+	 * whose visuals do not overlap, so draw order within a layer cannot
+	 * affect pixels.
+	 */
+	@Test
+	void tiledClippedDrawsMatchFullDraw() throws Exception {
+
+		StringBuilder text = new StringBuilder("CIRCUIT grid\n");
+		int id = 0;
+		for (int gx = 0; gx < 8; gx += 1) {
+			for (int gy = 0; gy < 6; gy += 1) {
+				text.append("ELEMENT Constant\n int id ").append(id++)
+					.append("\n int x ").append(180 + gx * 48)
+					.append("\n int y ").append(180 + gy * 48)
+					.append("\n int width 24\n int height 24\n Int value 1\n int base 10\n")
+					.append(" String orient \"RIGHT\"\nEND\n");
+			}
+		}
+		text.append("ENDCIRCUIT\n");
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(text.toString())));
+		assertTrue(circuit.finishLoad(null));
+
+		int width = 720;
+		int height = 600;
+		BufferedImage full = new BufferedImage(width, height,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = full.createGraphics();
+		g.setColor(Color.WHITE);
+		g.fillRect(0, 0, width, height);
+		circuit.draw(g, new HashSet<Element>(), null);
+		g.dispose();
+
+		BufferedImage tiled = new BufferedImage(width, height,
+				BufferedImage.TYPE_INT_RGB);
+		g = tiled.createGraphics();
+		g.setColor(Color.WHITE);
+		g.fillRect(0, 0, width, height);
+		int tile = 100;
+		for (int tx = 0; tx < width; tx += tile) {
+			for (int ty = 0; ty < height; ty += tile) {
+				g.setClip(tx, ty, tile, tile);
+				circuit.draw(g, new HashSet<Element>(), null);
+			}
+		}
+		g.dispose();
+
+		assertArrayEquals(
+				full.getRGB(0, 0, width, height, null, 0, width),
+				tiled.getRGB(0, 0, width, height, null, 0, width),
+				"tiled clipped draws must reproduce the full-canvas image");
+	}
+}

--- a/test/jls/ProofBridgeTest.java
+++ b/test/jls/ProofBridgeTest.java
@@ -1,0 +1,212 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.Element;
+
+/**
+ * The bridge between the machine-checked proofs in
+ * proofs/SpatialIndexCorrectness.agda and the Java implementation.
+ *
+ * The Agda development proves two theorems over an idealized model:
+ * query-parity (THEOREM 1: the grid query equals a brute-force
+ * boundsTouch scan) and culling-parity (THEOREM 2: index-driven draw
+ * culling selects exactly the elements a full mayBeVisible scan
+ * selects). Those theorems hold for the real code only if the model's
+ * assumptions (A1)-(A5) describe what the Java actually does -- each
+ * test here pins one assumption to the implementation, and is named
+ * after it. The theorem-level statements themselves are exercised
+ * end-to-end by SpatialIndexTest (THEOREM 1) and DrawCullingParityTest
+ * (THEOREM 2).
+ *
+ * Scope note: the model works in unbounded integers; the tests sample
+ * coordinates well inside int range, matching the editor's canvas
+ * coordinates (overflow is out of scope for both model and editor).
+ */
+class ProofBridgeTest {
+
+	/** Deterministic seed: failures must reproduce. */
+	private static final long SEED = 20260717L;
+
+	private static int cellSize() throws Exception {
+		Field cell = SpatialIndex.class.getDeclaredField("CELL");
+		cell.setAccessible(true);
+		return cell.getInt(null);
+	}
+
+	private static boolean boundsTouch(Rectangle a, Rectangle b)
+			throws Exception {
+		Method m = SpatialIndex.class.getDeclaredMethod("boundsTouch",
+				Rectangle.class, Rectangle.class);
+		m.setAccessible(true);
+		return (Boolean) m.invoke(null, a, b);
+	}
+
+	private static int drawMargin() throws Exception {
+		Field margin = Circuit.class.getDeclaredField("DRAW_MARGIN");
+		margin.setAccessible(true);
+		return margin.getInt(null);
+	}
+
+	private static boolean mayBeVisible(Element el, Rectangle clip)
+			throws Exception {
+		Method m = Circuit.class.getDeclaredMethod("mayBeVisible",
+				Element.class, Rectangle.class);
+		m.setAccessible(true);
+		return (Boolean) m.invoke(null, el, clip);
+	}
+
+	/**
+	 * (A1) Index intervals are non-empty: every element's index bounds
+	 * have non-negative width and height (the model's Ival.sane field),
+	 * and they stay that way as elements move the way a drag moves them.
+	 */
+	@Test
+	void a1IndexIntervalsAreNonEmpty() throws Exception {
+
+		Circuit circuit = SpatialIndexTest.loadWired();
+		Random random = new Random(SEED);
+		for (int round = 0; round < 20; round += 1) {
+			for (Element el : circuit.getElements()) {
+				Rectangle b = el.getIndexBounds();
+				assertTrue(b.width >= 0 && b.height >= 0,
+						"index bounds must be non-empty (A1): " + b + " for " + el);
+				if (random.nextBoolean()) {
+					el.move(JLSInfo.spacing * (random.nextInt(5) - 2),
+							JLSInfo.spacing * (random.nextInt(5) - 2));
+				}
+			}
+		}
+	}
+
+	/**
+	 * (A2) The cell function Math.floorDiv(_, CELL) is monotone -- the
+	 * only property of the bucketing the completeness proof
+	 * (query-complete) uses. Checked exhaustively on adjacent pairs
+	 * around zero (adjacent monotonicity implies monotonicity) and on
+	 * random ordered pairs, at the index's real cell size.
+	 */
+	@Test
+	void a2CellFunctionIsMonotone() throws Exception {
+
+		int cell = cellSize();
+		assertTrue(cell > 0, "cell size must be positive: " + cell);
+
+		for (int i = -5000; i < 5000; i += 1) {
+			assertTrue(Math.floorDiv(i, cell) <= Math.floorDiv(i + 1, cell),
+					"floorDiv must be monotone at " + i);
+		}
+
+		Random random = new Random(SEED + 1);
+		for (int trial = 0; trial < 10000; trial += 1) {
+			int i = random.nextInt(2_000_001) - 1_000_000;
+			int j = random.nextInt(2_000_001) - 1_000_000;
+			int lo = Math.min(i, j);
+			int hi = Math.max(i, j);
+			assertTrue(Math.floorDiv(lo, cell) <= Math.floorDiv(hi, cell),
+					"floorDiv must be monotone on (" + lo + "," + hi + ")");
+		}
+	}
+
+	/**
+	 * (A3) SpatialIndex.boundsTouch is the closed-interval overlap test
+	 * of the model (Touch, per axis): lo_a <= hi_b and lo_b <= hi_a on
+	 * both axes, counting zero-area contact. Sampled over random
+	 * rectangles including zero-width/height ones (wire spans, points).
+	 */
+	@Test
+	void a3BoundsTouchIsClosedIntervalOverlap() throws Exception {
+
+		Random random = new Random(SEED + 2);
+		for (int trial = 0; trial < 20000; trial += 1) {
+			Rectangle a = new Rectangle(random.nextInt(200) - 100,
+					random.nextInt(200) - 100, random.nextInt(40), random.nextInt(40));
+			Rectangle b = new Rectangle(random.nextInt(200) - 100,
+					random.nextInt(200) - 100, random.nextInt(40), random.nextInt(40));
+			boolean model = a.x <= b.x + b.width && b.x <= a.x + a.width
+					&& a.y <= b.y + b.height && b.y <= a.y + a.height;
+			assertEquals(model, boundsTouch(a, b),
+					"boundsTouch must match the model Touch for " + a + " vs " + b);
+		}
+	}
+
+	/**
+	 * (A4) java.awt semantics the culling model relies on:
+	 * Rectangle.grow(m,m) maps the interval [lo, hi] to [lo-m, hi+m] on
+	 * each axis, and Rectangle.intersects on non-degenerate rectangles
+	 * is the open-interval overlap test (Cross: strict inequalities).
+	 */
+	@Test
+	void a4AwtGrowAndIntersectsMatchModel() {
+
+		Random random = new Random(SEED + 3);
+		for (int trial = 0; trial < 20000; trial += 1) {
+			int x = random.nextInt(400) - 200;
+			int y = random.nextInt(400) - 200;
+			int w = random.nextInt(60);
+			int h = random.nextInt(60);
+			int m = random.nextInt(100);
+			Rectangle grown = new Rectangle(x, y, w, h);
+			grown.grow(m, m);
+			assertEquals(x - m, grown.x, "grow must move lo down by m");
+			assertEquals(y - m, grown.y, "grow must move lo down by m");
+			assertEquals(x + w + m, grown.x + grown.width,
+					"grow must move hi up by m");
+			assertEquals(y + h + m, grown.y + grown.height,
+					"grow must move hi up by m");
+
+			Rectangle a = new Rectangle(random.nextInt(200) - 100,
+					random.nextInt(200) - 100,
+					random.nextInt(40) + 1, random.nextInt(40) + 1);
+			Rectangle b = new Rectangle(random.nextInt(200) - 100,
+					random.nextInt(200) - 100,
+					random.nextInt(40) + 1, random.nextInt(40) + 1);
+			boolean cross = a.x < b.x + b.width && b.x < a.x + a.width
+					&& a.y < b.y + b.height && b.y < a.y + a.height;
+			assertEquals(cross, a.intersects(b),
+					"intersects must match the model Cross for " + a + " vs " + b);
+		}
+	}
+
+	/**
+	 * (A5) The draw margin is non-negative (the model needs 0 <= m to
+	 * keep the grown clip a valid interval), and Circuit.mayBeVisible
+	 * computes exactly the model's MayBeVisible: the element's index
+	 * bounds grown by the margin, strictly intersected with the clip.
+	 */
+	@Test
+	void a5DrawMarginAndMayBeVisibleMatchModel() throws Exception {
+
+		int m = drawMargin();
+		assertTrue(m >= 0, "draw margin must be non-negative: " + m);
+
+		Circuit circuit = SpatialIndexTest.loadWired();
+		Random random = new Random(SEED + 4);
+		for (int trial = 0; trial < 2000; trial += 1) {
+			Rectangle clip = new Rectangle(random.nextInt(900) - 150,
+					random.nextInt(600) - 150,
+					random.nextInt(300) + 1, random.nextInt(300) + 1);
+			for (Element el : circuit.getElements()) {
+				Rectangle b = el.getIndexBounds();
+				long loX = (long) b.x - m;
+				long hiX = (long) b.x + b.width + m;
+				long loY = (long) b.y - m;
+				long hiY = (long) b.y + b.height + m;
+				boolean model = loX < clip.x + (long) clip.width
+						&& clip.x < hiX
+						&& loY < clip.y + (long) clip.height
+						&& clip.y < hiY;
+				assertEquals(model, mayBeVisible(el, clip),
+						"mayBeVisible must match the model for " + b + " vs " + clip);
+			}
+		}
+	}
+}

--- a/test/jls/SpatialIndexTest.java
+++ b/test/jls/SpatialIndexTest.java
@@ -32,7 +32,7 @@ class SpatialIndexTest {
 	 * the editor, so the element set includes WireEnds and Wires (whose
 	 * index bounds are derived from their ends, not x/y/width/height).
 	 */
-	private static String wiredCircuitText() {
+	static String wiredCircuitText() {
 		StringBuilder text = new StringBuilder("CIRCUIT indexed\n");
 		int id = 0;
 		int constA = id++;
@@ -79,7 +79,7 @@ class SpatialIndexTest {
 			.append("END\n");
 	}
 
-	private static Circuit loadWired() throws Exception {
+	static Circuit loadWired() throws Exception {
 		Circuit circuit = new Circuit("");
 		assertTrue(circuit.load(new Scanner(wiredCircuitText())),
 				() -> "load failed: " + JLSInfo.loadError);

--- a/test/jls/edit/WireSweepSymmetryTest.java
+++ b/test/jls/edit/WireSweepSymmetryTest.java
@@ -1,0 +1,200 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.elem.Constant;
+import jls.elem.Element;
+import jls.elem.Wire;
+import jls.elem.WireEnd;
+
+/**
+ * Regression tests for the wire-drag collision asymmetry closed by
+ * SimpleEditor.wireCollidesAlongSpan.
+ *
+ * <p>Dragging an element into a wire body has always been an overlap:
+ * the main overlap() loop calls sel.intersects(wire), which line-tests
+ * the wire against the element's rectangle. But the wire-drag direction
+ * only checked the dragged wire ends and wire-end landings -- the wire
+ * BODY sweeping across a stationary element was never tested, so the
+ * same forbidden geometry (a wire crossing an element) could be created
+ * by dragging the wire but not by dragging the element.</p>
+ *
+ * <p>wireCollidesAlongSpan closes this with the exact predicate the
+ * reverse direction uses (elm.intersects(wire)), so the two directions
+ * cannot disagree; each test here asserts that agreement explicitly.
+ * Deliberately preserved behavior is pinned too: wire-over-wire
+ * crossings stay legal, a wire never collides with an element an end of
+ * it sits on (so attached wires do not collide with their own element),
+ * landing on a stationary wire end still flags, and elements moving
+ * rigidly with the selection are skipped.</p>
+ */
+class WireSweepSymmetryTest {
+
+	/** A circuit containing one Constant block at (240,120), 24x24. */
+	private static Circuit withConstant() throws Exception {
+		String text = "CIRCUIT sweep\n"
+				+ "ELEMENT Constant\n int id 0\n int x 240\n int y 120\n"
+				+ " int width 24\n int height 24\n Int value 1\n int base 10\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ENDCIRCUIT\n";
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(text)), "fixture must load");
+		assertTrue(circuit.finishLoad(null), "fixture must finish loading");
+		return circuit;
+	}
+
+	private static Constant constantIn(Circuit circuit) {
+		for (Element el : circuit.getElements()) {
+			if (el instanceof Constant) {
+				return (Constant) el;
+			}
+		}
+		throw new AssertionError("fixture has a Constant");
+	}
+
+	/** A dangling wire between two free ends, added to the circuit. */
+	private static Wire wire(Circuit circuit, int x1, int y1, int x2, int y2) {
+		WireEnd e1 = new WireEnd(circuit);
+		e1.setXY(x1, y1);
+		WireEnd e2 = new WireEnd(circuit);
+		e2.setXY(x2, y2);
+		Wire w = new Wire(e1, e2);
+		e1.addWire(w);
+		e2.addWire(w);
+		circuit.addElement(e1);
+		circuit.addElement(e2);
+		circuit.addElement(w);
+		return w;
+	}
+
+	private static Set<Element> endsOf(Wire w) {
+		Set<Element> selected = new HashSet<Element>();
+		WireEnd e1 = w.getEnd();
+		selected.add(e1);
+		selected.add(w.getOtherEnd(e1));
+		return selected;
+	}
+
+	/**
+	 * A wire body crossing a stationary element collides -- and by the
+	 * SAME verdict the reverse drag direction (element into wire) has
+	 * always produced.
+	 */
+	@Test
+	void wireSweepingAcrossElementCollidesLikeTheReverseDrag()
+			throws Exception {
+		Circuit circuit = withConstant();
+		Constant block = constantIn(circuit);
+		Wire w = wire(circuit, 180, 132, 324, 132); // crosses the block
+
+		boolean reverse = block.intersects(w);
+		boolean forward = SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(w), w.getEnd(), w);
+
+		assertTrue(reverse, "element dragged into the wire overlaps");
+		assertTrue(forward, "wire dragged across the element overlaps too");
+		assertEquals(reverse, forward, "the two drag directions must agree");
+	}
+
+	/**
+	 * A wire body clear of the element collides in neither direction.
+	 */
+	@Test
+	void clearWireCollidesInNeitherDirection() throws Exception {
+		Circuit circuit = withConstant();
+		Constant block = constantIn(circuit);
+		Wire w = wire(circuit, 180, 180, 324, 180); // passes below the block
+
+		boolean reverse = block.intersects(w);
+		boolean forward = SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(w), w.getEnd(), w);
+
+		assertFalse(reverse, "no overlap dragging the element");
+		assertFalse(forward, "no overlap dragging the wire");
+		assertEquals(reverse, forward, "the two drag directions must agree");
+	}
+
+	/**
+	 * Wires crossing wires stay legal: schematic wires cross freely
+	 * without connecting, in both directions before and after the fix.
+	 */
+	@Test
+	void wireCrossingWireStaysLegal() throws Exception {
+		Circuit circuit = new Circuit("crossings");
+		Wire horizontal = wire(circuit, 480, 132, 600, 132);
+		Wire vertical = wire(circuit, 540, 72, 540, 192); // crosses it
+
+		assertFalse(SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(vertical), vertical.getEnd(), vertical),
+				"dragging a wire across another wire is not an overlap");
+		assertFalse(SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(horizontal), horizontal.getEnd(), horizontal),
+				"nor from the other wire's point of view");
+	}
+
+	/**
+	 * A wire hanging off an element (an end on or inside the element's
+	 * rectangle, as attached wires are) does not collide with that
+	 * element -- Wire.intersects excludes wires whose endpoint the
+	 * rectangle contains, in both drag directions alike.
+	 */
+	@Test
+	void wireHangingOffAnElementDoesNotCollideWithIt() throws Exception {
+		Circuit circuit = withConstant();
+		Constant block = constantIn(circuit);
+		Wire w = wire(circuit, 252, 132, 360, 132); // end inside the block
+
+		boolean reverse = block.intersects(w);
+		boolean forward = SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(w), w.getEnd(), w);
+
+		assertFalse(reverse, "an element ignores wires ending on it");
+		assertFalse(forward, "and the wire ignores the element it hangs off");
+		assertEquals(reverse, forward, "the two drag directions must agree");
+	}
+
+	/**
+	 * The pre-existing wire-end landing check is preserved: a wire body
+	 * dragged onto a stationary free wire end still collides.
+	 */
+	@Test
+	void landingOnAStationaryWireEndStillCollides() throws Exception {
+		Circuit circuit = new Circuit("landing");
+		Wire w = wire(circuit, 660, 132, 780, 132);
+		WireEnd stationary = new WireEnd(circuit);
+		stationary.setXY(720, 132); // mid-span
+		circuit.addElement(stationary);
+
+		assertTrue(SimpleEditor.wireCollidesAlongSpan(circuit,
+				endsOf(w), w.getEnd(), w),
+				"a wire dragged onto a stationary wire end overlaps");
+	}
+
+	/**
+	 * Elements in the moving selection are skipped: they move rigidly
+	 * with the wire, exactly as the main overlap() candidate loop skips
+	 * them, so a group drag does not collide with itself.
+	 */
+	@Test
+	void elementsMovingWithTheSelectionAreSkipped() throws Exception {
+		Circuit circuit = withConstant();
+		Constant block = constantIn(circuit);
+		Wire w = wire(circuit, 180, 132, 324, 132); // crosses the block
+
+		Set<Element> selected = endsOf(w);
+		selected.add(block); // the block moves with the wire
+
+		assertFalse(SimpleEditor.wireCollidesAlongSpan(circuit,
+				selected, w.getEnd(), w),
+				"a selected element moving with the wire is not an overlap");
+	}
+}

--- a/test/jls/elem/HollowVsFilledCollisionTest.java
+++ b/test/jls/elem/HollowVsFilledCollisionTest.java
@@ -1,0 +1,260 @@
+package jls.elem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Rectangle;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.JLSInfo;
+
+/**
+ * Collision semantics of a hollow square drawn with four wires versus a
+ * filled square container element (a SubCircuit block), through the
+ * exact predicate the drag overlap check uses --
+ * {@link Element#intersects(Element)}, as called by
+ * SimpleEditor.overlap() on each dragged element against its spatial
+ * index candidates (#3, #17).
+ *
+ * The contract under test:
+ *
+ *  - a square OUTLINE of wires collides only on its edges: an element
+ *    dropped in the hollow interior overlaps nothing, an element
+ *    crossing an edge overlaps that wire, and an element covering a
+ *    corner overlaps the corner's WireEnd (wires deliberately exclude
+ *    their endpoints, so corner contact is attributed to the end);
+ *
+ *  - a square CONTAINER element collides across its whole filled area,
+ *    interior included, because every non-wire element's collision
+ *    surface is its bounding rectangle;
+ *
+ *  - the spatial index shortlists by bounding box only (THEOREM 1 in
+ *    proofs/SpatialIndexCorrectness.agda: candidates are a superset,
+ *    the exact predicate decides). For axis-aligned wires the boxes
+ *    are thin bands, so the hollow interior is not even a candidate;
+ *    for a diagonal wire the box covers area the wire does not, and
+ *    the exact predicate is what rejects the non-collision.
+ */
+class HollowVsFilledCollisionTest {
+
+	private static final int S = JLSInfo.spacing; // 12
+
+	/** A rectangular probe element standing in for a dragged selection. */
+	private static SubCircuit probe(int x, int y, int w, int h) {
+		SubCircuit p = new SubCircuit(null);
+		p.setXY(x, y);
+		p.width = w;
+		p.height = h;
+		return p;
+	}
+
+	private WireEnd endA, endB, endC, endD;      // square corners
+	private Wire top, right, bottom, left;       // square edges
+	private WireEnd diagE1, diagE2;              // a separate diagonal wire
+	private Wire diag;
+	private SubCircuit container;                // the filled square block
+	private Circuit circuit;
+
+	/**
+	 * corners A(120,120) B(216,120) C(216,216) D(120,216); container at
+	 * x 360..456, y 120..216; diagonal wire (480,120)-(576,216). All far
+	 * enough apart that candidate sets below are exact.
+	 */
+	private void build() {
+		circuit = new Circuit("hollowVsFilled");
+
+		endA = corner(120, 120);
+		endB = corner(216, 120);
+		endC = corner(216, 216);
+		endD = corner(120, 216);
+		top = edge(endA, endB);
+		right = edge(endB, endC);
+		bottom = edge(endC, endD);
+		left = edge(endD, endA);
+
+		container = probe(360, 120, 8 * S, 8 * S);
+		circuit.addElement(container);
+
+		diagE1 = corner(480, 120);
+		diagE2 = corner(576, 216);
+		diag = edge(diagE1, diagE2);
+	}
+
+	private WireEnd corner(int x, int y) {
+		WireEnd end = new WireEnd(circuit);
+		end.setXY(x, y);
+		circuit.addElement(end);
+		return end;
+	}
+
+	private Wire edge(WireEnd e1, WireEnd e2) {
+		Wire wire = new Wire(e1, e2);
+		e1.addWire(wire);
+		e2.addWire(wire);
+		circuit.addElement(wire);
+		return wire;
+	}
+
+	/**
+	 * An element well inside the wire square's hollow overlaps none of
+	 * the four wires and none of the corners -- and the hollow's center
+	 * point is contained by nothing, so hover finds nothing there either.
+	 */
+	@Test
+	void hollowInteriorDoesNotCollide() {
+		build();
+		SubCircuit inside = probe(156, 156, 2 * S, 2 * S);
+
+		for (Wire wire : new Wire[] { top, right, bottom, left }) {
+			assertFalse(inside.intersects(wire),
+					"interior probe must not collide with an outline wire");
+		}
+		for (WireEnd end : new WireEnd[] { endA, endB, endC, endD }) {
+			assertFalse(inside.intersects(end),
+					"interior probe must not collide with a corner end");
+		}
+		for (Element el : circuit.getElements()) {
+			assertFalse(el.contains(168, 168),
+					"nothing may claim the hollow center point: " + el);
+		}
+	}
+
+	/**
+	 * An element crossing one edge of the square collides with exactly
+	 * that wire.
+	 */
+	@Test
+	void edgeCrossingCollidesWithThatWireOnly() {
+		build();
+		SubCircuit acrossTop = probe(150, 108, 2 * S, 2 * S);
+
+		assertTrue(acrossTop.intersects(top),
+				"probe across the top edge must collide with the top wire");
+		assertFalse(acrossTop.intersects(right), "right edge is far away");
+		assertFalse(acrossTop.intersects(bottom), "bottom edge is far away");
+		assertFalse(acrossTop.intersects(left), "left edge is far away");
+	}
+
+	/**
+	 * An element covering a corner collides with the corner's WireEnd,
+	 * not with the wires: Wire.intersects deliberately excludes its
+	 * endpoints, so corner contact is the end's to report. (In the drag
+	 * paths that end IS part of the collision surface -- a corner drop
+	 * is still flagged, just attributed to the end.)
+	 */
+	@Test
+	void cornerCollisionIsAttributedToTheWireEnd() {
+		build();
+		SubCircuit onCorner = probe(108, 108, 2 * S, 2 * S);
+
+		assertTrue(onCorner.intersects(endA),
+				"probe on the corner must collide with the corner end");
+		assertFalse(onCorner.intersects(top),
+				"wires exclude their endpoints: corner is not the top wire's");
+		assertFalse(onCorner.intersects(left),
+				"wires exclude their endpoints: corner is not the left wire's");
+	}
+
+	/**
+	 * The container element is filled: the same interior placement that
+	 * is legal inside the wire square collides inside the block, and the
+	 * block's center point is contained (hover would find it).
+	 */
+	@Test
+	void containerInteriorDoesCollide() {
+		build();
+		SubCircuit inside = probe(396, 156, 2 * S, 2 * S);
+
+		assertTrue(inside.intersects(container),
+				"a probe inside the container block must collide");
+		assertTrue(container.intersects(inside),
+				"and symmetrically from the container's side");
+		assertTrue(container.contains(408, 168),
+				"the container contains its center point");
+	}
+
+	/**
+	 * The filled-square semantics above are structural, not incidental:
+	 * SubCircuit takes its whole collision surface (intersects/contains/
+	 * getRect) unmodified from Element, like every non-wire element. If
+	 * an override ever appears, this test flags that the hollow-vs-filled
+	 * contract needs re-examination.
+	 */
+	@Test
+	void containerCollisionSurfaceIsTheInheritedRectangle()
+			throws Exception {
+		assertEquals(Element.class,
+				SubCircuit.class.getMethod("intersects", Element.class)
+						.getDeclaringClass(),
+				"SubCircuit must inherit Element.intersects");
+		assertEquals(Element.class,
+				SubCircuit.class.getMethod("contains", int.class, int.class)
+						.getDeclaringClass(),
+				"SubCircuit must inherit Element.contains");
+		assertEquals(Element.class,
+				SubCircuit.class.getMethod("getRect").getDeclaringClass(),
+				"SubCircuit must inherit Element.getRect");
+	}
+
+	/**
+	 * The index-vs-predicate division of labor (THEOREM 1's shape) on
+	 * these exact fixtures. Axis-aligned outline wires have thin bounding
+	 * bands, so the hollow interior yields NO candidates at all -- the
+	 * index never even shortlists the square for an interior drop. An
+	 * edge placement shortlists exactly the crossed wire. A corner
+	 * placement shortlists the two adjacent wires and the corner end,
+	 * and the exact predicate then rejects the wires (endpoint
+	 * exclusion) while keeping the end.
+	 */
+	@Test
+	void indexShortlistsMatchOutlineGeometry() {
+		build();
+
+		assertEquals(Set.of(),
+				circuit.elementsNear(probe(156, 156, 2 * S, 2 * S).getRect()),
+				"hollow interior must produce no candidates");
+
+		assertEquals(Set.of(top),
+				circuit.elementsNear(probe(150, 108, 2 * S, 2 * S).getRect()),
+				"edge placement must shortlist exactly the crossed wire");
+
+		Set<Element> corner = circuit
+				.elementsNear(probe(108, 108, 2 * S, 2 * S).getRect());
+		assertEquals(Set.of(top, left, endA), corner,
+				"corner placement must shortlist adjacent wires and the end");
+	}
+
+	/**
+	 * A diagonal wire is where bounding boxes over-approximate: its box
+	 * covers the whole square between its endpoints, so a probe in the
+	 * off-diagonal region IS a candidate -- and the exact predicate is
+	 * what rejects the collision. Candidate supersets plus exact
+	 * predicates are precisely the contract THEOREM 1 (query-parity)
+	 * verifies; this pins the concrete case where they differ.
+	 */
+	@Test
+	void diagonalWireIsCandidateButNotCollisionOffTheDiagonal() {
+		build();
+		SubCircuit offDiagonal = probe(552, 132, 2 * S, 2 * S);
+
+		Set<Element> candidates = new HashSet<Element>(
+				circuit.elementsNear(offDiagonal.getRect()));
+		assertTrue(candidates.contains(diag),
+				"the diagonal wire's bounding box makes it a candidate");
+		assertFalse(offDiagonal.intersects(diag),
+				"but the exact predicate rejects the off-diagonal placement");
+
+		Rectangle onPath = new Rectangle(516, 144, 2 * S, 2 * S);
+		SubCircuit onDiagonal = probe(onPath.x, onPath.y, onPath.width,
+				onPath.height);
+		assertTrue(circuit.elementsNear(onPath).contains(diag),
+				"an on-diagonal placement is also a candidate");
+		assertTrue(onDiagonal.intersects(diag),
+				"and the exact predicate confirms the collision");
+	}
+}


### PR DESCRIPTION
A review of the drag-and-drop path after the spatial-index work found
three places still paying whole-circuit costs:

- Circuit.draw culled against the clip by scanning every element, so
  the dirty-region repaint issued by every drag event was O(circuit)
  no matter how small the region. Candidates now come from the spatial
  index (clip padded by the label margin mayBeVisible allows), with
  the exact mayBeVisible predicate unchanged, making a drag event's
  repaint O(visible + moved).
- The mousePressed/mouseReleased idle hit-tests (drag pickup and the
  context menu) scanned every element; they now ask the index for the
  few elements near the cursor, with the same contains() predicate.
- connect() invalidated the index after *every* selected element on
  drop, so dropping S elements cost S full rebuilds even when nothing
  connected. The rebuild now happens only after an element actually
  made a connection (only then can geometry have changed); the common
  no-connection drop no longer rebuilds at all.

With these, a drag event costs O(moved + local density) end to end --
move, incremental reindex, overlap checks, and repaint -- which is
the output-sensitive optimum: work proportional to what moved and
what it can collide with. Gesture endpoints keep their one O(N) pass
(full repaint, removeCoLinear, lazy rebuild on state transition),
once per gesture by design.

DrawCullingParityTest pins the new culling: index-filtered candidates
equal a full mayBeVisible scan across randomized clips and drag-style
moves, and tiling a canvas with clipped draws reproduces the exact
pixels of one full-canvas draw.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VeF164yJkDKTz7CxpwmqgA