### PR TITLE
Land the remaining cleanup from PR #5: drop leftover duplicate input.close() calls

### DIFF
--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -164,7 +164,6 @@ public class JLSStart extends JFrame implements ChangeListener {
 						+ " is not a valid circuit file: " + JLSInfo.loadError);
 				System.exit(1);
 			}
-			input.close();
 
 			// finish up load
 			try {
@@ -273,7 +272,6 @@ public class JLSStart extends JFrame implements ChangeListener {
 						+ " is not a valid circuit file: " + JLSInfo.loadError);
 				System.exit(1);
 			}
-			input.close();
 
 			// finish up load
 			try {


### PR DESCRIPTION
## What & why

Salvages the still-applicable piece of @AmityWilder's #5 onto current master. That PR correctly diagnosed the save-to-opened-file bug back in February; its core fix later landed independently via #34 (`590f124`), the improved save-error dialog message arrived with the `TellUser`/`FileAbstractor` refactors, and the Makefile/.gitignore changes were superseded by the Maven + Nix build. The one remnant master still carried was the duplicated unconditional `input.close()` in both command-line load paths of `JLSStart` — a later refactor moved the close ahead of the `loadOK` check but left the original trailing close behind. This drops the second close so each `Scanner` is closed exactly once. Amy is credited as co-author on the commit.

Closes #5

## Testing

No behavior change to pin — closing an already-closed `Scanner` is a no-op, so this is purely cleanup. Full suite run locally on JDK 25: `mvn test` green, 398 tests, 0 failures (2 skipped for missing external HDL toolchains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsCdD8B7xvL4A5VDyDLzWc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsCdD8B7xvL4A5VDyDLzWc)_