### PR TITLE
Test-coverage program + library adoptions (31% → 55% line)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,25 @@ jobs:
           cache: maven
 
       # External HDL simulators activate the otherwise-skipped
-      # Verilog/VHDL validation tests (issue #60); best-effort so a
-      # transient apt failure doesn't block the build
-      - name: Install HDL simulators
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends iverilog ghdl || echo "HDL simulators unavailable; validation tests will skip"
+      # Verilog/VHDL validation tests (issue #60); xvfb activates the
+      # display-tagged UI suite (issue #162). Best-effort so a
+      # transient apt failure doesn't block the build - each affected
+      # suite skips itself when its tool is missing
+      - name: Install HDL simulators and virtual display
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends iverilog ghdl xvfb || echo "some optional tools unavailable; their tests will skip"
 
       # Compiles with -Xlint:deprecation,removal,unchecked -Werror, runs
       # the headless test suite, and runs the SpotBugs check goal
       # (threshold High, baseline in config/spotbugs-exclude.xml).
+      # Under xvfb the display-tagged surefire execution also runs
+      # (issue #162); the main test execution stays headless either way.
       - name: Build, lint, and analyze
-        run: mvn -B verify
+        run: |
+          if command -v xvfb-run >/dev/null; then
+            xvfb-run -a mvn -B verify -Djls.test.headless=false
+          else
+            mvn -B verify
+          fi
 
       - name: Upload jar
         if: matrix.java == 25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ All notable changes to JLS are documented here. The format follows
   the same circuit produces byte-identical SVG across runs and load
   instances (elements draw in a stable geometric order, not HashSet
   order), so SVG goldens and reproducible-builds expectations hold.
+- Executable architecture rules (#155): ArchUnit 1.4.2 (test scope
+  only, nothing ships in the jar) checks the compiled bytecode for
+  the invariants the source-scan ratchets state - only `TellUser`
+  touches `JOptionPane` (#81), HDL internals are wired only from the
+  CLI (#60), and `jls.sim` must not depend on `jls.edit` (#77, with
+  the three existing simulator classes pinned as a shrinking
+  baseline). New violations fail `mvn test` immediately.
 - Seeded generative fuzzing of the save/load pair (#160), dependency
   free: `GenerativeRoundTripFuzzTest` drives random circuits (element
   mix, boundary bit widths, escape-space names, wired pin pairs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Vector circuit image export (#154): `-i out.svg` writes the circuit
+  as resolution-independent SVG through the same element paint path
+  the PNG/JPEG export uses, via JFreeSVG (GPLv3, same license as JLS,
+  ~50 KB, no transitive dependencies). Exports are deterministic -
+  the same circuit produces byte-identical SVG across runs and load
+  instances (elements draw in a stable geometric order, not HashSet
+  order), so SVG goldens and reproducible-builds expectations hold.
 - Seeded generative fuzzing of the save/load pair (#160), dependency
   free: `GenerativeRoundTripFuzzTest` drives random circuits (element
   mix, boundary bit widths, escape-space names, wired pin pairs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Per-element simulation goldens with a completeness ratchet (#158):
+  every simulating palette element now has a behavioral pin -
+  Adder (sum/carry sweep), Decoder (one-hot), Extend, Mux, the
+  barrel shifter's three kinds, TruthTable (rows and don't-cares),
+  Binder/Splitter range routing, JumpStart/JumpEnd, SigGen and Stop
+  join the existing gate/memory/sequential goldens. Expected values
+  are computed independently of the implementation. A reflective
+  ratchet fails the build when a palette element has neither a
+  golden nor a commented exemption, so the gap cannot reopen.
+  Detection power was verified the issue's way: a hand-mutated Mux
+  select decode passes the entire pre-existing suite (40 tests) and
+  fails the new golden precisely.
+- CLI subprocess coverage (#159): the JaCoCo agent now rides into
+  the JVMs the CLI suites spawn, so JLSStart's exercised paths are
+  measured (4.7% -> 25.5% line on its own). The coverage ratchet
+  floors rose from 17.5%/18.0% (set 2026-07-08) to 34.5%
+  instruction / 34.0% line, plus a first 32.5% BRANCH floor
+  (measured: 35.58% / 34.99% / 33.46%).
 - Vector circuit image export (#154): `-i out.svg` writes the circuit
   as resolution-independent SVG through the same element paint path
   the PNG/JPEG export uses, via JFreeSVG (GPLv3, same license as JLS,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to JLS are documented here. The format follows
   CLI (#60), and `jls.sim` must not depend on `jls.edit` (#77, with
   the three existing simulator classes pinned as a shrinking
   baseline). New violations fail `mvn test` immediately.
+- An opt-in `errorprone` Maven profile (#157):
+  `mvn -Perrorprone clean compile` runs Error Prone 2.50.0's default
+  checks over the build. The trial verdict (no default-build gate;
+  the plumbing waits for #93 NullAway) is recorded in
+  `docs/library-survey-2026-07.md`.
 - Seeded generative fuzzing of the save/load pair (#160), dependency
   free: `GenerativeRoundTripFuzzTest` drives random circuits (element
   mix, boundary bit widths, escape-space names, wired pin pairs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,21 @@ All notable changes to JLS are documented here. The format follows
   Graphics2D. Plus direct tests for the clipboard copy machinery
   (`Util.copy`/`partition`, including partial-selection pruning),
   the pure Util helpers, and Memory's file-based initialization.
+- The display-test substrate (#162): a `display`-tagged surefire
+  execution, headless (self-skipping) by default and run for real
+  under `xvfb-run -a mvn -B verify -Djls.test.headless=false`, which
+  CI now does. First tenant: `DialogConstructionSmokeTest`, which
+  constructs all 24 element create/edit dialog families through the
+  editor's real `setup()` entry and dismisses each through the
+  close-box cancel path. The bulk of the suite stays headless in its
+  own execution either way (with a display present, `TellUser` turns
+  interactive, so mixing the two would let a stray warning block a
+  test on a modal dialog).
 - The coverage ratchet floors rose twice from 17.5%/18.0% (set
   2026-07-08): first to 34.5% instruction / 34.0% line with a first
-  32.5% BRANCH floor, then to 42.0% / 40.0% / 36.5% (measured:
-  42.65% / 40.88% / 37.21%).
+  32.5% BRANCH floor, then to 42.0% / 40.0% / 36.5% (measured
+  headless: 42.65% / 40.88% / 37.21%; under the display substrate
+  the same commit measures 51.13% / 48.85% / 38.26%).
 - Vector circuit image export (#154): `-i out.svg` writes the circuit
   as resolution-independent SVG through the same element paint path
   the PNG/JPEG export uses, via JFreeSVG (GPLv3, same license as JLS,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Fixed
+- Printing a freshly loaded circuit containing a truth table no longer
+  crashes with a NullPointerException: `TruthTable.print` assumed the
+  table's display panel had been built by the edit dialog, which is
+  only true after the dialog has been opened once in the session. The
+  panel is now built lazily at print time. Found by the new print-path
+  smoke test.
 - A Memory whose initial-contents text names addresses at or past the
   declared capacity no longer saves a file JLS itself refuses to load
   (#160): such text is accepted leniently at load (zeros assumed at
@@ -32,10 +38,20 @@ All notable changes to JLS are documented here. The format follows
   fails the new golden precisely.
 - CLI subprocess coverage (#159): the JaCoCo agent now rides into
   the JVMs the CLI suites spawn, so JLSStart's exercised paths are
-  measured (4.7% -> 25.5% line on its own). The coverage ratchet
-  floors rose from 17.5%/18.0% (set 2026-07-08) to 34.5%
-  instruction / 34.0% line, plus a first 32.5% BRANCH floor
-  (measured: 35.58% / 34.99% / 33.46%).
+  measured (4.7% -> 25.5% line on its own).
+- Headless draw- and print-path smoke coverage (#91 layer 1, #162):
+  every palette element (including a nested SubCircuit) draws on
+  both export canvases - raster and SVG - with a reflective
+  completeness sweep keeping the fixture honest; every page the
+  print Book collects (circuit, state machine and its output
+  summary, truth table, nested subcircuit) renders into a
+  Graphics2D. Plus direct tests for the clipboard copy machinery
+  (`Util.copy`/`partition`, including partial-selection pruning),
+  the pure Util helpers, and Memory's file-based initialization.
+- The coverage ratchet floors rose twice from 17.5%/18.0% (set
+  2026-07-08): first to 34.5% instruction / 34.0% line with a first
+  32.5% BRANCH floor, then to 42.0% / 40.0% / 36.5% (measured:
+  42.65% / 40.88% / 37.21%).
 - Vector circuit image export (#154): `-i out.svg` writes the circuit
   as resolution-independent SVG through the same element paint path
   the PNG/JPEG export uses, via JFreeSVG (GPLv3, same license as JLS,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,23 @@ All notable changes to JLS are documented here. The format follows
 - The display-test substrate (#162): a `display`-tagged surefire
   execution, headless (self-skipping) by default and run for real
   under `xvfb-run -a mvn -B verify -Djls.test.headless=false`, which
-  CI now does. First tenant: `DialogConstructionSmokeTest`, which
-  constructs all 24 element create/edit dialog families through the
-  editor's real `setup()` entry and dismisses each through the
-  close-box cancel path. The bulk of the suite stays headless in its
-  own execution either way (with a display present, `TellUser` turns
-  interactive, so mixing the two would let a stray warning block a
-  test on a modal dialog).
+  CI now does. Tenants:
+  - `DialogConstructionSmokeTest` constructs all 24 element
+    create/edit dialog families through the editor's real `setup()`
+    entry and dismisses each through the close-box cancel path.
+  - `EditorGestureTest` (#91 layer 2, #84 safety net) drives the
+    SimpleEditor mouse state machine with synthetic events - move,
+    rubber-band select, right-click delete, undo/redo - and asserts
+    the resulting circuit model. Synthetic `MouseEvent` dispatch, not
+    `Robot`: the move/select/menu paths read `event.getX()/getY()`,
+    so the whole suite runs deterministically in ~1.3 s. Because it
+    touches only surfaces that survive the #84 decomposition (canvas
+    events, popup item texts, the circuit model), it is the
+    characterization safety net for that refactor.
+  The bulk of the suite stays headless in its own execution either
+  way (with a display present, `TellUser` turns interactive, so
+  mixing the two would let a stray warning block a test on a modal
+  dialog).
 - The coverage ratchet floors rose twice from 17.5%/18.0% (set
   2026-07-08): first to 34.5% instruction / 34.0% line with a first
   32.5% BRANCH floor, then to 42.0% / 40.0% / 36.5% (measured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ All notable changes to JLS are documented here. The format follows
 
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
+### Fixed
+- A Memory whose initial-contents text names addresses at or past the
+  declared capacity no longer saves a file JLS itself refuses to load
+  (#160): such text is accepted leniently at load (zeros assumed at
+  simulation start, as before), but the save path re-encoded it as an
+  `initrle` attribute whose loader enforces the capacity bound. The
+  RLE encoder now falls back to the raw `init` encoding for
+  out-of-capacity addresses. Found by the new generative fuzzer on
+  its second seed.
+
 ### Added
+- Seeded generative fuzzing of the save/load pair (#160), dependency
+  free: `GenerativeRoundTripFuzzTest` drives random circuits (element
+  mix, boundary bit widths, escape-space names, wired pin pairs)
+  through the save → load → save fixed point and asserts truncated
+  saves classify cleanly; `ContainerMutationFuzzTest` bit-flips,
+  truncates, splices and corrupts valid text/zip/XZ containers and
+  asserts every outcome is a classified `LoadError`, never an escaped
+  exception. Failures reproduce from printed seeds.
 - Opt-in plain-text saves (#129): the Save As dialog offers a
   plain-text file type, and the new `-savetext out.jls circuit.jls`
   flag rewrites an existing circuit file uncompressed. Plain-text

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
   list, including batch mode (`-b`), test-input files (`-t`), simulation time
   limits (`-d`), VCD waveform export (`-vcd`, for GTKWave/Surfer and
   autograders), image export (`-i`, PNG named after the circuit file by
-  default, or pass an output path such as `-i out.jpg` for JPEG),
+  default, or pass an output path such as `-i out.jpg` for JPEG or
+  `-i out.svg` for resolution-independent SVG — the right format for
+  slides, lab reports and hosted docs),
   Verilog export (`-export out.v circuit.jls` writes the drawn circuit
   as a structural Verilog-2005 module — a deployment bridge, not an HDL
   tutorial; note JLS's two-state-plus-HiZ semantics),

--- a/docs/library-survey-2026-07.md
+++ b/docs/library-survey-2026-07.md
@@ -132,8 +132,23 @@ FlatLaf #153, JFreeSVG #154, ArchUnit #155, picocli #156, Error Prone
 
 ## Recommended — test/build scope only (not distributed)
 
-### 4. ArchUnit — executable architecture rules
+### 4. ArchUnit — executable architecture rules *(ADOPTED, #155)*
 
+- **Verdict (2026-07-17):** adopted at 1.4.2, core artifact only — the
+  `archunit-junit5` integration pins a junit-platform line that would
+  fight the JUnit 6 dependency, and plain `@Test` methods calling
+  `ArchRule.check()` need no integration. JDK 25 bytecode imports fine.
+  `ArchitectureRulesTest` lands three rules: the bytecode half of the
+  #81 TellUser discipline (passes clean), jls.hdl reachable only via
+  the JLSStart wiring point (passes clean), and jls.sim ↛ jls.edit with
+  the three simulator classes pinned as a shrinking baseline (the #77
+  debt, now machine-enforced instead of prose). Cost measured: ~2.5 s
+  added to the test run, all in the one-time class-file import. The
+  source-scan ratchets stay alongside: they see comments and would
+  catch a use ArchUnit can't see (reflection), while ArchUnit catches
+  fully-qualified references the text scan misses — complementary, not
+  redundant. Future recorded decisions should get a rule here as their
+  tripwire.
 - **What:** [ArchUnit](https://github.com/TNG/ArchUnit), Apache-2.0,
   v1.4.2 (April 2026). Test-scope; runs as ordinary JUnit tests.
 - **Overlap:** JLS already enforces architectural invariants with

--- a/docs/library-survey-2026-07.md
+++ b/docs/library-survey-2026-07.md
@@ -170,7 +170,26 @@ FlatLaf #153, JFreeSVG #154, ArchUnit #155, picocli #156, Error Prone
 - **Cost:** one test dependency; the existing bespoke ratchet tests can
   be ported incrementally or left alongside.
 
-### 5. Error Prone — compile-time bug pattern checks *(optional)*
+### 5. Error Prone — compile-time bug pattern checks *(TRIALED, #157: plumbing kept opt-in; no default-build gate)*
+
+- **Verdict (2026-07-17):** the trial run happened (2.50.0 on the JDK 25
+  build, default check set, full `src/` compile). Result: **zero
+  ERROR-severity findings and zero true bugs** among 99 warnings —
+  52 MissingOverride (style), 24 PatternMatchingInstanceof (useful, but
+  exactly the #95 sealed-dispatch program's job), 8 InvalidParam
+  (javadoc drift), 5 JdkObsolete (the Vector/LinkedList holdouts #94
+  and #96 already track), and singletons that are benign or false
+  positives (both ReferenceEquality hits are *intentional* identity
+  comparisons of wire ends in `Element.touches`). Compile time 6 s →
+  22 s. The survey's own bar was "keep only if the first report pays
+  for the setup" — it did not: SpotBugs at threshold High had already
+  taken the real bugs off the table. **Decision:** no `-Werror` gate
+  and no baseline apparatus for EP core; but the compiler plumbing
+  (the `errorprone` Maven profile: forked javac, `--add-exports`,
+  processor path) stays in-tree as the ready-made substrate for #93 —
+  NullAway is an Error Prone plugin and was the strategic reason to
+  wire this at all. `mvn -Perrorprone clean compile` reproduces the
+  report at any time.
 
 - **What:** [Error Prone](https://github.com/google/error-prone)
   (Google), Apache-2.0, a javac plugin (build-time only; requires

--- a/docs/library-survey-2026-07.md
+++ b/docs/library-survey-2026-07.md
@@ -74,8 +74,20 @@ FlatLaf #153, JFreeSVG #154, ArchUnit #155, picocli #156, Error Prone
   dialogs (the `test/jls/ui` layer-1 assertions are layout-independent
   and should survive).
 
-### 2. JFreeSVG — vector image export
+### 2. JFreeSVG — vector image export *(ADOPTED, #154)*
 
+- **Verdict (2026-07-17):** adopted at 5.0.7. The spike went exactly as
+  predicted — `SVGGraphics2D` slotted into `Circuit.exportImage` with no
+  per-element changes, and `-i out.svg` works end to end. One finding the
+  survey missed: SVG serializes *draw order* into the output, and the
+  element set is a `HashSet`, so a naive drop-in was byte-unstable across
+  load instances (the render-path twin of the #166 save-order problem).
+  The export now draws in a stable geometric order and `SvgExportTest`
+  pins byte-identical output across fresh loads. Text stays as SVG
+  `<text>` elements (smaller, selectable, and the font-metrics caveat is
+  the same one that already rules out pixel goldens); no golden of the
+  full document for that reason — determinism plus structural assertions
+  instead.
 - **What:** [JFreeSVG](https://github.com/jfree/jfreesvg) (jfree.org),
   **GPLv3** — the same license as JLS, so no compatibility question at
   all. Tiny (~50 KB), zero dependencies, requires Java 11+.

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,10 @@
                Raised 2026-07-17 (issues #158/#159/#160: element
                simulation goldens, generative fuzzing, CLI-subprocess
                agent propagation): INSTRUCTION 35.58%, LINE 34.99%,
-               and a first BRANCH floor at measured 33.46%. -->
+               and a first BRANCH floor at measured 33.46%.
+               Raised again same day (draw/print-path smoke, Util and
+               Memory-file coverage): INSTRUCTION 42.65%, LINE 40.88%,
+               BRANCH 37.21%. -->
           <execution>
             <id>coverage-ratchet</id>
             <phase>verify</phase>
@@ -226,17 +229,17 @@
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.345</minimum>
+                      <minimum>0.420</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.340</minimum>
+                      <minimum>0.400</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.325</minimum>
+                      <minimum>0.365</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,18 @@
       <version>6.1.2</version>
       <scope>test</scope>
     </dependency>
+    <!-- executable architecture rules (issue #155): bytecode-level
+         dependency checks complementing the source-scan ratchets.
+         Deliberately the core artifact, not archunit-junit5: the
+         junit5 integration pins a junit-platform version that would
+         fight the JUnit 6 line above, and plain @Test methods calling
+         ArchRule.check() need no integration -->
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <version>1.4.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
       <artifactId>xz</artifactId>
       <version>1.12</version>
     </dependency>
+    <!-- vector circuit image export: -i out.svg (issue #154). GPLv3,
+         same license as JLS; ~50 KB, zero transitive dependencies -->
+    <dependency>
+      <groupId>org.jfree</groupId>
+      <artifactId>org.jfree.svg</artifactId>
+      <version>5.0.7</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,15 @@
          wall-clock time, so the same commit rebuilds byte-identically;
          bump it alongside the version when cutting a release (#44) -->
     <project.build.outputTimestamp>2026-07-16T00:00:00Z</project.build.outputTimestamp>
+    <!-- the display-tagged suite (issue #162) runs in its own surefire
+         execution with this property controlling java.awt.headless:
+         true (default) makes it self-skip; CI and local runs execute it
+         under a real or virtual display with
+           xvfb-run -a mvn -B verify -Djls.test.headless=false
+         The shared headless execution never sees a display either way -
+         with one present, TellUser turns interactive and a stray
+         warning in an unrelated test would block on a modal dialog. -->
+    <jls.test.headless>true</jls.test.headless>
   </properties>
 
   <dependencies>
@@ -178,11 +187,31 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.6</version>
-        <configuration>
-          <!-- tests exercise load/save and element construction without a
-               display; @{argLine} lets the JaCoCo agent attach (#66) -->
-          <argLine>@{argLine} -Djava.awt.headless=true</argLine>
-        </configuration>
+        <executions>
+          <execution>
+            <!-- the bulk of the suite: load/save, simulation, element
+                 construction - all without a display; @{argLine} lets
+                 the JaCoCo agent attach (#66) -->
+            <id>default-test</id>
+            <configuration>
+              <argLine>@{argLine} -Djava.awt.headless=true</argLine>
+              <excludedGroups>display</excludedGroups>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- the display-tagged suite (issue #162): dialog
+                 construction and other tests that need a real or
+                 virtual display; see the jls.test.headless property -->
+            <id>display-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <argLine>@{argLine} -Djava.awt.headless=${jls.test.headless}</argLine>
+              <groups>display</groups>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <!-- coverage report on every test run: target/site/jacoco
@@ -214,7 +243,14 @@
                and a first BRANCH floor at measured 33.46%.
                Raised again same day (draw/print-path smoke, Util and
                Memory-file coverage): INSTRUCTION 42.65%, LINE 40.88%,
-               BRANCH 37.21%. -->
+               BRANCH 37.21%.
+               The floors are pinned to the *headless* measurement so a
+               plain mvn verify passes anywhere; under the #162 display
+               substrate (xvfb-run ... -Djls.test.headless=false, which
+               CI uses) the same commit measures higher - 51.13%
+               instruction / 48.85% line / 38.26% branch on
+               2026-07-17 - because the dialog-construction suite runs
+               too. Raise the floors from headless numbers only. -->
           <execution>
             <id>coverage-ratchet</id>
             <phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,11 @@
                slightly below measured coverage to absorb JDK jitter;
                a PR that raises coverage should also raise the floor to
                just below the new measurement (issue #66).
-               Baseline 2026-07-08: INSTRUCTION 18.04%, LINE 18.44%. -->
+               Baseline 2026-07-08: INSTRUCTION 18.04%, LINE 18.44%.
+               Raised 2026-07-17 (issues #158/#159/#160: element
+               simulation goldens, generative fuzzing, CLI-subprocess
+               agent propagation): INSTRUCTION 35.58%, LINE 34.99%,
+               and a first BRANCH floor at measured 33.46%. -->
           <execution>
             <id>coverage-ratchet</id>
             <phase>verify</phase>
@@ -222,12 +226,17 @@
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.175</minimum>
+                      <minimum>0.345</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.180</minimum>
+                      <minimum>0.340</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.325</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -301,4 +301,56 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Error Prone trial gate (issue #157): opt-in AST-level bug
+         patterns complementing SpotBugs' bytecode pass. Run with
+           mvn -Perrorprone clean compile
+         Deliberately a profile, not the default build: the default
+         build is -Werror and adopting Error Prone there needs the
+         baseline-or-fix pass recorded in the issue. NullAway (#93)
+         would ride this same plumbing. -->
+    <profile>
+      <id>errorprone</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.15.0</version>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.self="override">
+                <!-- keep the lints but not -Werror: the trial measures
+                     the report, it does not gate yet -->
+                <arg>-Xlint:deprecation,removal,unchecked</arg>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>--should-stop=ifError=FLOW</arg>
+                <arg>-Xplugin:ErrorProne</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.50.0</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -247,10 +247,13 @@
                The floors are pinned to the *headless* measurement so a
                plain mvn verify passes anywhere; under the #162 display
                substrate (xvfb-run ... -Djls.test.headless=false, which
-               CI uses) the same commit measures higher - 51.13%
-               instruction / 48.85% line / 38.26% branch on
-               2026-07-17 - because the dialog-construction suite runs
-               too. Raise the floors from headless numbers only. -->
+               CI uses) the same commit measures higher - 57.88%
+               instruction / 55.47% line / 44.19% branch on
+               2026-07-17 - because the dialog-construction and
+               editor-gesture suites run too. That substrate number
+               crossing 50% line is the milestone that gates PIT
+               mutation testing (#161). Raise the floors from headless
+               numbers only. -->
           <execution>
             <id>coverage-ratchet</id>
             <phase>verify</phase>

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1357,6 +1357,58 @@ public class Circuit implements Printable {
 		rect = new Rectangle(rect.x - border, rect.y - border, rect.width + 2
 				* border, rect.height + 2 * border);
 
+		// vector export (issue #154): the same element paint path that
+		// fills a bitmap below draws into JFreeSVG's Graphics2D instead,
+		// so .svg output needs no per-element work
+		if (file.toLowerCase(java.util.Locale.ROOT).endsWith(".svg")) {
+			org.jfree.svg.SVGGraphics2D svg =
+					new org.jfree.svg.SVGGraphics2D(rect.width, rect.height);
+			// a fixed defs prefix keeps two exports of the same circuit
+			// byte-identical (the default prefix is instance-derived)
+			svg.setDefsKeyPrefix("jls");
+			AffineTransform svgTranslate = new AffineTransform();
+			svgTranslate.translate(-rect.x, -rect.y);
+			svg.setTransform(svgTranslate);
+			svg.setColor(Color.white);
+			svg.fill(rect);
+			// draw in a deterministic order: elements live in a
+			// HashSet, and while raster export doesn't care (same
+			// pixels either way, overlaps aside), SVG serializes the
+			// draw order into the file - an unstable order would break
+			// byte-identical goldens across load instances. Wires
+			// under non-wires, like the interactive draw path.
+			java.util.List<Element> wireLayer = new java.util.ArrayList<Element>();
+			java.util.List<Element> partLayer = new java.util.ArrayList<Element>();
+			for (Element el : elements) {
+				(el instanceof jls.elem.Wire ? wireLayer : partLayer).add(el);
+			}
+			// order on index bounds, not x/y: wires keep x/y at their
+			// defaults, but their bounds are derived from their ends
+			java.util.Comparator<Element> drawOrder = java.util.Comparator
+					.comparingInt((Element el) -> el.getIndexBounds().x)
+					.thenComparingInt(el -> el.getIndexBounds().y)
+					.thenComparingInt(el -> el.getIndexBounds().width)
+					.thenComparingInt(el -> el.getIndexBounds().height)
+					.thenComparing(el -> el.getClass().getName())
+					.thenComparingInt(Element::getID);
+			wireLayer.sort(drawOrder);
+			partLayer.sort(drawOrder);
+			for (Element el : wireLayer) {
+				el.draw(svg);
+			}
+			for (Element el : partLayer) {
+				el.draw(svg);
+			}
+			try {
+				java.nio.file.Files.writeString(java.nio.file.Path.of(file),
+						svg.getSVGDocument(),
+						java.nio.charset.StandardCharsets.UTF_8);
+			} finally {
+				svg.dispose();
+			}
+			return;
+		}
+
 		// set up image
 		BufferedImage image = new BufferedImage(rect.width, rect.height,
 				BufferedImage.TYPE_INT_RGB);

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -575,7 +575,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 		new FlagSpec("b", Arity.NONE, null, null,
 				"run in batch (headless) mode"),
 		new FlagSpec("i", Arity.OPTIONAL, "imagefile", "an image file",
-				"export an image of the circuit (default circuit_file.png; use .jpg/.jpeg for JPEG)"),
+				"export an image of the circuit (default circuit_file.png; use .jpg/.jpeg for JPEG, .svg for SVG)"),
 		new FlagSpec("s", Arity.REQUIRED, "file", "a startup file",
 				"startup parameter file"),
 		new FlagSpec("t", Arity.REQUIRED, "file", "a test file",
@@ -613,7 +613,8 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 	/**
 	 * Whether a file name names a supported image output format:
-	 * .png, .jpg or .jpeg, case-insensitive (issue #71).
+	 * .png, .jpg or .jpeg (issue #71), or .svg (issue #154),
+	 * case-insensitive.
 	 *
 	 * @param name The file name to check.
 	 *
@@ -623,7 +624,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		String lower = name.toLowerCase(java.util.Locale.ROOT);
 		return lower.endsWith(".png") || lower.endsWith(".jpg")
-				|| lower.endsWith(".jpeg");
+				|| lower.endsWith(".jpeg") || lower.endsWith(".svg");
 	} // end of isImageFileName method
 
 	/**
@@ -747,7 +748,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 			JLSInfo.imgexport = true;
 			if (opnd != null) {
 				if (!isImageFileName(opnd)) {
-					usageError("option -i output file must end in .png, .jpg or .jpeg: "
+					usageError("option -i output file must end in .png, .jpg, .jpeg or .svg: "
 							+ opnd);
 				}
 				imageFile = opnd;

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -424,8 +424,18 @@ public class Element {
 	} // end of setHightlight method
 
 	/**
+	 * Whether this element is currently drawn highlighted (selected).
+	 *
+	 * @return true if highlighted.
+	 */
+	public boolean isHighlighted() {
+
+		return highlight;
+	} // end of isHighlighted method
+
+	/**
 	 * Set id of this element (for file save).
-	 * 
+	 *
 	 * @param id The id.
 	 */
 	public void setID(int id) {

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -369,7 +369,8 @@ public class Memory extends LogicElement {
 		// long runs of identical words; save those run-length encoded
 		// (#21). Text with comments or hand formatting keeps the raw
 		// encoding so it round-trips exactly. The loader accepts both.
-		String rle = encodeInitRLE(initialValue);
+		String rle = encodeInitRLE(initialValue,
+				Math.min(capacity, MAX_INIT_WORDS));
 		if (rle != null && rle.length() < initialValue.length()) {
 			output.println(" String initrle \"" + rle + "\"");
 		} else {
@@ -397,6 +398,25 @@ public class Memory extends LogicElement {
 	 */
 	static String encodeInitRLE(String text) {
 
+		return encodeInitRLE(text, MAX_INIT_WORDS);
+	} // end of encodeInitRLE method
+
+	/**
+	 * Encode with an explicit address bound. Addresses at or past the
+	 * bound keep the raw encoding: the raw form is loaded leniently
+	 * (out-of-range init falls back to zeros with a warning at
+	 * simulation start), but the RLE decoder rejects such addresses at
+	 * load, so encoding them would save a file the loader refuses to
+	 * read back - a save/load fixed-point violation found by the
+	 * generative fuzzer (issue #160).
+	 *
+	 * @param text The initial-memory text.
+	 * @param maxWords Upper bound on encoded addresses (exclusive).
+	 *
+	 * @return the encoded form, or null to use the raw encoding.
+	 */
+	static String encodeInitRLE(String text, long maxWords) {
+
 		if (text.isEmpty()) {
 			return null;
 		}
@@ -420,7 +440,7 @@ public class Memory extends LogicElement {
 			} catch (NumberFormatException ex) {
 				return null;
 			}
-			if (addr < 0) {
+			if (addr < 0 || addr >= maxWords) {
 				return null;
 			}
 			addrs.add(addr);

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -428,6 +428,13 @@ public final class TruthTable extends LogicElement implements Printable {
 		// use better graphics
 		Graphics2D gg = (Graphics2D)g;
 
+		// the display panel is otherwise created only when the edit
+		// dialog opens, so printing a freshly loaded circuit crashed
+		// here with an NPE (found by PrintPathSmokeTest, issue #91)
+		if (disp == null) {
+			disp = new DisplayBool(this);
+		}
+
 		// construct name
 		Circuit c = circuit;
 		String nm = name + " in " + circuit.getName();

--- a/test/jls/ArchitectureRulesTest.java
+++ b/test/jls/ArchitectureRulesTest.java
@@ -1,0 +1,101 @@
+package jls;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Executable architecture rules (issue #155). The in-tree ratchets
+ * scan source text (NotificationRatchetTest, HeadlessCoreRatchetTest);
+ * these rules check the compiled bytecode, which catches what a text
+ * scan cannot - fully qualified references without an import,
+ * dependencies created by field/method signatures - and cannot be
+ * fooled by mentions in comments or strings.
+ *
+ * Rules that already hold are zero-tolerance. Rules with standing
+ * violations pin the exact offender list as a shrinking baseline,
+ * the same pattern HeadlessCoreRatchetTest documents: never add a
+ * name, delete names as they are cleaned, and when the list is empty
+ * collapse the rule to zero-tolerance.
+ */
+class ArchitectureRulesTest {
+
+	private static JavaClasses classes;
+
+	@BeforeAll
+	static void importCompiledClasses() {
+		// target/classes is where surefire's classpath points anyway;
+		// importing once keeps the per-rule cost to milliseconds
+		classes = new ClassFileImporter()
+				.importPath("target/classes");
+	}
+
+	/**
+	 * The bytecode half of the issue #81 reporter discipline: only
+	 * TellUser may touch JOptionPane. NotificationRatchetTest enforces
+	 * the same rule on source text (and so also polices comments that
+	 * would normalize new uses); this one catches a fully qualified
+	 * javax.swing.JOptionPane.showMessageDialog(...) that never
+	 * imports the class.
+	 */
+	@Test
+	void onlyTellUserDependsOnJOptionPane() {
+		noClasses()
+				.that().doNotHaveFullyQualifiedName("jls.TellUser")
+				.should().dependOnClassesThat()
+				.haveFullyQualifiedName("javax.swing.JOptionPane")
+				.because("every user notification flows through the"
+						+ " headless-aware TellUser reporter (issue #81)")
+				.check(classes);
+	}
+
+	/**
+	 * The HDL emitters are internal to jls.hdl; the one sanctioned
+	 * consumer outside the package is the CLI wiring point in
+	 * JLSStart, which instantiates the emitter chosen by the output
+	 * file extension (issue #60). Element classes must not grow
+	 * direct emitter knowledge - per-element HDL text lives behind
+	 * the exporter walk.
+	 */
+	@Test
+	void hdlInternalsAreOnlyWiredFromTheCli() {
+		noClasses()
+				.that().resideOutsideOfPackage("jls.hdl..")
+				.and().doNotHaveFullyQualifiedName("jls.JLSStart")
+				.should().dependOnClassesThat()
+				.resideInAPackage("jls.hdl..")
+				.because("HDL export is reached through the JLSStart"
+						+ " wiring point only (issue #60)")
+				.check(classes);
+	}
+
+	/**
+	 * The headless-core direction (issue #77): the simulation engine
+	 * must not depend on the editor. This does not hold yet - the
+	 * simulator base class and both concrete simulators reach into
+	 * jls.edit today, which is exactly the debt #77 records. The
+	 * baseline below pins the offenders; anything new in jls.sim
+	 * picking up an editor dependency fails immediately.
+	 */
+	@Test
+	void onlyTheKnownDebtInSimDependsOnEdit() {
+		// the name pattern covers the classes' anonymous/nested
+		// classes too - they compile from the same source files
+		noClasses()
+				.that().resideInAPackage("jls.sim..")
+				.and().haveNameNotMatching(
+						"jls\\.sim\\.(Simulator|InteractiveSimulator|"
+						+ "BatchSimulator)(\\$.*)?")
+				.should().dependOnClassesThat()
+				.resideInAPackage("jls.edit..")
+				.because("the simulation engine belongs to the headless"
+						+ " core (issue #77); the three named classes are"
+						+ " the recorded debt - shrink the list, never"
+						+ " grow it")
+				.check(classes);
+	}
+}

--- a/test/jls/CircuitTextBuilder.java
+++ b/test/jls/CircuitTextBuilder.java
@@ -241,6 +241,138 @@ public final class CircuitTextBuilder {
 		return id;
 	}
 
+	/** Puts: "address", "CS", "OE" (+"WE", "input" for RAM), "output". */
+	public int memory(String type, int bits, int capacity, String init) {
+		int id = nextId++;
+		open("Memory", id)
+				.append(" String name \"mem").append(id).append("\"\n")
+				.append(" String type \"").append(type).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int cap ").append(capacity).append('\n')
+				.append(" int time 10\n")
+				.append(" int watch 0\n")
+				.append(" String file \"\"\n")
+				.append(" String init \"").append(init).append("\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Clocked register; type "nff" (negative edge) or "pff". */
+	public int register(int bits, long init, String type) {
+		int id = nextId++;
+		open("Register", id)
+				.append(" String name \"reg").append(id).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" Int init ").append(init).append('\n')
+				.append(" String orient \"RIGHT\"\n")
+				.append(" int delay 8\n")
+				.append(" String type \"").append(type).append("\"\n")
+				.append(" int watch 1\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Value display; put "input". */
+	public int display(int bits, int base) {
+		int id = nextId++;
+		open("Display", id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int base ").append(base).append('\n')
+				.append("END\n");
+		return id;
+	}
+
+	/** Decorative annotation; no puts. */
+	public int text(String content) {
+		int id = nextId++;
+		open("Text", id)
+				.append(" String text \"").append(content).append("\"\n")
+				.append(" String fn \"Dialog\"\n int fs 12\n")
+				.append(" int bold 0\n int ital 0\n int color -16777216\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Pauses the interactive simulator; puts "input0".."input3". */
+	public int pause() {
+		int id = nextId++;
+		open("Pause", id).append("END\n");
+		return id;
+	}
+
+	/** Puts: "input", "control", "output"; control perpendicular. */
+	public int triState(int bits) {
+		int id = nextId++;
+		open("TriState", id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int delay 10\n")
+				.append(" String Gorient \"UP\"\n")
+				.append(" String Corient \"LEFT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/**
+	 * One-state machine driving output signal z with the given value on
+	 * every clock edge (the SequentialGoldenTest fixture shape).
+	 * Puts: "clock" and the output signal name "z".
+	 */
+	public int stateMachine(long zValue, int zBits) {
+		int id = nextId++;
+		open("StateMachine", id)
+				.append(" String name \"sm").append(id).append("\"\n")
+				.append(" int delay 5\n int trig 0\n")
+				.append(" String state \"S\"\n")
+				.append("  int x 40\n  int y 40\n  int diameter 40\n")
+				.append("  int init 1\n")
+				.append("  String output \"z\"\n   long value ").append(zValue)
+				.append("\n   int bits ").append(zBits).append('\n')
+				.append("  String trans \"always\"\n   String next \"S\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/**
+	 * Subcircuit block wrapping a one-wire passthrough inner circuit
+	 * (input pin "a" wired to output pin "y"). The block's puts take
+	 * the inner pins' names: "a" (input) and "y" (output).
+	 */
+	public int subCircuit(String name) {
+		int id = nextId++;
+		text.append("ELEMENT SubCircuit\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append(" int id ").append(id).append('\n')
+				.append(" int x ").append(60 + 24 * id).append('\n')
+				.append(" int y 60\n int width 48\n int height 48\n")
+				.append(" String name \"").append(name).append("\"\n")
+				.append("CIRCUIT inner\n")
+				.append("ELEMENT InputPin\n")
+				.append(" int id 0\n int x 60\n int y 60\n")
+				.append(" int width 48\n int height 24\n")
+				.append(" String name \"a\"\n int bits 1\n int watch 0\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append("END\n")
+				.append("ELEMENT OutputPin\n")
+				.append(" int id 1\n int x 240\n int y 60\n")
+				.append(" int width 48\n int height 24\n")
+				.append(" String name \"y\"\n int bits 1\n int watch 0\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append("END\n")
+				.append("ELEMENT WireEnd\n")
+				.append(" int id 2\n int x 120\n int y 60\n")
+				.append(" int width 8\n int height 8\n")
+				.append(" String put \"output\"\n ref attach 0\n ref wire 3\n")
+				.append("END\n")
+				.append("ELEMENT WireEnd\n")
+				.append(" int id 3\n int x 180\n int y 60\n")
+				.append(" int width 8\n int height 8\n")
+				.append(" String put \"input\"\n ref attach 1\n ref wire 2\n")
+				.append("END\n")
+				.append("ENDCIRCUIT\n")
+				.append("END\n");
+		return id;
+	}
+
 	public int clock(int cycle, int one) {
 		int id = nextId++;
 		open("Clock", id)

--- a/test/jls/CircuitTextBuilder.java
+++ b/test/jls/CircuitTextBuilder.java
@@ -1,0 +1,278 @@
+package jls;
+
+/**
+ * Builds circuit text in the on-disk save format, for behavioral tests
+ * that load through the real loader and run the real simulator. This is
+ * the shared extraction of the private CircuitBuilder inside
+ * BatchSimulationGoldenTest (issue #158 method step 1); new golden
+ * suites build on this one, and the older in-test builders can migrate
+ * here as they are touched.
+ *
+ * Wire ends are attached by element id + put name exactly as the editor
+ * saves them. Every factory returns the new element's id for wiring.
+ */
+public final class CircuitTextBuilder {
+
+	private final StringBuilder text = new StringBuilder("CIRCUIT golden\n");
+	private int nextId = 0;
+
+	/** Start an ELEMENT block with the shared position header. */
+	private StringBuilder open(String type, int id) {
+		return text.append("ELEMENT ").append(type).append('\n')
+				.append(" int id ").append(id).append('\n')
+				.append(" int x ").append(60 + 24 * id).append('\n')
+				.append(" int y ").append(60 + 12 * (id % 8)).append('\n')
+				.append(" int width 24\n int height 24\n");
+	}
+
+	public int constant(long value) {
+		int id = nextId++;
+		open("Constant", id)
+				.append(" Int value ").append(value).append('\n')
+				.append(" int base 10\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	public int gate(String type, int bits, int numInputs) {
+		int id = nextId++;
+		open(type, id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int numInputs ").append(numInputs).append('\n')
+				.append(" String orientation \"right\"\n")
+				.append(" int delay 10\n")
+				.append("END\n");
+		return id;
+	}
+
+	public int inputPin(String name, int bits) {
+		int id = nextId++;
+		open("InputPin", id)
+				.append(" String name \"").append(name).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int watch 0\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	public int outputPin(String name, int bits) {
+		int id = nextId++;
+		open("OutputPin", id)
+				.append(" String name \"").append(name).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int watch 1\n")
+				.append(" String orient \"RIGHT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Puts: inputs "A", "B", "Cin" (1 bit); outputs "S", "Cout" (1 bit). */
+	public int adder(int bits) {
+		int id = nextId++;
+		open("Adder", id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" String orient \"UP\"\n")
+				.append(" int delay 12\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Puts: input "input" (bits wide), output "output" (2^bits wide). */
+	public int decoder(int bits) {
+		int id = nextId++;
+		open("Decoder", id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int delay 10\n")
+				.append(" String orient \"DOWN\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Puts: input "input0" (1 bit), output "output" (bits wide). */
+	public int extend(int bits) {
+		int id = nextId++;
+		open("Extend", id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int numInputs 1\n")
+				.append(" String orientation \"right\"\n")
+				.append(" int delay 0\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Puts: "input0".."inputN-1", "select", "output". */
+	public int mux(int inputs, int bits) {
+		int id = nextId++;
+		open("Mux", id)
+				.append(" int inputs ").append(inputs).append('\n')
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int delay 10\n")
+				.append(" String iOrient \"DOWN\"\n")
+				.append(" String sOrient \"LEFT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/**
+	 * Combinational barrel shifter (issue #122). Puts: "input" (bits),
+	 * "amount" (ceil log2 bits), "output" (bits). Kind is LogicalLeft,
+	 * LogicalRight or ArithmeticRight.
+	 */
+	public int shifter(String kind, int bits) {
+		int id = nextId++;
+		open("ShiftRegister", id)
+				.append(" String type \"").append(kind).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int delay 25\n")
+				.append(" String iOrient \"DOWN\"\n")
+				.append(" String sOrient \"LEFT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/**
+	 * Truth table. Puts are named by the signal names. The table is
+	 * rows x (inputs+outputs) cells; cell value 2 in an input column is
+	 * a don't-care.
+	 */
+	public int truthTable(String name, String[] inputNames,
+			String[] outputNames, int[][] table) {
+		int id = nextId++;
+		StringBuilder b = open("TruthTable", id)
+				.append(" String name \"").append(name).append("\"\n")
+				.append(" int delay 10\n")
+				.append(" int rows ").append(table.length).append('\n')
+				.append(" int cols ")
+				.append(inputNames.length + outputNames.length).append('\n');
+		for (String in : inputNames) {
+			b.append(" String input \"").append(in).append("\"\n");
+		}
+		for (String out : outputNames) {
+			b.append(" String output \"").append(out).append("\"\n");
+		}
+		for (int r = 0; r < table.length; r++) {
+			for (int c = 0; c < table[r].length; c++) {
+				b.append(" pair ").append(r).append(' ')
+						.append(table[r][c]).append('\n');
+			}
+		}
+		b.append("END\n");
+		return id;
+	}
+
+	/**
+	 * Binder: bundles range inputs into one output ("output"). Each
+	 * range is the list of bus bit indices it carries, highest first;
+	 * its put is named like "3-2" (contiguous) or "0" (single bit).
+	 */
+	public int binder(int bits, int[][] ranges) {
+		return group("Binder", bits, ranges);
+	}
+
+	/** Splitter: input "input", one output put per range. */
+	public int splitter(int bits, int[][] ranges) {
+		return group("Splitter", bits, ranges);
+	}
+
+	private int group(String type, int bits, int[][] ranges) {
+		int id = nextId++;
+		StringBuilder b = open(type, id)
+				.append(" int bits ").append(bits).append('\n')
+				.append(" String orient \"RIGHT\"\n")
+				.append(" String noncontig \"true\"\n")
+				.append(" int tristate 0\n");
+		for (int r = 0; r < ranges.length; r++) {
+			// the saved value order is meaningful: put names derive
+			// from it, and the editor stores range bits ascending -
+			// "pair 0 2, pair 0 3" names its put "3-2", while the
+			// reverse order names it "2, 3"
+			int[] bitsAscending = ranges[r].clone();
+			java.util.Arrays.sort(bitsAscending);
+			for (int bit : bitsAscending) {
+				b.append(" pair ").append(r).append(' ').append(bit)
+						.append('\n');
+			}
+		}
+		b.append("END\n");
+		return id;
+	}
+
+	/** Named wireless jump source; put "input". */
+	public int jumpStart(String name, int bits) {
+		int id = nextId++;
+		open("JumpStart", id)
+				.append(" String name \"").append(name).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" int watch 0\n")
+				.append(" String orientation \"RIGHT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Named wireless jump sink; put "output". */
+	public int jumpEnd(String name, int bits) {
+		int id = nextId++;
+		open("JumpEnd", id)
+				.append(" String name \"").append(name).append("\"\n")
+				.append(" int bits ").append(bits).append('\n')
+				.append(" String orientation \"LEFT\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/**
+	 * Signal generator driving named input pins over time. Grammar per
+	 * SigSim: "pin initial (for dur value | until t value)* end".
+	 */
+	public int sigGen(String signals) {
+		int id = nextId++;
+		open("SigGen", id)
+				.append(" String signals \"").append(signals).append("\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Stops the simulation when any attached 1-bit input is 1. */
+	public int stop() {
+		int id = nextId++;
+		open("Stop", id).append("END\n");
+		return id;
+	}
+
+	public int clock(int cycle, int one) {
+		int id = nextId++;
+		open("Clock", id)
+				.append(" int cycle ").append(cycle).append('\n')
+				.append(" int one ").append(one).append('\n')
+				.append(" String orient \"DOWN\"\n")
+				.append("END\n");
+		return id;
+	}
+
+	/** Wire fromElement's put to toElement's put, as two attached wire ends. */
+	public void wire(int fromElement, String fromPut, int toElement,
+			String toPut) {
+		int endA = nextId++;
+		int endB = nextId++;
+		wireEnd(endA, fromElement, fromPut, endB);
+		wireEnd(endB, toElement, toPut, endA);
+	}
+
+	private void wireEnd(int id, int attachTo, String put, int otherEnd) {
+		text.append("ELEMENT WireEnd\n")
+				.append(" int id ").append(id).append('\n')
+				.append(" int x ").append(12 * id).append('\n')
+				.append(" int y 480\n")
+				.append(" int width 8\n int height 8\n")
+				.append(" String put \"").append(put).append("\"\n")
+				.append(" ref attach ").append(attachTo).append('\n')
+				.append(" ref wire ").append(otherEnd).append('\n')
+				.append("END\n");
+	}
+
+	public String build() {
+		return text + "ENDCIRCUIT\n";
+	}
+}

--- a/test/jls/CliFlagTableTest.java
+++ b/test/jls/CliFlagTableTest.java
@@ -43,6 +43,7 @@ class CliFlagTableTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/CliImageExportTest.java
+++ b/test/jls/CliImageExportTest.java
@@ -50,6 +50,7 @@ class CliImageExportTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/CliImageExportTest.java
+++ b/test/jls/CliImageExportTest.java
@@ -148,6 +148,21 @@ class CliImageExportTest {
 	}
 
 	@Test
+	void svgOperandProducesAVectorImage() throws Exception {
+		// vector export (issue #154): same paint path, SVG output
+		writeCircuit("export.jls");
+		Result r = run("-i", "shot.svg", "export.jls");
+		assertEquals(0, r.exit, r.stderr);
+		File file = new File(tmp.toFile(), "shot.svg");
+		assertTrue(file.exists(), "shot.svg was not written");
+		String svg = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+		assertTrue(svg.contains("<svg"), "no <svg element in output");
+		assertTrue(svg.contains("</svg>"), "unterminated SVG document");
+		assertFalse(new File(tmp.toFile(), "export.png").exists(),
+				"the default output must not be written when a path is given");
+	}
+
+	@Test
 	void unsupportedImageExtensionIsAUsageError() throws Exception {
 		writeCircuit("export.jls");
 		Result r = run("-ishot.bmp", "export.jls");

--- a/test/jls/CliSmokeTest.java
+++ b/test/jls/CliSmokeTest.java
@@ -42,6 +42,7 @@ class CliSmokeTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/CliTextSaveTest.java
+++ b/test/jls/CliTextSaveTest.java
@@ -45,6 +45,7 @@ class CliTextSaveTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/ContainerMutationFuzzTest.java
+++ b/test/jls/ContainerMutationFuzzTest.java
@@ -1,0 +1,227 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Seeded byte-mutation fuzzing of the three on-disk container formats
+ * (issue #160). The hostile-input suite (issue #38) proves the loader
+ * rejects a handful of hand-built attacks; this harness asserts the
+ * broader contract from the LoadError taxonomy (issue #58) at
+ * pseudo-random points: whatever bytes are in the file, the
+ * format-sniffing open and the circuit load either succeed or classify
+ * the failure - they never let an exception escape, and every
+ * rejection publishes a structured LoadError.
+ *
+ * Deterministic seeds: failures must reproduce. Dependency-free by
+ * decision - jqwik was rejected under the active-maintenance policy
+ * (docs/library-survey-2026-07.md).
+ */
+class ContainerMutationFuzzTest {
+
+	/** Mutants per container format. */
+	private static final int MUTANTS = 150;
+
+	@TempDir
+	Path tmp;
+
+	/** A small but representative circuit: elements, a wire, escapes. */
+	private static final String CIRCUIT_TEXT = "CIRCUIT mutate\n"
+			+ "ELEMENT Constant\n"
+			+ " int id 0\n int x 60\n int y 60\n"
+			+ " int width 24\n int height 24\n"
+			+ " Int value 255\n int base 16\n"
+			+ " String orient \"RIGHT\"\n"
+			+ "END\n"
+			+ "ELEMENT Text\n"
+			+ " int id 1\n int x 60\n int y 120\n"
+			+ " int width 24\n int height 24\n"
+			+ " String text \"esc \\\\ \\\" \\n done\"\n"
+			+ "END\n"
+			+ "ELEMENT InputPin\n"
+			+ " int id 2\n int x 120\n int y 240\n"
+			+ " int width 48\n int height 24\n"
+			+ " String name \"src\"\n int bits 4\n int watch 0\n"
+			+ " String orient \"RIGHT\"\n"
+			+ "END\n"
+			+ "ELEMENT OutputPin\n"
+			+ " int id 3\n int x 480\n int y 240\n"
+			+ " int width 48\n int height 24\n"
+			+ " String name \"dst\"\n int bits 4\n int watch 0\n"
+			+ " String orient \"LEFT\"\n"
+			+ "END\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 4\n int x 168\n int y 252\n"
+			+ " int width 8\n int height 8\n"
+			+ " String put \"output\"\n ref attach 2\n ref wire 5\n"
+			+ "END\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 5\n int x 480\n int y 252\n"
+			+ " int width 8\n int height 8\n"
+			+ " String put \"input\"\n ref attach 3\n ref wire 4\n"
+			+ "END\n"
+			+ "ENDCIRCUIT\n";
+
+	/** Apply one random byte-level mutation. */
+	private static byte[] mutate(byte[] original, Random rng) {
+		byte[] bytes = Arrays.copyOf(original, original.length);
+		switch (rng.nextInt(5)) {
+		case 0: { // flip one bit
+			int at = rng.nextInt(bytes.length);
+			bytes[at] ^= (byte) (1 << rng.nextInt(8));
+			return bytes;
+		}
+		case 1: { // overwrite one byte with a random value
+			bytes[rng.nextInt(bytes.length)] = (byte) rng.nextInt(256);
+			return bytes;
+		}
+		case 2: { // truncate at a random point
+			return Arrays.copyOf(bytes, rng.nextInt(bytes.length));
+		}
+		case 3: { // insert a short burst of random bytes
+			int at = rng.nextInt(bytes.length);
+			byte[] burst = new byte[1 + rng.nextInt(16)];
+			rng.nextBytes(burst);
+			byte[] out = new byte[bytes.length + burst.length];
+			System.arraycopy(bytes, 0, out, 0, at);
+			System.arraycopy(burst, 0, out, at, burst.length);
+			System.arraycopy(bytes, at, out, at + burst.length,
+					bytes.length - at);
+			return out;
+		}
+		default: { // duplicate a random region over another
+			int from = rng.nextInt(bytes.length);
+			int to = rng.nextInt(bytes.length);
+			int len = Math.min(1 + rng.nextInt(64),
+					bytes.length - Math.max(from, to));
+			System.arraycopy(bytes, from, bytes, to, len);
+			return bytes;
+		}
+		}
+	}
+
+	/**
+	 * Open, load and finish-load a mutant. Success and classified
+	 * rejection are both legal; an escaped exception or a rejection
+	 * without a structured LoadError fails the run.
+	 */
+	private void loadMutant(File file, String label) {
+		Scanner scanner;
+		try {
+			scanner = FileAbstractor.openCircuit(file.getAbsolutePath());
+		} catch (RuntimeException | Error e) {
+			throw new AssertionError(label
+					+ ": openCircuit threw instead of classifying", e);
+		}
+		if (scanner == null) {
+			assertTrue(JLSInfo.lastLoadError != null,
+					label + ": a rejected open must publish a structured"
+					+ " LoadError");
+			return;
+		}
+		Circuit circuit = new Circuit("mutate");
+		boolean ok;
+		try {
+			ok = circuit.load(scanner);
+		} catch (RuntimeException | Error e) {
+			throw new AssertionError(label
+					+ ": load threw instead of classifying", e);
+		} finally {
+			scanner.close();
+		}
+		if (!ok) {
+			assertTrue(JLSInfo.lastLoadError != null,
+					label + ": a rejected load must publish a structured"
+					+ " LoadError");
+			return;
+		}
+		BufferedImage img = new BufferedImage(64, 64,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		try {
+			ok = circuit.finishLoad(g);
+		} catch (Exception | Error e) {
+			throw new AssertionError(label
+					+ ": finishLoad threw instead of classifying", e);
+		} finally {
+			g.dispose();
+		}
+		if (!ok) {
+			assertTrue(JLSInfo.lastLoadError != null,
+					label + ": a rejected finishLoad must publish a"
+					+ " structured LoadError");
+		}
+	}
+
+	private void fuzzContainer(String container, byte[] valid)
+			throws Exception {
+		Random rng = new Random(container.hashCode());
+		for (int i = 0; i < MUTANTS; i++) {
+			byte[] mutant = mutate(valid, rng);
+			File file = tmp.resolve("m" + i + ".jls").toFile();
+			Files.write(file.toPath(), mutant);
+			loadMutant(file, container + " mutant " + i
+					+ " (seed " + container.hashCode() + ")");
+		}
+	}
+
+	@Test
+	void mutatedTextContainersAreClassifiedNeverThrown() throws Exception {
+		File valid = tmp.resolve("valid.jls").toFile();
+		FileFormatSupport.writeText(valid, CIRCUIT_TEXT);
+		fuzzContainer("text", Files.readAllBytes(valid.toPath()));
+	}
+
+	@Test
+	void mutatedZipContainersAreClassifiedNeverThrown() throws Exception {
+		File valid = tmp.resolve("valid.jls").toFile();
+		FileFormatSupport.writeZip(valid, CIRCUIT_TEXT);
+		fuzzContainer("zip", Files.readAllBytes(valid.toPath()));
+	}
+
+	@Test
+	void mutatedXzContainersAreClassifiedNeverThrown() throws Exception {
+		File valid = tmp.resolve("valid.jls").toFile();
+		FileFormatSupport.writeXZ(valid, CIRCUIT_TEXT);
+		fuzzContainer("xz", Files.readAllBytes(valid.toPath()));
+	}
+
+	@Test
+	void theUnmutatedBaselinesActuallyLoad() throws Exception {
+		// positive control: if the base circuit stopped loading, the
+		// three properties above would pass vacuously
+		File text = tmp.resolve("basetext.jls").toFile();
+		FileFormatSupport.writeText(text, CIRCUIT_TEXT);
+		File zip = tmp.resolve("basezip.jls").toFile();
+		FileFormatSupport.writeZip(zip, CIRCUIT_TEXT);
+		File xz = tmp.resolve("basexz.jls").toFile();
+		FileFormatSupport.writeXZ(xz, CIRCUIT_TEXT);
+		for (File file : new File[] {text, zip, xz}) {
+			Scanner scanner = FileAbstractor.openCircuit(
+					file.getAbsolutePath());
+			assertTrue(scanner != null,
+					file.getName() + ": " + JLSInfo.loadError);
+			Circuit circuit = new Circuit("mutate");
+			assertTrue(circuit.load(scanner),
+					file.getName() + ": " + JLSInfo.loadError);
+			scanner.close();
+			BufferedImage img = new BufferedImage(64, 64,
+					BufferedImage.TYPE_INT_RGB);
+			Graphics2D g = img.createGraphics();
+			assertTrue(circuit.finishLoad(g),
+					file.getName() + ": " + JLSInfo.loadError);
+			g.dispose();
+		}
+	}
+}

--- a/test/jls/CoverageAgent.java
+++ b/test/jls/CoverageAgent.java
@@ -1,0 +1,44 @@
+package jls;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Propagates the JaCoCo agent into the JVMs the CLI tests spawn.
+ *
+ * The CLI suites exercise JLSStart end to end through real
+ * {@code java -cp ... jls.JLS} subprocesses, but the coverage agent
+ * only instruments the surefire JVM - so everything those tests
+ * actually execute used to read as uncovered (JLSStart measured 4.7%
+ * despite the whole flag table being driven). Adding this JVM's own
+ * agent argument to the child command line makes the measurement
+ * honest; the agent appends to the shared exec file with file
+ * locking, so concurrent child JVMs are safe.
+ *
+ * When the tests run without JaCoCo (plain IDE runs), there is no
+ * agent argument to copy and this contributes nothing.
+ */
+public final class CoverageAgent {
+
+	private CoverageAgent() {
+	}
+
+	/**
+	 * The JaCoCo agent argument(s) of the current JVM, if any.
+	 *
+	 * @return JVM arguments to add to a spawned java command line;
+	 *         empty when no coverage agent is attached.
+	 */
+	public static List<String> jvmArgs() {
+
+		List<String> args = new ArrayList<String>();
+		for (String arg : ManagementFactory.getRuntimeMXBean()
+				.getInputArguments()) {
+			if (arg.startsWith("-javaagent:") && arg.contains("jacoco")) {
+				args.add(arg);
+			}
+		}
+		return args;
+	}
+}

--- a/test/jls/ElementDrawSmokeTest.java
+++ b/test/jls/ElementDrawSmokeTest.java
@@ -1,0 +1,160 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.imageio.ImageIO;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jls.elem.Element;
+
+/**
+ * Headless draw-path smoke coverage (issues #91 layer 1 / #162): every
+ * palette element's draw() runs against both export canvases - the
+ * raster BufferedImage path and the JFreeSVG path (#154) - via
+ * Circuit.exportImage on a fixture containing one instance of every
+ * drawable element type. None of this needs a display: paint code is
+ * plain Graphics2D.
+ *
+ * The assertions are deliberately smoke-grade (draws without throwing,
+ * produces a decodable image / well-formed SVG with the elements
+ * plausibly present); pixel-exact rendering is not pinned, for the same
+ * font-metrics reason as CliImageExportTest. The completeness sweep at
+ * the bottom keeps the fixture honest as the palette grows.
+ */
+class ElementDrawSmokeTest {
+
+	@TempDir
+	Path tmp;
+
+	/** Element classes deliberately absent from the draw fixture. */
+	private static final Set<String> EXEMPT = Set.of(
+			// created by the simulator for -t runs, never placed/drawn
+			"TestGen");
+
+	/** One instance of every drawable element type, wired plausibly. */
+	private static String fixture() {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		for (String g : new String[] {"AndGate", "OrGate", "NandGate",
+				"NorGate", "XorGate"}) {
+			cb.gate(g, 2, 2);
+		}
+		cb.gate("NotGate", 1, 1);
+		cb.gate("DelayGate", 1, 1);
+		cb.constant(0xAB);
+		cb.extend(4);
+		cb.adder(4);
+		cb.clock(20, 10);
+		cb.decoder(2);
+		cb.display(4, 16);
+		cb.memory("ROM", 8, 4, "0 5\\n1 9");
+		cb.mux(4, 2);
+		cb.pause();
+		cb.register(4, 3, "nff");
+		cb.shifter("ArithmeticRight", 8);
+		cb.stateMachine(1, 1);
+		cb.stop();
+		cb.text("hello \\\"draw\\\"");
+		cb.triState(1);
+		cb.truthTable("tt", new String[] {"a"}, new String[] {"z"},
+				new int[][] {{0, 1}, {1, 0}});
+		cb.binder(4, new int[][] {{3, 2}, {1, 0}});
+		cb.splitter(4, new int[][] {{3, 2}, {1, 0}});
+		cb.jumpStart("js", 4);
+		cb.jumpEnd("js", 4);
+		cb.sigGen("in1 0 for 50 1 end");
+		cb.subCircuit("sub");
+		int in = cb.inputPin("in1", 1);
+		int out = cb.outputPin("watched", 1);
+		// one real wire so Wire and WireEnd draw too
+		cb.wire(in, "output", out, "input");
+		return cb.build();
+	}
+
+	private Circuit load() throws Exception {
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(fixture())),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	@Test
+	void everyElementDrawsOnTheRasterExportPath() throws Exception {
+		Circuit circuit = load();
+		File png = tmp.resolve("draw.png").toFile();
+		circuit.exportImage(png.getAbsolutePath());
+		BufferedImage image = ImageIO.read(png);
+		assertNotNull(image, "export did not produce a decodable PNG");
+		assertTrue(image.getWidth() > 100 && image.getHeight() > 50,
+				"implausibly small render: " + image.getWidth() + "x"
+						+ image.getHeight());
+	}
+
+	@Test
+	void everyElementDrawsOnTheSvgExportPath() throws Exception {
+		Circuit circuit = load();
+		File svg = tmp.resolve("draw.svg").toFile();
+		circuit.exportImage(svg.getAbsolutePath());
+		String text = Files.readString(svg.toPath(), StandardCharsets.UTF_8);
+		assertTrue(text.contains("<svg") && text.contains("</svg>"),
+				"export did not produce a well-formed SVG document");
+		// the watched pin's label proves text drawing ran
+		assertTrue(text.contains("watched"),
+				"pin labels should appear in the SVG");
+	}
+
+	@Test
+	void theFixtureCoversEveryDrawableElementType() throws Exception {
+		// the smoke above is only as good as the fixture is complete:
+		// sweep the palette reflectively (ElementConstructorContractTest
+		// pattern) and fail when a type is neither drawn nor exempt
+		Set<String> present = new TreeSet<>();
+		for (Element el : load().getElements()) {
+			present.add(el.getClass().getSimpleName());
+		}
+
+		File dir = new File(Element.class.getProtectionDomain()
+				.getCodeSource().getLocation().toURI());
+		File pkg = new File(dir, "jls/elem");
+		assertTrue(pkg.isDirectory(), "compiled classes not found at " + pkg);
+		Set<String> missing = new TreeSet<>();
+		int checked = 0;
+		for (File f : pkg.listFiles()) {
+			String name = f.getName();
+			if (!name.endsWith(".class") || name.contains("$")) {
+				continue;
+			}
+			String simple = name.replace(".class", "");
+			Class<?> c = Class.forName("jls.elem." + simple);
+			if (!Element.class.isAssignableFrom(c)
+					|| Modifier.isAbstract(c.getModifiers())
+					|| c == Element.class) {
+				continue;
+			}
+			checked++;
+			if (!present.contains(simple) && !EXEMPT.contains(simple)) {
+				missing.add(simple);
+			}
+		}
+		assertTrue(checked > 25, "sweep found too few element classes ("
+				+ checked + ") - wrong directory?");
+		assertTrue(missing.isEmpty(),
+				"drawable element types missing from the draw fixture"
+						+ " (add them to fixture(), or an exemption with"
+						+ " a reason): " + missing);
+	}
+}

--- a/test/jls/ElementSimulationGoldenTest.java
+++ b/test/jls/ElementSimulationGoldenTest.java
@@ -458,8 +458,15 @@ class ElementSimulationGoldenTest {
 		String outcome = captured.toString(StandardCharsets.UTF_8);
 		assertTrue(outcome.startsWith("Simulation Stopped at "),
 				"a triggered Stop must end the run (got: " + outcome + ")");
-		long stoppedAt = Long.parseLong(outcome
-				.substring("Simulation Stopped at ".length()).trim());
+		String stoppedText = outcome
+				.substring("Simulation Stopped at ".length()).trim();
+		long stoppedAt;
+		try {
+			stoppedAt = Long.parseLong(stoppedText);
+		} catch (NumberFormatException malformed) {
+			throw new AssertionError("the outcome line must end in a"
+					+ " numeric stop time, got: " + outcome, malformed);
+		}
 		assertTrue(stoppedAt < 1_000_000,
 				"the stop must fire before the time limit, at "
 						+ stoppedAt);

--- a/test/jls/ElementSimulationGoldenTest.java
+++ b/test/jls/ElementSimulationGoldenTest.java
@@ -1,0 +1,518 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.Element;
+import jls.elem.OutputPin;
+import jls.sim.BatchSimulator;
+
+/**
+ * Per-element simulation goldens (issue #158). BatchSimulationGoldenTest
+ * and SequentialGoldenTest cover the gates, memory and the clocked
+ * elements; this suite gives every remaining simulating palette element
+ * a behavioral pin, so a regression in, e.g., Adder carry handling or
+ * Mux select decoding fails mvn verify instead of passing silently.
+ *
+ * Expected values are computed independently of the implementation
+ * (issue #158 section 10): adder sums and carries by arithmetic, shifter
+ * results by hand, decoder one-hot by definition - never by running the
+ * simulator and copying what it printed.
+ *
+ * The completeness ratchet at the bottom enumerates the concrete element
+ * classes reflectively (ElementConstructorContractTest's sweep) and
+ * fails when a simulating element has no golden and no recorded
+ * exemption - so the gap this issue closes cannot silently reopen when
+ * the palette grows.
+ */
+class ElementSimulationGoldenTest {
+
+	// ------------------------------------------------------------------
+	// harness
+	// ------------------------------------------------------------------
+
+	/** Load circuit text, run the batch simulator, return the circuit. */
+	private static Circuit simulate(String circuitText) {
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(circuitText)),
+				() -> "load failed: " + JLSInfo.loadError);
+		try {
+			assertTrue(circuit.finishLoad(null),
+					() -> "finishLoad failed: " + JLSInfo.loadError);
+		} catch (Exception e) {
+			throw new AssertionError("finishLoad threw", e);
+		}
+		BatchSimulator sim = new BatchSimulator();
+		sim.setCircuit(circuit);
+		sim.setTimeLimit(1_000_000);
+		sim.runSim();
+		return circuit;
+	}
+
+	/** The settled value of a named watched output pin. */
+	private static long pinValue(Circuit circuit, String pinName) {
+		OutputPin pin = null;
+		for (Element el : circuit.getElements()) {
+			if (el instanceof OutputPin
+					&& pinName.equals(((OutputPin) el).getName())) {
+				pin = (OutputPin) el;
+			}
+		}
+		assertNotNull(pin, "output pin " + pinName + " not found");
+		BitSet value = pin.getCurrentValue();
+		assertNotNull(value, "output pin " + pinName + " never settled");
+		return BitSetUtils.ToLong(value);
+	}
+
+	private static long simulate(String circuitText, String pinName) {
+		return pinValue(simulate(circuitText), pinName);
+	}
+
+	// ------------------------------------------------------------------
+	// Adder
+	// ------------------------------------------------------------------
+
+	@Test
+	void adderSumsAndCarries() {
+		// 4-bit adder: S = (A+B+Cin) mod 16, Cout = the carry out -
+		// expected values by arithmetic, including both carry cases
+		long[] interesting = {0, 1, 5, 7, 10, 15};
+		for (long a : interesting) {
+			for (long b : interesting) {
+				for (long cin = 0; cin <= 1; cin++) {
+					CircuitTextBuilder cb = new CircuitTextBuilder();
+					int adder = cb.adder(4);
+					int ca = cb.constant(a);
+					int cbv = cb.constant(b);
+					int cc = cb.constant(cin);
+					int sum = cb.outputPin("sum", 4);
+					int carry = cb.outputPin("carry", 1);
+					cb.wire(ca, "output", adder, "A");
+					cb.wire(cbv, "output", adder, "B");
+					cb.wire(cc, "output", adder, "Cin");
+					cb.wire(adder, "S", sum, "input");
+					cb.wire(adder, "Cout", carry, "input");
+					Circuit circuit = simulate(cb.build());
+					long total = a + b + cin;
+					assertEquals(total % 16, pinValue(circuit, "sum"),
+							a + "+" + b + "+" + cin + " sum");
+					assertEquals(total / 16, pinValue(circuit, "carry"),
+							a + "+" + b + "+" + cin + " carry");
+				}
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Decoder
+	// ------------------------------------------------------------------
+
+	@Test
+	void decoderOutputIsOneHot() {
+		// n-bit decoder: 2^n-bit output with exactly bit[input] set
+		for (long in = 0; in < 4; in++) {
+			CircuitTextBuilder cb = new CircuitTextBuilder();
+			int dec = cb.decoder(2);
+			int c = cb.constant(in);
+			int out = cb.outputPin("out", 4);
+			cb.wire(c, "output", dec, "input");
+			cb.wire(dec, "output", out, "input");
+			assertEquals(1L << in, simulate(cb.build(), "out"),
+					"decode(" + in + ")");
+		}
+		// 3-bit spot checks at the edges
+		for (long in : new long[] {0, 5, 7}) {
+			CircuitTextBuilder cb = new CircuitTextBuilder();
+			int dec = cb.decoder(3);
+			int c = cb.constant(in);
+			int out = cb.outputPin("out", 8);
+			cb.wire(c, "output", dec, "input");
+			cb.wire(dec, "output", out, "input");
+			assertEquals(1L << in, simulate(cb.build(), "out"),
+					"decode3(" + in + ")");
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Extend
+	// ------------------------------------------------------------------
+
+	@Test
+	void extendReplicatesTheBit() {
+		// 1-bit input sign-extended across the output width
+		for (long in = 0; in <= 1; in++) {
+			CircuitTextBuilder cb = new CircuitTextBuilder();
+			int ext = cb.extend(4);
+			int c = cb.constant(in);
+			int out = cb.outputPin("out", 4);
+			cb.wire(c, "output", ext, "input0");
+			cb.wire(ext, "output", out, "input");
+			assertEquals(in == 0 ? 0 : 0b1111, simulate(cb.build(), "out"),
+					"extend(" + in + ")");
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Mux
+	// ------------------------------------------------------------------
+
+	@Test
+	void muxRoutesTheSelectedInput() {
+		// 4-way mux over 8-bit data: out = input[select], with four
+		// distinct data values so a wrong pick cannot alias a right one
+		long[] data = {0x11, 0x22, 0x44, 0x88};
+		for (long select = 0; select < 4; select++) {
+			CircuitTextBuilder cb = new CircuitTextBuilder();
+			int mux = cb.mux(4, 8);
+			int sel = cb.constant(select);
+			int out = cb.outputPin("out", 8);
+			for (int i = 0; i < 4; i++) {
+				int c = cb.constant(data[i]);
+				cb.wire(c, "output", mux, "input" + i);
+			}
+			cb.wire(sel, "output", mux, "select");
+			cb.wire(mux, "output", out, "input");
+			assertEquals(data[(int) select], simulate(cb.build(), "out"),
+					"mux select " + select);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// ShiftRegister (combinational barrel shifter, issue #122)
+	// ------------------------------------------------------------------
+
+	private long shifterGolden(String kind, long value, long amount) {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int sh = cb.shifter(kind, 8);
+		int v = cb.constant(value);
+		int a = cb.constant(amount);
+		int out = cb.outputPin("out", 8);
+		cb.wire(v, "output", sh, "input");
+		cb.wire(a, "output", sh, "amount");
+		cb.wire(sh, "output", out, "input");
+		return simulate(cb.build(), "out");
+	}
+
+	@Test
+	void logicalLeftShiftZeroFills() {
+		// 0xB4 = 1011_0100
+		assertEquals(0xB4, shifterGolden("LogicalLeft", 0xB4, 0));
+		assertEquals(0x68, shifterGolden("LogicalLeft", 0xB4, 1));
+		assertEquals(0xA0, shifterGolden("LogicalLeft", 0xB4, 3));
+		assertEquals(0x00, shifterGolden("LogicalLeft", 0xB4, 7));
+	}
+
+	@Test
+	void logicalRightShiftZeroFills() {
+		assertEquals(0xB4, shifterGolden("LogicalRight", 0xB4, 0));
+		assertEquals(0x5A, shifterGolden("LogicalRight", 0xB4, 1));
+		assertEquals(0x16, shifterGolden("LogicalRight", 0xB4, 3));
+		assertEquals(0x01, shifterGolden("LogicalRight", 0xB4, 7));
+	}
+
+	@Test
+	void arithmeticRightShiftSignFills() {
+		// sign bit set: ones shift in from the left
+		assertEquals(0xDA, shifterGolden("ArithmeticRight", 0xB4, 1));
+		assertEquals(0xF6, shifterGolden("ArithmeticRight", 0xB4, 3));
+		assertEquals(0xFF, shifterGolden("ArithmeticRight", 0xB4, 7));
+		// sign bit clear: behaves like logical right
+		assertEquals(0x1A, shifterGolden("ArithmeticRight", 0x34, 1));
+		assertEquals(0x06, shifterGolden("ArithmeticRight", 0x34, 3));
+	}
+
+	// ------------------------------------------------------------------
+	// TruthTable
+	// ------------------------------------------------------------------
+
+	@Test
+	void truthTableMatchesItsRows() {
+		// a NAND written as an explicit table: rows are (a, b, z)
+		int[][] nand = {
+				{0, 0, 1},
+				{0, 1, 1},
+				{1, 0, 1},
+				{1, 1, 0},
+		};
+		for (long a = 0; a <= 1; a++) {
+			for (long b = 0; b <= 1; b++) {
+				CircuitTextBuilder cb = new CircuitTextBuilder();
+				int tt = cb.truthTable("tt" + a + b,
+						new String[] {"a", "b"}, new String[] {"z"}, nand);
+				int ca = cb.constant(a);
+				int cbv = cb.constant(b);
+				int out = cb.outputPin("out", 1);
+				cb.wire(ca, "output", tt, "a");
+				cb.wire(cbv, "output", tt, "b");
+				cb.wire(tt, "z", out, "input");
+				assertEquals((a == 1 && b == 1) ? 0 : 1,
+						simulate(cb.build(), "out"),
+						"table(" + a + "," + b + ")");
+			}
+		}
+	}
+
+	@Test
+	void truthTableDontCareMatchesEitherValue() {
+		// row (2, 1): input a is don't-care whenever b is 1
+		int[][] table = {
+				{2, 1, 1},
+				{0, 0, 0},
+				{1, 0, 1},
+		};
+		long[][] cases = {{0, 1, 1}, {1, 1, 1}, {0, 0, 0}, {1, 0, 1}};
+		for (long[] c : cases) {
+			CircuitTextBuilder cb = new CircuitTextBuilder();
+			int tt = cb.truthTable("tt" + c[0] + c[1],
+					new String[] {"a", "b"}, new String[] {"z"}, table);
+			int ca = cb.constant(c[0]);
+			int cbv = cb.constant(c[1]);
+			int out = cb.outputPin("out", 1);
+			cb.wire(ca, "output", tt, "a");
+			cb.wire(cbv, "output", tt, "b");
+			cb.wire(tt, "z", out, "input");
+			assertEquals(c[2], simulate(cb.build(), "out"),
+					"dontcare(" + c[0] + "," + c[1] + ")");
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Binder / Splitter
+	// ------------------------------------------------------------------
+
+	@Test
+	void splitterRoutesBusBitsToRangeOutputs() {
+		// 4-bit bus 1101 split into "3-2" (11) and "1-0" (01)
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int split = cb.splitter(4, new int[][] {{3, 2}, {1, 0}});
+		int c = cb.constant(0b1101);
+		int hi = cb.outputPin("hi", 2);
+		int lo = cb.outputPin("lo", 2);
+		cb.wire(c, "output", split, "input");
+		cb.wire(split, "3-2", hi, "input");
+		cb.wire(split, "1-0", lo, "input");
+		Circuit circuit = simulate(cb.build());
+		assertEquals(0b11, pinValue(circuit, "hi"), "high range");
+		assertEquals(0b01, pinValue(circuit, "lo"), "low range");
+	}
+
+	@Test
+	void binderBundlesRangeInputsIntoTheBus() {
+		// inverse of the splitter case: 11 into "3-2" and 01 into "1-0"
+		// must reassemble 1101
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int bind = cb.binder(4, new int[][] {{3, 2}, {1, 0}});
+		int chi = cb.constant(0b11);
+		int clo = cb.constant(0b01);
+		int out = cb.outputPin("out", 4);
+		cb.wire(chi, "output", bind, "3-2");
+		cb.wire(clo, "output", bind, "1-0");
+		cb.wire(bind, "output", out, "input");
+		assertEquals(0b1101, simulate(cb.build(), "out"));
+	}
+
+	@Test
+	void splitterSingleBitRangeIsolatesOneLine() {
+		// 3-bit bus 101: single-bit ranges "2", "1", "0"
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int split = cb.splitter(3, new int[][] {{2}, {1}, {0}});
+		int c = cb.constant(0b101);
+		int b2 = cb.outputPin("b2", 1);
+		int b1 = cb.outputPin("b1", 1);
+		int b0 = cb.outputPin("b0", 1);
+		cb.wire(c, "output", split, "input");
+		cb.wire(split, "2", b2, "input");
+		cb.wire(split, "1", b1, "input");
+		cb.wire(split, "0", b0, "input");
+		Circuit circuit = simulate(cb.build());
+		assertEquals(1, pinValue(circuit, "b2"), "bit 2");
+		assertEquals(0, pinValue(circuit, "b1"), "bit 1");
+		assertEquals(1, pinValue(circuit, "b0"), "bit 0");
+	}
+
+	// ------------------------------------------------------------------
+	// JumpStart / JumpEnd
+	// ------------------------------------------------------------------
+
+	@Test
+	void jumpCarriesTheValueWirelessly() {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int c = cb.constant(0b1010);
+		int start = cb.jumpStart("js", 4);
+		int end = cb.jumpEnd("js", 4);
+		int out = cb.outputPin("out", 4);
+		cb.wire(c, "output", start, "input");
+		cb.wire(end, "output", out, "input");
+		assertEquals(0b1010, simulate(cb.build(), "out"));
+	}
+
+	// ------------------------------------------------------------------
+	// SigGen
+	// ------------------------------------------------------------------
+
+	@Test
+	void sigGenDrivesItsNamedPinOverTime() {
+		// in1 starts at 0 and becomes 1 at t=50; the settled value on
+		// the wired-through output pin must be the final one
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int in = cb.inputPin("in1", 1);
+		cb.sigGen("in1 0 for 50 1 end");
+		int out = cb.outputPin("out", 1);
+		cb.wire(in, "output", out, "input");
+		assertEquals(1, simulate(cb.build(), "out"));
+	}
+
+	// ------------------------------------------------------------------
+	// Stop
+	// ------------------------------------------------------------------
+
+	@Test
+	void stopHaltsTheSimulationEarly() {
+		// a free-running clock would run to the 1,000,000 time limit;
+		// a Stop fed a constant 1 must end the run at once. The
+		// outcome line is the observable (same one batch mode prints).
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.clock(20, 10);
+		int one = cb.constant(1);
+		int stop = cb.stop();
+		cb.wire(one, "output", stop, "input0");
+
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load failed: " + JLSInfo.loadError);
+		try {
+			assertTrue(circuit.finishLoad(null),
+					() -> "finishLoad failed: " + JLSInfo.loadError);
+		} catch (Exception e) {
+			throw new AssertionError("finishLoad threw", e);
+		}
+		BatchSimulator sim = new BatchSimulator();
+		sim.setCircuit(circuit);
+		sim.setTimeLimit(1_000_000);
+		sim.runSim();
+
+		PrintStream saved = System.out;
+		ByteArrayOutputStream captured = new ByteArrayOutputStream();
+		try {
+			System.setOut(new PrintStream(captured, true,
+					StandardCharsets.UTF_8));
+			sim.displayOutcome();
+		} finally {
+			System.setOut(saved);
+		}
+		String outcome = captured.toString(StandardCharsets.UTF_8);
+		assertTrue(outcome.startsWith("Simulation Stopped at "),
+				"a triggered Stop must end the run (got: " + outcome + ")");
+		long stoppedAt = Long.parseLong(outcome
+				.substring("Simulation Stopped at ".length()).trim());
+		assertTrue(stoppedAt < 1_000_000,
+				"the stop must fire before the time limit, at "
+						+ stoppedAt);
+	}
+
+	// ------------------------------------------------------------------
+	// completeness ratchet
+	// ------------------------------------------------------------------
+
+	/**
+	 * Elements with a behavioral simulation golden, and where it lives.
+	 * Add the element here when its golden lands - the ratchet below
+	 * fails any simulating element in neither this set nor EXEMPT.
+	 */
+	private static final Set<String> COVERED = Set.of(
+			// BatchSimulationGoldenTest
+			"AndGate", "OrGate", "NandGate", "NorGate", "XorGate",
+			"NotGate", "DelayGate", "Constant", "Memory", "OutputPin",
+			// SequentialGoldenTest / SimulationSemanticsRegressionTest
+			"Clock", "Register", "StateMachine", "SubCircuit", "TriState",
+			"Pause", "InputPin", "WireEnd",
+			// this suite
+			"Adder", "Decoder", "Extend", "Mux", "ShiftRegister",
+			"TruthTable", "Binder", "Splitter", "JumpStart", "JumpEnd",
+			"SigGen", "Stop");
+
+	/**
+	 * Elements deliberately without a simulation golden. Every entry
+	 * needs a reason; removing an element from the palette removes it
+	 * here too.
+	 */
+	private static final Set<String> EXEMPT = Set.of(
+			// display-only: consumes a value for the GUI, drives nothing
+			"Display",
+			// decorative annotation, no puts, never simulates
+			"Text",
+			// the -t test-vector driver; exercised end to end by the
+			// batch CLI suites and VcdExportGoldenTest
+			"TestGen");
+
+	@Test
+	void everySimulatingElementHasAGoldenOrARecordedExemption()
+			throws Exception {
+		File dir = new File(Element.class.getProtectionDomain()
+				.getCodeSource().getLocation().toURI());
+		File pkg = new File(dir, "jls/elem");
+		assertTrue(pkg.isDirectory(), "compiled classes not found at " + pkg);
+
+		Set<String> unaccounted = new TreeSet<>();
+		List<String> stale = new ArrayList<>();
+		Set<String> concrete = new TreeSet<>();
+		for (File f : pkg.listFiles()) {
+			String name = f.getName();
+			if (!name.endsWith(".class") || name.contains("$")) {
+				continue;
+			}
+			String simple = name.replace(".class", "");
+			Class<?> c = Class.forName("jls.elem." + simple);
+			if (!Element.class.isAssignableFrom(c)
+					|| Modifier.isAbstract(c.getModifiers())) {
+				continue;
+			}
+			if (c == jls.elem.Wire.class) {
+				continue; // rebuilt from WireEnd refs, not a palette item
+			}
+			if (c == Element.class) {
+				continue; // the (historically non-abstract) base class
+			}
+			concrete.add(simple);
+			if (!COVERED.contains(simple) && !EXEMPT.contains(simple)) {
+				unaccounted.add(simple);
+			}
+		}
+		assertTrue(concrete.size() > 25,
+				"sweep found too few element classes (" + concrete.size()
+						+ ") - wrong directory?");
+		// both lists must stay honest: no unknown names rotting in them
+		for (String claimed : COVERED) {
+			if (!concrete.contains(claimed)) {
+				stale.add("COVERED: " + claimed);
+			}
+		}
+		for (String claimed : EXEMPT) {
+			if (!concrete.contains(claimed)) {
+				stale.add("EXEMPT: " + claimed);
+			}
+		}
+		assertTrue(stale.isEmpty(),
+				"ratchet lists name classes that no longer exist: " + stale);
+		assertTrue(unaccounted.isEmpty(),
+				"simulating elements with no behavioral golden and no"
+						+ " recorded exemption (add a golden to"
+						+ " ElementSimulationGoldenTest, or an exemption"
+						+ " with a reason): " + unaccounted);
+	}
+}

--- a/test/jls/ElementSimulationGoldenTest.java
+++ b/test/jls/ElementSimulationGoldenTest.java
@@ -378,6 +378,46 @@ class ElementSimulationGoldenTest {
 	}
 
 	// ------------------------------------------------------------------
+	// Memory file-based initialization
+	// ------------------------------------------------------------------
+
+	@org.junit.jupiter.api.io.TempDir
+	java.nio.file.Path tmp;
+
+	@Test
+	void memoryInitializesFromItsNamedFile() throws Exception {
+		// the "file" attribute names an on-disk image that overrides
+		// the inline init text at simulation start; same "addr value"
+		// hex format. Batch mode keeps a failed read headless (stdout
+		// message), so pin the success path under batch like the CLI.
+		java.nio.file.Path image = tmp.resolve("mem.dat");
+		java.nio.file.Files.writeString(image, "0 5\n1 9\n2 c\n");
+
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int rom = cb.memory("ROM", 8, 4, "");
+		int addr = cb.constant(2);
+		int select = cb.constant(0);
+		int enable = cb.constant(0);
+		int out = cb.outputPin("out", 8);
+		cb.wire(addr, "output", rom, "address");
+		cb.wire(select, "output", rom, "CS");
+		cb.wire(enable, "output", rom, "OE");
+		cb.wire(rom, "output", out, "input");
+		String text = cb.build().replace(" String file \"\"",
+				" String file \"" + image.toAbsolutePath() + "\"");
+
+		boolean batch = JLSInfo.batch;
+		JLSInfo.batch = true;
+		try {
+			assertEquals(0xc, simulate(text, "out"),
+					"the file image, not the empty inline init, must"
+							+ " provide the contents");
+		} finally {
+			JLSInfo.batch = batch;
+		}
+	}
+
+	// ------------------------------------------------------------------
 	// Stop
 	// ------------------------------------------------------------------
 

--- a/test/jls/GenerativeRoundTripFuzzTest.java
+++ b/test/jls/GenerativeRoundTripFuzzTest.java
@@ -1,0 +1,403 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Seeded generative round-trip fuzzing (issue #160). The existing
+ * round-trip suites state the property - save -> load -> save is a
+ * fixed point, and a rejected load is always a classified LoadError,
+ * never an escaped exception - but evaluate it only at hand-enumerated
+ * fixtures. This harness evaluates the same two properties at
+ * pseudo-random points of the input space: random element mixes,
+ * parameter values at and around their boundaries, names exercising
+ * the escape space, and randomly wired pin pairs.
+ *
+ * Deterministic seeds: failures must reproduce (the in-tree precedent
+ * is DragCandidateBoundTest). Dependency-free by decision - jqwik was
+ * rejected under the active-maintenance policy
+ * (docs/library-survey-2026-07.md), so the generator is plain
+ * java.util.Random over the save-format text grammar.
+ */
+class GenerativeRoundTripFuzzTest {
+
+	/** Seeds per property run; each seed generates one circuit. */
+	private static final int SEEDS = 100;
+
+	/** Bit widths at and around the boundaries elements care about. */
+	private static final int[] BITS = {1, 2, 3, 4, 8, 16, 31, 32};
+
+	private static final String[] GATES = {
+			"AndGate", "OrGate", "NandGate", "NorGate", "XorGate"};
+
+	private static final String[] LOWER_ORIENT = {"up", "down", "left", "right"};
+
+	private static final String[] UPPER_ORIENT = {"UP", "DOWN", "LEFT", "RIGHT"};
+
+	/** Strings that exercise the escape space pinned by issue #53. */
+	private static final String[] HOSTILE_TEXT = {
+			"plain", "with \"quotes\"", "back\\slash", "trailing\\",
+			"line\nbreak", "\\n literal", "mixed \\\" \n end\\",
+			"\"", "\\", "", "two\n\nbreaks"};
+
+	// ------------------------------------------------------------------
+	// generator
+	// ------------------------------------------------------------------
+
+	/**
+	 * One generated element block. Coordinates are unique per element
+	 * (the canonicalizer needs pairwise-distinct blocks).
+	 */
+	private static String el(String type, int id, int x, int y, String attrs) {
+		return "ELEMENT " + type + "\n int id " + id + "\n int x " + x
+				+ "\n int y " + y + "\n" + attrs + "END\n";
+	}
+
+	private static String esc(String s) {
+		return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+	}
+
+	private static int pick(Random rng, int[] values) {
+		return values[rng.nextInt(values.length)];
+	}
+
+	private static String pick(Random rng, String[] values) {
+		return values[rng.nextInt(values.length)];
+	}
+
+	/**
+	 * Generate a random circuit in the on-disk text format. Every
+	 * element gets a distinct grid position so canonicalization can
+	 * sort blocks without ties.
+	 */
+	private static String generate(long seed) {
+		Random rng = new Random(seed);
+		StringBuilder t = new StringBuilder("CIRCUIT fuzz\n");
+		int id = 0;
+		int x = 0;
+		int count = 3 + rng.nextInt(20);
+		for (int i = 0; i < count; i++) {
+			x += 120; // unique per element
+			int y = 120 + 12 * rng.nextInt(4);
+			switch (rng.nextInt(12)) {
+			case 0 -> t.append(el(pick(rng, GATES), id++, x, y,
+					" int bits " + pick(rng, BITS)
+					+ "\n int numInputs " + (2 + rng.nextInt(4))
+					+ "\n String orientation \"" + pick(rng, LOWER_ORIENT)
+					+ "\"\n int delay " + rng.nextInt(100) + "\n"));
+			case 1 -> t.append(el("NotGate", id++, x, y,
+					" int bits 1\n int numInputs 1\n String orientation \""
+					+ pick(rng, LOWER_ORIENT) + "\"\n int delay "
+					+ rng.nextInt(50) + "\n"));
+			case 2 -> t.append(el("Adder", id++, x, y,
+					" int bits " + pick(rng, BITS) + "\n String orient \""
+					+ pick(rng, UPPER_ORIENT) + "\"\n int delay "
+					+ (1 + rng.nextInt(40)) + "\n"));
+			case 3 -> t.append(el("Clock", id++, x, y,
+					" int cycle " + (2 + 2 * rng.nextInt(50)) + "\n int one "
+					+ (1 + rng.nextInt(50)) + "\n String orient \""
+					+ pick(rng, UPPER_ORIENT) + "\"\n"));
+			case 4 -> {
+				// random-width constants, including values needing BigInteger
+				BigInteger value = new BigInteger(1 + rng.nextInt(96), rng);
+				t.append(el("Constant", id++, x, y,
+						" int width 24\n int height 24\n Int value " + value
+						+ "\n int base " + new int[] {2, 10, 16}[rng.nextInt(3)]
+						+ "\n String orient \"" + pick(rng, UPPER_ORIENT)
+						+ "\"\n"));
+			}
+			case 5 -> t.append(el("Decoder", id++, x, y,
+					" int bits " + (1 + rng.nextInt(6)) + "\n int delay "
+					+ rng.nextInt(30) + "\n String orient \""
+					+ pick(rng, UPPER_ORIENT) + "\"\n"));
+			case 6 -> t.append(el("Display", id++, x, y,
+					" int bits " + pick(rng, BITS) + "\n int base "
+					+ new int[] {2, 10, 16}[rng.nextInt(3)] + "\n"));
+			case 7 -> {
+				int bits = pick(rng, BITS);
+				int cap = 4 << rng.nextInt(4);
+				StringBuilder init = new StringBuilder();
+				int rows = rng.nextInt(4);
+				for (int r = 0; r < rows; r++) {
+					init.append(rng.nextInt(cap)).append(' ')
+							.append(rng.nextInt(1 << Math.min(bits, 16)))
+							.append("\\n");
+				}
+				t.append(el("Memory", id++, x, y,
+						" String name \"mem" + id + "\"\n String type \""
+						+ (rng.nextBoolean() ? "ROM" : "RAM") + "\"\n int bits "
+						+ bits + "\n int cap " + cap + "\n int time "
+						+ (1 + rng.nextInt(20)) + "\n int watch 0\n"
+						+ " String file \"\"\n String init \"" + init + "\"\n"));
+			}
+			case 8 -> t.append(el("Mux", id++, x, y,
+					" int inputs " + (2 + rng.nextInt(6)) + "\n int bits "
+					+ pick(rng, BITS) + "\n int delay " + rng.nextInt(30)
+					+ "\n String iOrient \"" + pick(rng, UPPER_ORIENT)
+					+ "\"\n String sOrient \"" + pick(rng, UPPER_ORIENT)
+					+ "\"\n"));
+			case 9 -> t.append(el("Register", id++, x, y,
+					" String name \"reg" + id + "\"\n int bits "
+					+ pick(rng, BITS) + "\n Int init "
+					+ new BigInteger(1 + rng.nextInt(31), rng)
+					+ "\n String orient \"" + pick(rng, UPPER_ORIENT)
+					+ "\"\n int delay " + (1 + rng.nextInt(20))
+					+ "\n String type \"" + (rng.nextBoolean() ? "nff" : "pff")
+					+ "\"\n int watch " + rng.nextInt(2) + "\n"));
+			case 10 -> t.append(el("Text", id++, x, y,
+					" String text \"" + esc(pick(rng, HOSTILE_TEXT))
+					+ "\"\n String fn \"Dialog\"\n int fs "
+					+ (8 + rng.nextInt(24)) + "\n int bold " + rng.nextInt(2)
+					+ "\n int ital " + rng.nextInt(2)
+					+ "\n int color -16777216\n"));
+			default -> {
+				// the control input must be perpendicular to the gate
+				boolean vertical = rng.nextBoolean();
+				String gorient = vertical
+						? (rng.nextBoolean() ? "UP" : "DOWN")
+						: (rng.nextBoolean() ? "LEFT" : "RIGHT");
+				String corient = vertical
+						? (rng.nextBoolean() ? "LEFT" : "RIGHT")
+						: (rng.nextBoolean() ? "UP" : "DOWN");
+				t.append(el("TriState", id++, x, y,
+						" int bits " + pick(rng, BITS) + "\n int delay "
+						+ rng.nextInt(30) + "\n String Gorient \"" + gorient
+						+ "\"\n String Corient \"" + corient + "\"\n"));
+			}
+			}
+		}
+		// random wired pin pairs, following the fixture pattern of the
+		// element round-trip suite: source pin -> wire -> sink pin
+		int pairs = rng.nextInt(4);
+		for (int p = 0; p < pairs; p++) {
+			int bits = pick(rng, BITS);
+			x += 120;
+			int src = id++;
+			t.append(el("InputPin", src, x, 600,
+					" String name \"wsrc" + p + "\"\n int bits " + bits
+					+ "\n int watch 0\n String orient \"RIGHT\"\n"));
+			int dst = id++;
+			t.append(el("OutputPin", dst, x + 48, 720,
+					" String name \"wdst" + p + "\"\n int bits " + bits
+					+ "\n int watch 0\n String orient \"LEFT\"\n"));
+			int ea = id++;
+			int eb = id++;
+			t.append("ELEMENT WireEnd\n int id " + ea + "\n int x " + (x + 12)
+					+ "\n int y 612\n int width 8\n int height 8\n"
+					+ " String put \"output\"\n ref attach " + src
+					+ "\n ref wire " + eb + "\nEND\n");
+			t.append("ELEMENT WireEnd\n int id " + eb + "\n int x " + (x + 48)
+					+ "\n int y 732\n int width 8\n int height 8\n"
+					+ " String put \"input\"\n ref attach " + dst
+					+ "\n ref wire " + ea + "\nEND\n");
+		}
+		t.append("ENDCIRCUIT\n");
+		return t.toString();
+	}
+
+	// ------------------------------------------------------------------
+	// canonicalization (ref-aware; see AllElementsRoundTripTest)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Canonical form for saves of circuits that may contain ref lines:
+	 * blocks sorted by ref-masked content, ids renumbered in sorted
+	 * order, ref targets rewritten to the new ids. Sound only when the
+	 * masked blocks are pairwise distinct, which the generator
+	 * guarantees by giving every element a unique x coordinate.
+	 */
+	private static String canonicalize(String saved, long seed) {
+		List<String> blocks = new ArrayList<String>();
+		StringBuilder current = null;
+		StringBuilder header = new StringBuilder();
+		for (String line : saved.split("\n")) {
+			if (line.startsWith("ELEMENT")) {
+				current = new StringBuilder();
+			}
+			if (current == null) {
+				header.append(line).append('\n');
+			} else {
+				current.append(line).append('\n');
+			}
+			if (line.equals("END") && current != null) {
+				blocks.add(current.toString());
+				current = null;
+			}
+		}
+		List<String> masked = new ArrayList<String>();
+		for (String b : blocks) {
+			masked.add(mask(b));
+		}
+		List<Integer> order = new ArrayList<Integer>();
+		for (int i = 0; i < blocks.size(); i++) {
+			order.add(i);
+		}
+		order.sort((a, b) -> masked.get(a).compareTo(masked.get(b)));
+		for (int i = 1; i < order.size(); i++) {
+			assertTrue(!masked.get(order.get(i - 1)).equals(masked.get(order.get(i))),
+					"seed " + seed + ": generated blocks must be pairwise"
+					+ " distinct for canonicalization");
+		}
+		Map<String, String> newId = new HashMap<String, String>();
+		for (int pos = 0; pos < order.size(); pos++) {
+			for (String line : blocks.get(order.get(pos)).split("\n")) {
+				if (line.startsWith(" int id ")) {
+					newId.put(line.substring(" int id ".length()).trim(),
+							Integer.toString(pos));
+				}
+			}
+		}
+		StringBuilder out = new StringBuilder(header);
+		for (int pos = 0; pos < order.size(); pos++) {
+			for (String line : blocks.get(order.get(pos)).split("\n")) {
+				if (line.startsWith(" int id ")) {
+					out.append(" int id ").append(pos).append('\n');
+				} else if (line.startsWith(" ref ")) {
+					String[] parts = line.trim().split("\\s+");
+					out.append(" ref ").append(parts[1]).append(' ')
+							.append(newId.get(parts[2])).append('\n');
+				} else {
+					out.append(line).append('\n');
+				}
+			}
+		}
+		return out.toString();
+	}
+
+	/** A block with its id and ref targets hidden, for stable sorting. */
+	private static String mask(String block) {
+		StringBuilder out = new StringBuilder();
+		for (String line : block.split("\n")) {
+			if (line.startsWith(" int id ")) {
+				continue;
+			}
+			if (line.startsWith(" ref ")) {
+				String[] parts = line.trim().split("\\s+");
+				out.append(" ref ").append(parts[1]).append(" ?\n");
+			} else {
+				out.append(line).append('\n');
+			}
+		}
+		return out.toString();
+	}
+
+	// ------------------------------------------------------------------
+	// harness
+	// ------------------------------------------------------------------
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString();
+	}
+
+	/**
+	 * Load a generated text. Returns the circuit on success and null on
+	 * a classified rejection; anything thrown is a harness failure
+	 * (the classify-never-crash contract of issue #58).
+	 */
+	private static Circuit loadClassified(String text, long seed) {
+		Circuit circuit = new Circuit("fuzz");
+		boolean ok;
+		try {
+			ok = circuit.load(new Scanner(text));
+		} catch (RuntimeException | Error e) {
+			throw new AssertionError("seed " + seed
+					+ ": load threw instead of classifying:\n" + text, e);
+		}
+		if (!ok) {
+			assertTrue(JLSInfo.lastLoadError != null,
+					"seed " + seed + ": rejected load must publish a"
+					+ " structured LoadError");
+			return null;
+		}
+		BufferedImage img = new BufferedImage(64, 64,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		try {
+			ok = circuit.finishLoad(g);
+		} catch (Exception | Error e) {
+			throw new AssertionError("seed " + seed
+					+ ": finishLoad threw instead of classifying:\n" + text, e);
+		} finally {
+			g.dispose();
+		}
+		if (!ok) {
+			assertTrue(JLSInfo.lastLoadError != null,
+					"seed " + seed + ": rejected finishLoad must publish a"
+					+ " structured LoadError");
+			return null;
+		}
+		return circuit;
+	}
+
+	@Test
+	void generatedCircuitsRoundTripToAFixedPoint() {
+		int loaded = 0;
+		for (long seed = 0; seed < SEEDS; seed++) {
+			String text = generate(seed);
+			Circuit first = loadClassified(text, seed);
+			if (first == null) {
+				continue; // classified rejection is a legal outcome
+			}
+			loaded += 1;
+			String savedOnce = save(first);
+			Circuit second = loadClassified(savedOnce, seed);
+			if (second == null) {
+				fail("seed " + seed + ": a circuit that loaded and saved"
+						+ " must load again; got: " + JLSInfo.loadError);
+			}
+			assertEquals(canonicalize(savedOnce, seed),
+					canonicalize(save(second), seed),
+					"seed " + seed + ": save -> load -> save must be a"
+					+ " fixed point");
+		}
+		// guard the generator itself: if almost everything is rejected,
+		// the property above is vacuous and the generator has drifted
+		assertTrue(loaded >= SEEDS * 3 / 4,
+				"generator drift: only " + loaded + " of " + SEEDS
+				+ " generated circuits loaded");
+	}
+
+	@Test
+	void truncatedGeneratedCircuitsAreClassifiedNeverThrown() {
+		// structural mutation at the text layer: every prefix boundary
+		// of a valid save must classify cleanly (issue #58's contract);
+		// byte-level container mutation lives in ContainerMutationFuzzTest
+		for (long seed = 0; seed < SEEDS / 4; seed++) {
+			String text = generate(seed);
+			Random rng = new Random(~seed);
+			for (int i = 0; i < 8; i++) {
+				int cut = rng.nextInt(text.length());
+				Circuit circuit = loadClassified(text.substring(0, cut), seed);
+				if (circuit == null) {
+					continue; // classified rejection, as required
+				}
+				// a prefix that still loads (e.g. cut inside trailing
+				// whitespace) must still round-trip
+				String savedOnce = save(circuit);
+				Circuit again = loadClassified(savedOnce, seed);
+				assertTrue(again != null,
+						"seed " + seed + ": reload after truncation-load"
+						+ " failed: " + JLSInfo.loadError);
+			}
+		}
+	}
+}

--- a/test/jls/PrintPathSmokeTest.java
+++ b/test/jls/PrintPathSmokeTest.java
@@ -1,0 +1,86 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.print.Book;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Headless smoke coverage of the printing pipeline (issue #91 layer 1):
+ * Circuit implements Printable and addToBook collects the circuit, its
+ * state machines (plus their output-summary pages), truth tables, and
+ * nested subcircuits into a print Book. None of that needs a printer or
+ * a display - Printable.print draws into any Graphics2D, so rendering
+ * every booked page into a BufferedImage exercises the whole path.
+ */
+class PrintPathSmokeTest {
+
+	private static Circuit load() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.constant(5);
+		cb.clock(20, 10);
+		cb.stateMachine(1, 1);
+		cb.truthTable("tt", new String[] {"a"}, new String[] {"z"},
+				new int[][] {{0, 1}, {1, 0}});
+		cb.subCircuit("sub");
+		int in = cb.inputPin("in1", 1);
+		int out = cb.outputPin("out", 1);
+		cb.wire(in, "output", out, "input");
+
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	@Test
+	void everyBookedPagePrintsIntoAGraphics() throws Exception {
+		Circuit circuit = load();
+		Book book = new Book();
+		PageFormat format = new PageFormat();
+		circuit.addToBook(book, format);
+
+		// circuit + state machine + its output summary + truth table
+		// + the nested subcircuit's page
+		assertTrue(book.getNumberOfPages() >= 4,
+				"expected the fixture to book at least 4 pages, got "
+						+ book.getNumberOfPages());
+
+		BufferedImage image = new BufferedImage(850, 1100,
+				BufferedImage.TYPE_INT_RGB);
+		for (int page = 0; page < book.getNumberOfPages(); page++) {
+			Graphics2D g = image.createGraphics();
+			try {
+				int result = book.getPrintable(page)
+						.print(g, book.getPageFormat(page), page);
+				assertEquals(Printable.PAGE_EXISTS, result,
+						"page " + page + " must render");
+			} finally {
+				g.dispose();
+			}
+		}
+	}
+
+	@Test
+	void printingTheCircuitDirectlyRenders() throws Exception {
+		Circuit circuit = load();
+		BufferedImage image = new BufferedImage(850, 1100,
+				BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = image.createGraphics();
+		try {
+			assertEquals(Printable.PAGE_EXISTS,
+					circuit.print(g, new PageFormat(), 0));
+		} finally {
+			g.dispose();
+		}
+	}
+}

--- a/test/jls/SvgExportTest.java
+++ b/test/jls/SvgExportTest.java
@@ -1,0 +1,110 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Direct tests of the SVG branch of Circuit.exportImage (issue #154).
+ * The CLI-level behavior rides in CliImageExportTest; this pins the
+ * properties that matter for reproducible-build and golden-test use:
+ * exporting the same circuit twice yields byte-identical SVG, and the
+ * document is structurally an SVG image with the circuit's drawn
+ * content in it. Deliberately no full-document golden - text layout
+ * coordinates depend on the JDK's font metrics, which differ across
+ * machines (the same reason CliImageExportTest avoids pixel goldens).
+ */
+class SvgExportTest {
+
+	@TempDir
+	Path tmp;
+
+	private static final String CIRCUIT_TEXT = "CIRCUIT svgexport\n"
+			+ "ELEMENT Constant\n"
+			+ " int id 0\n int x 60\n int y 60\n"
+			+ " int width 24\n int height 24\n"
+			+ " Int value 1\n int base 10\n"
+			+ " String orient \"RIGHT\"\n"
+			+ "END\n"
+			+ "ELEMENT InputPin\n"
+			+ " int id 2\n int x 120\n int y 240\n"
+			+ " int width 48\n int height 24\n"
+			+ " String name \"src\"\n int bits 1\n int watch 0\n"
+			+ " String orient \"RIGHT\"\n"
+			+ "END\n"
+			+ "ELEMENT OutputPin\n"
+			+ " int id 1\n int x 480\n int y 120\n"
+			+ " int width 48\n int height 24\n"
+			+ " String name \"out\"\n int bits 1\n int watch 0\n"
+			+ " String orient \"RIGHT\"\n"
+			+ "END\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 4\n int x 168\n int y 252\n"
+			+ " int width 8\n int height 8\n"
+			+ " String put \"output\"\n ref attach 2\n ref wire 5\n"
+			+ "END\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 5\n int x 480\n int y 132\n"
+			+ " int width 8\n int height 8\n"
+			+ " String put \"input\"\n ref attach 1\n ref wire 4\n"
+			+ "END\n"
+			+ "ENDCIRCUIT\n";
+
+	private static Circuit load() throws Exception {
+		Circuit circuit = new Circuit("svgexport");
+		assertTrue(circuit.load(new Scanner(CIRCUIT_TEXT)),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	@Test
+	void exportingTwiceIsByteIdentical() throws Exception {
+		Circuit circuit = load();
+		Path first = tmp.resolve("first.svg");
+		Path second = tmp.resolve("second.svg");
+		circuit.exportImage(first.toString());
+		circuit.exportImage(second.toString());
+		assertArrayEquals(Files.readAllBytes(first),
+				Files.readAllBytes(second),
+				"two exports of the same circuit must be byte-identical");
+
+		// fresh loads of the same text must also export the same bytes,
+		// so goldens and reproducible-builds expectations hold. The
+		// element set is a HashSet whose identity-hash iteration order
+		// varies across load instances (issue #166); the export path
+		// must not let that order reach the SVG bytes. Several loads
+		// raise the odds of actually getting a different order.
+		for (int i = 0; i < 4; i++) {
+			Path fresh = tmp.resolve("fresh" + i + ".svg");
+			load().exportImage(fresh.toString());
+			assertArrayEquals(Files.readAllBytes(first),
+					Files.readAllBytes(fresh),
+					"a fresh load of the same circuit must export the"
+					+ " same bytes");
+		}
+	}
+
+	@Test
+	void theDocumentIsAnSvgImageWithDrawnContent() throws Exception {
+		Circuit circuit = load();
+		Path out = tmp.resolve("out.svg");
+		circuit.exportImage(out.toString());
+		String svg = Files.readString(out, StandardCharsets.UTF_8);
+		assertTrue(svg.startsWith("<?xml"), "missing XML prolog");
+		assertTrue(svg.contains("<svg"), "no <svg element");
+		assertTrue(svg.contains("</svg>"), "unterminated document");
+		// the output pin draws its name as text; its presence proves
+		// the element paint path ran against the SVG canvas
+		assertTrue(svg.contains("out"),
+				"the pin label should appear in the SVG text");
+	}
+}

--- a/test/jls/UtilFunctionsTest.java
+++ b/test/jls/UtilFunctionsTest.java
@@ -1,0 +1,166 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Point;
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.Element;
+import jls.elem.Wire;
+import jls.elem.WireEnd;
+
+/**
+ * Direct coverage of jls.Util: the clipboard copy machinery (the same
+ * code paste and cross-circuit copy run through in the editor, testable
+ * headlessly because it only touches the model), wire-net partitioning,
+ * and the small pure helpers (name validation, base conversion).
+ */
+class UtilFunctionsTest {
+
+	/** A gate fed by two wired constants - elements, ends and wires. */
+	private static Circuit source() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int a = cb.constant(1);
+		int b = cb.constant(0);
+		int gate = cb.gate("AndGate", 1, 2);
+		int out = cb.outputPin("out", 1);
+		cb.wire(a, "output", gate, "input0");
+		cb.wire(b, "output", gate, "input1");
+		cb.wire(gate, "output", out, "input");
+
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	@Test
+	void copyReproducesElementsWiresAndAttachment() throws Exception {
+		Circuit from = source();
+		Set<Element> selection = new HashSet<Element>(from.getElements());
+
+		Circuit to = new Circuit("golden");
+		Point min = Util.copy(selection, to);
+		assertNotNull(min);
+
+		int gates = 0, constants = 0, pins = 0, wires = 0, ends = 0;
+		for (Element el : to.getElements()) {
+			switch (el.getClass().getSimpleName()) {
+			case "AndGate" -> gates++;
+			case "Constant" -> constants++;
+			case "OutputPin" -> pins++;
+			case "Wire" -> wires++;
+			case "WireEnd" -> ends++;
+			default -> throw new AssertionError(
+					"unexpected copy: " + el.getClass().getSimpleName());
+			}
+		}
+		assertEquals(1, gates, "gate must copy");
+		assertEquals(2, constants, "constants must copy");
+		assertEquals(1, pins, "output pin must copy");
+		assertEquals(3, wires, "all three wires must copy");
+		assertEquals(6, ends, "all six wire ends must copy");
+
+		// the copied wires must connect copied ends, not originals
+		for (Element el : to.getElements()) {
+			if (el instanceof Wire wire) {
+				WireEnd end = wire.getEnd();
+				assertTrue(to.getElements().contains(end)
+						&& to.getElements().contains(wire.getOtherEnd(end)),
+						"copied wire must join copied ends");
+			}
+		}
+	}
+
+	@Test
+	void copyOfAPartialSelectionDropsDanglingWires() throws Exception {
+		Circuit from = source();
+		// select everything except the output pin and its attached
+		// wire end (the shape a rectangle selection produces): the
+		// gate-to-pin wire keeps only one copied end, so it must not
+		// be copied, and the surviving lone end must be pruned
+		Set<Element> selection = new HashSet<Element>();
+		for (Element el : from.getElements()) {
+			if (el instanceof jls.elem.OutputPin) {
+				continue;
+			}
+			if (el instanceof WireEnd end && end.getPut() != null
+					&& end.getPut().getElement()
+							instanceof jls.elem.OutputPin) {
+				continue;
+			}
+			selection.add(el);
+		}
+		Circuit to = new Circuit("golden");
+		Util.copy(selection, to);
+
+		int wires = 0, ends = 0;
+		for (Element el : to.getElements()) {
+			if (el instanceof Wire) {
+				wires++;
+			} else if (el instanceof WireEnd) {
+				ends++;
+			}
+		}
+		assertEquals(2, wires,
+				"only the two fully-selected wires may copy");
+		assertEquals(4, ends,
+				"wire ends without a surviving wire must be pruned");
+	}
+
+	@Test
+	void partitionRebuildsWireNets() throws Exception {
+		Circuit from = source();
+		Circuit to = new Circuit("golden");
+		Util.copy(new HashSet<Element>(from.getElements()), to);
+		// the copy has wires and ends but no nets yet; partitioning
+		// must group each wire's ends into a common net without error
+		Util.partition(to);
+		for (Element el : to.getElements()) {
+			if (el instanceof WireEnd end) {
+				assertNotNull(end.getNet(),
+						"every wire end must belong to a net after"
+								+ " partition");
+			}
+		}
+	}
+
+	@Test
+	void nameValidationAcceptsIdentifiersOnly() {
+		assertTrue(Util.isValidName("a"));
+		assertTrue(Util.isValidName("counter_4"));
+		assertTrue(!Util.isValidName(""));
+		assertTrue(!Util.isValidName("4bit"), "leading digit");
+		assertTrue(!Util.isValidName("_x"), "leading underscore");
+		assertTrue(!Util.isValidName("a b"), "space");
+		assertTrue(!Util.isValidName("a-b"), "hyphen");
+	}
+
+	@Test
+	void fileNameValidationStripsDirectoriesOnBothSeparators() {
+		assertEquals("circ", Util.isValidFileName("circ"));
+		assertEquals("circ", Util.isValidFileName("/home/user/circ"));
+		assertEquals("circ", Util.isValidFileName("C:\\work\\circ"));
+		assertNull(Util.isValidFileName("/home/user/4bad"));
+		assertNull(Util.isValidFileName(""));
+	}
+
+	@Test
+	void baseConversionMatchesItsDisplayContract() {
+		assertEquals("1010", Util.convert(BigInteger.valueOf(10), 2, false));
+		assertEquals("1010B", Util.convert(BigInteger.valueOf(10), 2, true));
+		assertEquals("10", Util.convert(BigInteger.valueOf(10), 10, false));
+		assertEquals("a", Util.convert(BigInteger.valueOf(10), 16, false));
+		assertEquals("0xa", Util.convert(BigInteger.valueOf(10), 16, true));
+	}
+}

--- a/test/jls/VcdExportGoldenTest.java
+++ b/test/jls/VcdExportGoldenTest.java
@@ -331,6 +331,7 @@ class VcdExportGoldenTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<String>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/WaylandStartupCliTest.java
+++ b/test/jls/WaylandStartupCliTest.java
@@ -64,6 +64,7 @@ class WaylandStartupCliTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.addAll(jvmFlags);
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/elem/MemoryInitEncodingTest.java
+++ b/test/jls/elem/MemoryInitEncodingTest.java
@@ -83,6 +83,19 @@ class MemoryInitEncodingTest {
 	}
 
 	@Test
+	void outOfCapacityAddressesStayRaw() {
+		// the raw init form is loaded leniently (zeros assumed at
+		// simulation start), but the RLE decoder rejects addresses at
+		// or past the capacity - so encoding them would save a file
+		// the loader refuses to read back. Found by the generative
+		// fuzzer (issue #160).
+		assertNull(Memory.encodeInitRLE("22 3\n", 32),
+				"an address past the capacity bound must stay raw");
+		assertNotNull(Memory.encodeInitRLE("1f 3\n", 32),
+				"the last in-capacity address must still encode");
+	}
+
+	@Test
 	void bigValuesSurvive() {
 		String text = "0 ffffffffffffffffffff\n"; // wider than a long
 		String rle = Memory.encodeInitRLE(text);

--- a/test/jls/hdl/CliVerilogExportTest.java
+++ b/test/jls/hdl/CliVerilogExportTest.java
@@ -43,6 +43,7 @@ class CliVerilogExportTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/hdl/CliVhdlExportTest.java
+++ b/test/jls/hdl/CliVhdlExportTest.java
@@ -43,6 +43,7 @@ class CliVhdlExportTest {
 				+ File.separator + "bin" + File.separator + "java";
 		List<String> cmd = new ArrayList<>();
 		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
 		cmd.add("-Djava.awt.headless=true");
 		cmd.add("-cp");
 		cmd.add(System.getProperty("java.class.path"));

--- a/test/jls/ui/DialogConstructionSmokeTest.java
+++ b/test/jls/ui/DialogConstructionSmokeTest.java
@@ -1,0 +1,253 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.elem.Element;
+
+/**
+ * Layer-2 dialog-construction smoke (issue #162): every element
+ * create/edit dialog is constructed for real - the {@code setup()}
+ * entry the editor's palette click runs - under a display, and
+ * dismissed through the close-box path (WINDOW_CLOSING, which
+ * ElementDialog wires to cancel). This exercises the full dialog
+ * build: form layout, field defaults, key bindings, help wiring.
+ *
+ * These tests are tagged {@code display} and run in a separate
+ * surefire execution with {@code java.awt.headless} controlled by the
+ * {@code jls.test.headless} property: plain builds keep it true and
+ * this suite self-skips; the CI leg (and local runs) execute it under
+ * {@code xvfb-run -a mvn -B verify -Djls.test.headless=false}. The
+ * suite must never run with the shared headless execution - with a
+ * display present, TellUser becomes interactive and a stray warning
+ * in an unrelated test would block on a modal dialog.
+ *
+ * A watcher thread dispatches WINDOW_CLOSING to every visible dialog
+ * for the whole test, so a modal dialog opened on the EDT (which
+ * pumps its own event loop) always comes back down; it also swats
+ * any stray JOptionPane a dialog might raise on the way out.
+ */
+@Tag("display")
+class DialogConstructionSmokeTest {
+
+	/** Per-dialog time allowance before the run is declared stuck. */
+	private static final long DIALOG_TIMEOUT_SECONDS = 30;
+
+	private volatile boolean closing;
+	private Thread closer;
+
+	@BeforeEach
+	void requireDisplayAndStartCloser() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		closing = true;
+		closer = new Thread(() -> {
+			while (closing) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (w.isVisible() && w instanceof JDialog) {
+							w.dispatchEvent(new WindowEvent(w,
+									WindowEvent.WINDOW_CLOSING));
+						}
+					}
+				});
+				try {
+					Thread.sleep(50);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "dialog-closer");
+		closer.setDaemon(true);
+		closer.start();
+	}
+
+	@AfterEach
+	void stopCloserAndDisposeStrays() throws Exception {
+		closing = false;
+		if (closer != null) {
+			closer.join(1000);
+		}
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Instantiate the element and run its setup() - the create-dialog
+	 * entry point - on the EDT, as the editor does. The watcher cancels
+	 * the dialog; setup returning (either verdict) is the assertion.
+	 */
+	private void constructAndCancel(String elementClass) throws Exception {
+		Circuit circuit = new Circuit("golden");
+		Element el = (Element) Class.forName("jls.elem." + elementClass)
+				.getConstructor(Circuit.class).newInstance(circuit);
+
+		BufferedImage img = new BufferedImage(400, 300,
+				BufferedImage.TYPE_INT_RGB);
+		CountDownLatch done = new CountDownLatch(1);
+		Throwable[] thrown = new Throwable[1];
+		SwingUtilities.invokeLater(() -> {
+			try {
+				el.setup(img.createGraphics(), new JPanel(), 100, 100);
+			} catch (Throwable t) {
+				thrown[0] = t;
+			} finally {
+				done.countDown();
+			}
+		});
+		assertTrue(done.await(DIALOG_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+				elementClass + ": dialog did not come back down - stuck"
+						+ " modal window");
+		if (thrown[0] != null) {
+			fail(elementClass + ": setup threw", thrown[0]);
+		}
+	}
+
+	// One test per dialog family, so a failure names its element and
+	// the rest still run. Families sharing one dialog class are
+	// represented once (AndGate stands in for the Gate dialog used by
+	// all five two-input gate kinds and NotGate).
+
+	@Test
+	void gateDialog() throws Exception {
+		constructAndCancel("AndGate");
+	}
+
+	@Test
+	void delayGateDialog() throws Exception {
+		constructAndCancel("DelayGate");
+	}
+
+	@Test
+	void extendDialog() throws Exception {
+		constructAndCancel("Extend");
+	}
+
+	@Test
+	void adderDialog() throws Exception {
+		constructAndCancel("Adder");
+	}
+
+	@Test
+	void clockDialog() throws Exception {
+		constructAndCancel("Clock");
+	}
+
+	@Test
+	void constantDialog() throws Exception {
+		constructAndCancel("Constant");
+	}
+
+	@Test
+	void decoderDialog() throws Exception {
+		constructAndCancel("Decoder");
+	}
+
+	@Test
+	void displayDialog() throws Exception {
+		constructAndCancel("Display");
+	}
+
+	@Test
+	void memoryDialog() throws Exception {
+		constructAndCancel("Memory");
+	}
+
+	@Test
+	void muxDialog() throws Exception {
+		constructAndCancel("Mux");
+	}
+
+	@Test
+	void registerDialog() throws Exception {
+		constructAndCancel("Register");
+	}
+
+	@Test
+	void shiftRegisterDialog() throws Exception {
+		constructAndCancel("ShiftRegister");
+	}
+
+	@Test
+	void sigGenDialog() throws Exception {
+		constructAndCancel("SigGen");
+	}
+
+	@Test
+	void stateMachineEditor() throws Exception {
+		// the big one: setup opens the full StateEditor window
+		constructAndCancel("StateMachine");
+	}
+
+	@Test
+	void textDialog() throws Exception {
+		constructAndCancel("Text");
+	}
+
+	@Test
+	void triStateDialog() throws Exception {
+		constructAndCancel("TriState");
+	}
+
+	@Test
+	void truthTableEditor() throws Exception {
+		constructAndCancel("TruthTable");
+	}
+
+	@Test
+	void jumpStartDialog() throws Exception {
+		constructAndCancel("JumpStart");
+	}
+
+	@Test
+	void jumpEndDialog() throws Exception {
+		constructAndCancel("JumpEnd");
+	}
+
+	@Test
+	void binderRangesDialog() throws Exception {
+		constructAndCancel("Binder");
+	}
+
+	@Test
+	void splitterRangesDialog() throws Exception {
+		constructAndCancel("Splitter");
+	}
+
+	@Test
+	void inputPinDialog() throws Exception {
+		constructAndCancel("InputPin");
+	}
+
+	@Test
+	void outputPinDialog() throws Exception {
+		constructAndCancel("OutputPin");
+	}
+
+	@Test
+	void subCircuitCreateDialog() throws Exception {
+		// cancelled at the SubCreate dialog, before any file chooser
+		constructAndCancel("SubCircuit");
+	}
+}

--- a/test/jls/ui/EditorGestureSupport.java
+++ b/test/jls/ui/EditorGestureSupport.java
@@ -1,0 +1,265 @@
+package jls.ui;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Window;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import javax.swing.event.MouseInputListener;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.edit.Editor;
+import jls.sim.InteractiveSimulator;
+
+/**
+ * Layer-2 gesture harness (issue #91): boots a real {@link Editor} on a
+ * circuit and drives its mouse state machine with synthetic
+ * {@link MouseEvent}s dispatched to the canvas on the EDT.
+ *
+ * Synthetic events, not {@link java.awt.Robot}: the editor's move,
+ * select, and menu paths read {@code event.getX()/getY()} (not
+ * {@code getMousePosition()}), so they are fully drivable without a real
+ * pointer - which makes the suite deterministic and fast instead of
+ * fighting Robot/Xvfb timing. Palette placement is the one flow that
+ * genuinely needs a live pointer; it is covered separately by
+ * {@link DialogConstructionSmokeTest} (which runs each element's
+ * {@code setup()}), so it is deliberately out of scope here.
+ *
+ * Everything the harness touches survives the #84 SimpleEditor
+ * decomposition: the canvas (found structurally as the scroll pane's
+ * mouse-listening viewport view), the popup menus (found by item text),
+ * and the circuit model asserted by {@link CircuitAssert}. It still
+ * needs a display for the popup {@code show()} calls and font metrics,
+ * so it is tagged {@code display} and runs under the #162 substrate.
+ */
+final class EditorGestureSupport implements AutoCloseable {
+
+	final JFrame frame;
+	final Editor editor;
+	final Circuit circuit;
+	private final Component canvas;
+	private long when = 1_000_000L;
+
+	EditorGestureSupport(Circuit circuit) throws Exception {
+		this.circuit = circuit;
+		// undo/redo restore snapshots through JLSInfo.sim, which only the
+		// full JLSStart GUI sets. The harness builds an Editor directly,
+		// so it must supply the simulator the editor's undo path expects
+		// (without this, undo NPEs - a harness gap, not an app bug).
+		if (JLSInfo.sim == null) {
+			JLSInfo.sim = new InteractiveSimulator();
+		}
+
+		AtomicReference<JFrame> frameRef = new AtomicReference<>();
+		AtomicReference<Editor> editorRef = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> {
+			JFrame f = new JFrame("gesture-harness");
+			JTabbedPane tabs = new JTabbedPane();
+			Editor ed = new Editor(tabs, circuit, circuit.getName(),
+					new Circuit("clipboard"));
+			tabs.addTab(circuit.getName(), ed);
+			f.add(tabs);
+			f.setSize(1000, 800);
+			f.setLocation(0, 0);
+			f.setVisible(true);
+			frameRef.set(f);
+			editorRef.set(ed);
+		});
+		frame = frameRef.get();
+		editor = editorRef.get();
+		canvas = findCanvas(editor);
+		if (canvas == null) {
+			throw new AssertionError("could not find the edit canvas");
+		}
+		SwingUtilities.invokeAndWait(() -> {}); // let the frame realize
+		forcePaint(); // establishes the undo base snapshot (first paint)
+	}
+
+	/**
+	 * Force a synchronous paint of the canvas. The editor pushes its
+	 * undo base snapshot on the first {@code paintComponent}; synthetic
+	 * gestures fire before the window manager's async first paint, so
+	 * without this the undo stack has no base and undo is a no-op.
+	 */
+	void forcePaint() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			java.awt.Graphics g = canvas.getGraphics();
+			if (g != null) {
+				canvas.paint(g);
+				g.dispose();
+			}
+		});
+	}
+
+	/**
+	 * The editor's current circuit. Undo/redo rebuild the circuit
+	 * through the load path and swap in a fresh instance
+	 * ({@code finishDo}: {@code circuit = newCopy}), so the reference
+	 * the harness was constructed with goes stale after an undo -
+	 * always read live state through here.
+	 */
+	Circuit currentCircuit() {
+		return editor.getCircuit();
+	}
+
+	@Override
+	public void close() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	// ------------------------------------------------------------------
+	// gestures - each dispatches synchronously on the EDT
+	// ------------------------------------------------------------------
+
+	private void dispatch(int id, int x, int y, int button,
+			int modifiers, boolean popup) throws Exception {
+		MouseEvent e = new MouseEvent(canvas, id, when++, modifiers,
+				x, y, 1, popup, button);
+		SwingUtilities.invokeAndWait(() -> canvas.dispatchEvent(e));
+	}
+
+	/** Left-press, drag through an intermediate point, release. */
+	void leftDrag(int fromX, int fromY, int toX, int toY) throws Exception {
+		dispatch(MouseEvent.MOUSE_PRESSED, fromX, fromY,
+				MouseEvent.BUTTON1, InputEvent.BUTTON1_DOWN_MASK, false);
+		int midX = (fromX + toX) / 2;
+		int midY = (fromY + toY) / 2;
+		dispatch(MouseEvent.MOUSE_DRAGGED, midX, midY, MouseEvent.NOBUTTON,
+				InputEvent.BUTTON1_DOWN_MASK, false);
+		dispatch(MouseEvent.MOUSE_DRAGGED, toX, toY, MouseEvent.NOBUTTON,
+				InputEvent.BUTTON1_DOWN_MASK, false);
+		dispatch(MouseEvent.MOUSE_RELEASED, toX, toY, MouseEvent.BUTTON1,
+				0, false);
+	}
+
+	/** A left click (press then release) at a point, no drag. */
+	void leftClick(int x, int y) throws Exception {
+		dispatch(MouseEvent.MOUSE_PRESSED, x, y, MouseEvent.BUTTON1,
+				InputEvent.BUTTON1_DOWN_MASK, false);
+		dispatch(MouseEvent.MOUSE_RELEASED, x, y, MouseEvent.BUTTON1,
+				0, false);
+	}
+
+	/** A right press (the popup trigger the editor checks for). */
+	void rightPress(int x, int y) throws Exception {
+		dispatch(MouseEvent.MOUSE_PRESSED, x, y, MouseEvent.BUTTON3,
+				InputEvent.BUTTON3_DOWN_MASK, true);
+	}
+
+	/**
+	 * Click the visible popup-menu item with the given text. The editor
+	 * shows its option/new menus with {@code show(this, x, y)}; the item
+	 * is found by walking every window's popup and doClick'd, which
+	 * fires the same actionPerformed the user's click would.
+	 */
+	void clickPopupItem(String text) throws Exception {
+		JMenuItem item = waitForMenuItem(text);
+		SwingUtilities.invokeAndWait(item::doClick);
+	}
+
+	// ------------------------------------------------------------------
+	// waiting and lookup
+	// ------------------------------------------------------------------
+
+	void pause(int ms) {
+		try {
+			Thread.sleep(ms);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	/** Poll the model until a condition holds, or fail after a bound. */
+	void waitFor(java.util.function.BooleanSupplier condition, String what) {
+		for (int i = 0; i < 200; i++) {
+			if (condition.getAsBoolean()) {
+				return;
+			}
+			pause(25);
+		}
+		throw new AssertionError("timed out waiting for " + what);
+	}
+
+	private JMenuItem waitForMenuItem(String text) {
+		for (int i = 0; i < 200; i++) {
+			AtomicReference<JMenuItem> found = new AtomicReference<>();
+			try {
+				SwingUtilities.invokeAndWait(() -> {
+					for (Window w : Window.getWindows()) {
+						JMenuItem item = findMenuItem(w, text);
+						if (item != null) {
+							found.set(item);
+							return;
+						}
+					}
+					found.set(findMenuItem(frame, text));
+				});
+			} catch (Exception e) {
+				throw new AssertionError("EDT lookup failed", e);
+			}
+			if (found.get() != null) {
+				return found.get();
+			}
+			pause(25);
+		}
+		throw new AssertionError("timed out waiting for popup item '"
+				+ text + "'");
+	}
+
+	/** The drawing canvas: the scroll pane's mouse-listening view. */
+	private static Component findCanvas(Container root) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JScrollPane pane) {
+				Component view = pane.getViewport().getView();
+				if (view instanceof MouseInputListener
+						|| view instanceof java.awt.event.MouseListener) {
+					return view;
+				}
+			}
+			if (c instanceof Container inner) {
+				Component found = findCanvas(inner);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static JMenuItem findMenuItem(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JPopupMenu menu && menu.isVisible()) {
+				for (Component mc : menu.getComponents()) {
+					if (mc instanceof JMenuItem item
+							&& text.equals(item.getText())) {
+						return item;
+					}
+				}
+			}
+			if (c instanceof JMenuItem item && text.equals(item.getText())
+					&& item.isShowing()) {
+				return item;
+			}
+			if (c instanceof Container inner) {
+				JMenuItem found = findMenuItem(inner, text);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/test/jls/ui/EditorGestureTest.java
+++ b/test/jls/ui/EditorGestureTest.java
@@ -1,0 +1,182 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.JLSInfo;
+import jls.elem.AndGate;
+import jls.elem.Constant;
+import jls.elem.Element;
+
+/**
+ * Layer-2 editor gesture characterization (issues #91 and #84). Each
+ * test loads a circuit into a real {@link jls.edit.Editor} and drives
+ * the SimpleEditor mouse state machine with synthetic events - move,
+ * rubber-band select, right-click delete, undo/redo - then asserts the
+ * resulting circuit model. These are the safety net for the #84
+ * decomposition: they touch only surfaces that survive it (canvas
+ * events, popup item texts, the circuit model), so the decomposition is
+ * correct exactly when this suite stays green.
+ *
+ * Tagged {@code display}: runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false), self-skips
+ * headless. Fast and deterministic - no Robot, no getMousePosition.
+ */
+@Tag("display")
+@Timeout(60)
+class EditorGestureTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/** A circuit with a single AND gate near the top-left of the canvas. */
+	private static Circuit oneGate() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static int centerX(Element el) {
+		return el.getX() + el.getRect().width / 2;
+	}
+
+	private static int centerY(Element el) {
+		return el.getY() + el.getRect().height / 2;
+	}
+
+	@Test
+	void pressAndDragMovesAnElement() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			int fromX = centerX(gate), fromY = centerY(gate);
+			int beforeX = gate.getX(), beforeY = gate.getY();
+
+			ui.leftDrag(fromX, fromY, fromX + 120, fromY + 96);
+			ui.waitFor(() -> gate.getX() != beforeX || gate.getY() != beforeY,
+					"gate moved");
+			GeometryAssert.assertOnGrid(gate);
+			// the move must land near the drag delta (grid-snapped)
+			assertTrue(Math.abs(gate.getX() - (beforeX + 120)) <= 12
+					&& Math.abs(gate.getY() - (beforeY + 96)) <= 12,
+					"gate moved to roughly the drop point: "
+							+ gate.getX() + "," + gate.getY());
+		}
+	}
+
+	@Test
+	void rubberBandSelectHighlightsEnclosedElements() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			// drag a rectangle from empty space fully around the gate
+			int x0 = gate.getX() - 40, y0 = gate.getY() - 40;
+			int x1 = gate.getX() + gate.getRect().width + 40;
+			int y1 = gate.getY() + gate.getRect().height + 40;
+			ui.leftDrag(x0, y0, x1, y1);
+			ui.waitFor(gate::isHighlighted,
+					"gate highlighted by rubber-band select");
+		}
+	}
+
+	@Test
+	void rightClickDeleteRemovesTheElement() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			ui.rightPress(centerX(gate), centerY(gate));
+			ui.clickPopupItem("Delete");
+			ui.waitFor(() -> circuit.getElements().stream()
+					.noneMatch(el -> el instanceof AndGate),
+					"gate deleted");
+		}
+	}
+
+	@Test
+	void undoRestoresADeletedElementAndRedoRemovesItAgain()
+			throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			ui.rightPress(centerX(gate), centerY(gate));
+			ui.clickPopupItem("Delete");
+			ui.waitFor(() -> circuit.getElements().stream()
+					.noneMatch(el -> el instanceof AndGate), "gate deleted");
+
+			// undo lives on the empty-canvas popup; open it well away
+			// from where the gate was. Undo swaps in a fresh circuit
+			// instance, so observe the editor's live circuit, not the
+			// stale reference this test was built with.
+			ui.rightPress(700, 600);
+			ui.clickPopupItem("Undo");
+			ui.waitFor(() -> ui.currentCircuit().getElements().stream()
+					.anyMatch(el -> el instanceof AndGate),
+					"gate restored by undo");
+
+			ui.rightPress(700, 600);
+			ui.clickPopupItem("Redo");
+			ui.waitFor(() -> ui.currentCircuit().getElements().stream()
+					.noneMatch(el -> el instanceof AndGate),
+					"gate removed again by redo");
+		}
+	}
+
+	@Test
+	void movingOneOfTwoElementsLeavesTheOtherPut() throws Exception {
+		// hand-positioned so the two elements are well separated - the
+		// builder's auto-layout packs them 24px apart, which would let a
+		// press aimed at one land on the other
+		String text = "CIRCUIT golden\n"
+				+ "ELEMENT AndGate\n int id 0\n int x 300\n int y 300\n"
+				+ " int width 48\n int height 24\n int bits 1\n"
+				+ " int numInputs 2\n String orientation \"right\"\n"
+				+ " int delay 10\nEND\n"
+				+ "ELEMENT Constant\n int id 1\n int x 60\n int y 60\n"
+				+ " int width 24\n int height 24\n Int value 5\n"
+				+ " int base 10\n String orient \"RIGHT\"\nEND\n"
+				+ "ENDCIRCUIT\n";
+		Circuit circuit = new Circuit("golden");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			Constant constant = assertElementPresent(circuit, Constant.class);
+			int constX = constant.getX(), constY = constant.getY();
+
+			ui.leftDrag(centerX(gate), centerY(gate),
+					centerX(gate) + 96, centerY(gate) + 120);
+			ui.waitFor(() -> gate.getY() != constY || gate.getX() != constX
+					|| gate.getX() != constX, "gate moved");
+			assertEquals(constX, constant.getX(),
+					"the un-dragged constant must not move in x");
+			assertEquals(constY, constant.getY(),
+					"the un-dragged constant must not move in y");
+			assertNotEquals(gate.getX() + "," + gate.getY(),
+					constX + "," + constY, "the gate did move");
+		}
+	}
+}


### PR DESCRIPTION
## What & why

Two threads of the open-issue backlog: adopt the surviving library-survey recommendations, and drive the coverage program from ~31% to over 55% line — building the test infrastructure the higher-coverage issues were waiting on. Ten commits; three pre-existing bugs found and fixed by the new tests along the way.

**Library adoptions (from `docs/library-survey-2026-07.md`)**
- **JFreeSVG (#154)** — `-i out.svg` exports resolution-independent SVG through the existing element paint path (GPLv3, +55 KB jar). Draws in a stable geometric order so output is byte-identical across runs and load instances.
- **ArchUnit (#155)** — three bytecode-level architecture rules (test scope): `TellUser`-only `JOptionPane`, CLI-only HDL wiring, and `jls.sim ↛ jls.edit` with the three simulator classes pinned as a shrinking baseline.
- **Error Prone (#157)** — trialed (zero true bugs among 99 style warnings); kept as an opt-in `-Perrorprone` profile because it is the plumbing #93's NullAway will ride, not gated into the default build.

**Coverage program**
- **Generative fuzzing (#160)** — seeded, dependency-free round-trip and container-mutation fuzzers.
- **Element simulation goldens (#158)** — every simulating palette element gets a behavioral golden (expected values computed independently of the implementation) plus a reflective completeness ratchet.
- **CLI subprocess coverage (#159)** — the JaCoCo agent now rides into the JVMs the CLI suites spawn (`JLSStart` 4.7% → 25.5%).
- **Draw/print smoke + Util/Memory tests** — every element drawn on both export canvases and every print-book page rendered, headlessly.
- **Display-test substrate (#162)** — a `display`-tagged surefire execution, headless-skipping by default and run under `xvfb-run … -Djls.test.headless=false` (CI now does this). Tenants: `DialogConstructionSmokeTest` (all 24 element dialogs) and `EditorGestureTest`.
- **Editor gesture layer (#91 layer 2, safety net for #84)** — drives the `SimpleEditor` mouse state machine with synthetic `MouseEvent`s (not `Robot`): move, rubber-band select, right-click delete, undo/redo. Deterministic, ~1.3 s. This took `jls.edit` from 5.9% → 48.3%.

**Bugs fixed (all found by the new tests)**
- Memory saved an `initrle` attribute its own loader rejected when init text named out-of-capacity addresses (#160).
- `TruthTable.print` NPE'd on any circuit printed before its edit dialog had ever opened (#91).
- SVG export was byte-unstable across load instances (draw order); now geometric (#154).

Coverage ratchet floors raised from 17.5%/18.0% (2026-07-08) to 42.0%/40.0% instruction/line with a first 36.5% BRANCH floor. Floors are pinned to the *headless* measurement so a plain `mvn verify` passes anywhere; under the CI display substrate the same commit measures **57.9% / 55.5% / 44.2%** (instruction / line / branch) — the >50% line milestone that gates PIT adoption (#161).

Closes #154
Closes #155
Closes #157
Closes #158
Closes #160

Advances #159, #162, #91, #161, #84 (coverage-climb program, UI-coverage tracking, UI harness, PIT gate now reached, and the SimpleEditor decomposition's characterization net) — these stay open with progress recorded in their threads.

## Testing

`mvn verify` green on JDK 25 and 26. Full suite: 488 tests (459 headless + 29 under the display substrate), 0 failures.

- Fuzzers and goldens pinned as regression tests; each new golden's detection power was demonstrated per #158's protocol (a mutated Mux select passes the whole prior suite and fails only the new golden).
- The display suite runs under `xvfb-run -a mvn -B verify -Djls.test.headless=false` (self-skips headless; verified 29-run-under-xvfb / 29-skip-plain, and the gesture suite stable across 3 consecutive runs).
- CI is green across all legs: Build (JDK 25), Build (JDK 26), GUI first light (Wayland/JBR), Verify Agda proofs, Reproducible build check, and CodeQL. The one CodeQL alert (uncaught `NumberFormatException` in a test parse) is fixed in the final commit.