### PR TITLE
Stable element identity: permanent ids minted at creation (#165)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Circuit fixtures are byte-exact test inputs (issue #111): a CRLF
+# rewrite on checkout would silently change what the round-trip and
+# determinism suites compare against. Never translate them.
+*.jls -text
+*.jls~ -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Stable element identity (#165, collaboration stage 0a): every
+  element now carries a permanent id (`replica:counter`), minted at
+  creation and persisted in the save format as a new `sid` base
+  attribute. Files that predate the field mint deterministic
+  `legacy:N` ids at load, in file order, so every load of the same
+  file agrees. Identity survives save/load, undo restore, and
+  checkpoint recovery; copying mints a fresh id (a paste is a new
+  element). A file declaring the same id twice is refused with a
+  structured load error. No format-version bump: the attribute is
+  simulation-neutral metadata under the documented evolution policy
+  (`docs/file-format.md` §8-9).
+- Deterministic canonical serialization (#166, collaboration stage
+  0c): a circuit's saved form is now a pure function of its content.
+  Elements are emitted sorted by stable id with the file-local
+  `id`s (and so the wire `ref` lines) assigned in that order -
+  previously two loads of the same file saved differently in 261 of
+  276 lines on the fork shift-register fixture. Round-trip suites
+  now assert byte equality end to end; the test-side `canonicalize`
+  workaround (documented as unsound for circuits with wires) is
+  deleted. `Circuit.stateHash()` exposes the SHA-256 of the
+  canonical bytes as the convergence oracle for #163.
 - Per-element simulation goldens with a completeness ratchet (#158):
   every simulating palette element now has a behavioral pin -
   Adder (sum/carry sweep), Decoder (one-hot), Extend, Mux, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Fixed
+- Circuits saved on Windows are now byte-identical to the same
+  circuits saved on Linux (#111): `Circuit.save` pins `\n` line
+  endings whatever the platform separator is, which the
+  deterministic-serialization guarantee (#166) and `stateHash`
+  require. Also fixed the first of the Windows test failures
+  (`CircuitRoundTripTest.saveLoadIsAFixedPoint`).
+- Opening a circuit no longer keeps the file locked (#111): the
+  XZ and plain-text read paths drained the file lazily through the
+  returned Scanner, holding an open handle for the circuit's whole
+  editing lifetime - which on Windows blocks deletion (and broke
+  the test suite's temp-dir cleanup). All three container paths now
+  read into memory (already bounded by the 64 MiB hostile-input cap)
+  and release the file before returning. A `.gitattributes` entry
+  additionally protects the byte-exact `.jls` fixtures from CRLF
+  rewriting on Windows checkouts.
 - Printing a freshly loaded circuit containing a truth table no longer
   crashes with a NullPointerException: `TruthTable.print` assumed the
   table's display panel had been built by the edit dialog, which is

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -368,6 +368,15 @@ pre-#165 reader that drops it loses nothing but identity continuity
 version. Distributed collaboration (issue #163) addresses elements
 by stable id.
 
+**Canonical order** (issue #166): the canonical writer emits element
+blocks sorted by stable id and assigns the save-time `id`s in that
+same order, making the serialized form a pure function of circuit
+content — two circuits with identical content save byte-identically,
+whatever their load/edit history. A reader MUST NOT rely on this
+order (block order is not significant, §5), but tools MAY rely on
+JLS saves being deterministic, and JLS uses the canonical bytes as
+its convergence oracle and state hash for collaboration.
+
 ---
 
 ## 9. Evolution policy

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -205,7 +205,7 @@ element's attributes; their order is not significant to the reader,
 but the canonical writer order is: the base attributes, then the
 type's own attributes, in each type's historical order.
 
-**Base attributes** (every element type; all `int`):
+**Base attributes** (every element type; `int` unless noted):
 <!-- Element.java: BASE_ATTRIBUTES, in save order. -->
 
 | attribute | meaning | omitted when |
@@ -215,6 +215,7 @@ type's own attributes, in each type's historical order.
 | `width`, `height` | drawn size | the type recomputes size on load |
 | `fixed` | element is not editable | editable (any value ⇒ fixed) |
 | `trpos` | position in the signal-trace window | `-1` (not traced) |
+| `sid` | permanent element identity (`String`, §8) | never |
 
 **Unknown attribute names are silently ignored.** The reader offers
 each item's name and value to the element; if no declared attribute
@@ -349,6 +350,24 @@ MUST resolve refs only within the block; writers MUST NOT emit
 forward ids that don't exist in the block. Ids carry no meaning
 beyond reference resolution and are not stable across saves.
 
+**Stable ids** (`sid`, issue #165) are the opposite: a permanent
+identity minted once, when the element comes into existence, and
+preserved by every save, load, undo restore, and checkpoint
+recovery. The value is `replica:counter`, where the replica id is
+1–64 characters of `[0-9a-z]` naming where the element was created
+and the counter is a non-negative decimal. Copying an element mints
+a fresh id — a paste is a new element. Stable ids MUST be unique
+within their `CIRCUIT` block; a reader MUST refuse a file that
+declares the same `sid` twice in one block. Elements in files that
+predate `sid` (or hand-edited blocks without one) get an id minted
+at load under the reserved replica id `legacy`, numbered in file
+order — deterministically, so every load of the same file mints the
+same ids. `sid` is metadata: it never affects simulation, and a
+pre-#165 reader that drops it loses nothing but identity continuity
+(§9's silent-drop caveat), which is why it did not bump the format
+version. Distributed collaboration (issue #163) addresses elements
+by stable id.
+
 ---
 
 ## 9. Evolution policy
@@ -424,6 +443,7 @@ ELEMENT Constant
  int y 60
  int width 24
  int height 24
+ String sid "legacy:0"
  Int value 5
  int base 10
  String orient "RIGHT"
@@ -434,6 +454,7 @@ ELEMENT OutputPin
  int y 60
  int width 48
  int height 24
+ String sid "legacy:1"
  String name "out"
  int bits 3
  int watch 0
@@ -445,6 +466,7 @@ ELEMENT WireEnd
  int y 72
  int width 8
  int height 8
+ String sid "legacy:2"
  String put "output"
  ref attach 0
  ref wire 3
@@ -455,6 +477,7 @@ ELEMENT WireEnd
  int y 72
  int width 8
  int height 8
+ String sid "legacy:3"
  String put "input"
  ref attach 1
  ref wire 2

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -964,6 +964,37 @@ public class Circuit implements Printable {
 		// if any exceptions, assume load problem
 		try {
 
+			// stable identity (#165): file-declared stable ids must be
+			// unique within the circuit, and elements from files that
+			// predate stable ids get one minted deterministically - in
+			// file order, which is itself deterministic (#98), so two
+			// loads of the same file always agree
+			Set<jls.elem.ElementId> usedIds = new HashSet<jls.elem.ElementId>();
+			for (Element el : loadedElements) {
+				if (el.hasFileStableId() && !usedIds.add(el.getStableId())) {
+					JLSInfo.setLoadError(LoadError.of(
+							LoadError.Category.ELEMENT_ERROR,
+							"two elements declare the same stable id '"
+									+ el.getStableId() + "'",
+							"Remove the duplicated sid line from the file, "
+									+ "or re-save the circuit from JLS."));
+					return false;
+				}
+			}
+			long nextLegacy = 0;
+			for (Element el : loadedElements) {
+				if (el.hasFileStableId()) {
+					continue;
+				}
+				jls.elem.ElementId minted;
+				do {
+					minted = jls.elem.ElementId.legacy(nextLegacy);
+					nextLegacy += 1;
+				} while (usedIds.contains(minted));
+				usedIds.add(minted);
+				el.assignLegacyStableId(minted);
+			}
+
 			// finish up non-wire ends first
 			for (Element el : loadedElements) {
 				if (el instanceof WireEnd)

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1123,21 +1123,64 @@ public class Circuit implements Printable {
 			output.println("CIRCUIT " + name);
 		}
 
+		// canonical save order (#166): elements sorted by stable id,
+		// wires - which are reconstructed from refs and save nothing -
+		// after every saved block. The sequential file-local ids are
+		// assigned in that same order, so id and ref lines depend only
+		// on circuit content: two circuits with identical content save
+		// byte-identically, whatever their load/edit history.
+		java.util.List<Element> ordered =
+				new java.util.ArrayList<Element>(elements);
+		ordered.sort(java.util.Comparator
+				.comparingInt((Element el) -> el instanceof Wire ? 1 : 0)
+				.thenComparing(Element::getStableId));
+
 		// give each element a unique id
 		int id = 0;
-		for (Element el : elements) {
+		for (Element el : ordered) {
 			el.setID(id);
 			id += 1;
 		}
 
 		// save elements
-		for (Element el : elements) {
+		for (Element el : ordered) {
 			el.save(output);
 		}
 
 		// write trailer
 		output.println("ENDCIRCUIT");
 	} // end of save method
+
+	/**
+	 * A hash of this circuit's canonical serialized form (#166): equal
+	 * for any two circuits with identical content, whatever their
+	 * load/edit history. The convergence oracle and sync indicator for
+	 * collaborative editing (#163).
+	 *
+	 * @return the SHA-256 of the canonical save text, in lowercase hex.
+	 */
+	public String stateHash() {
+
+		java.io.StringWriter text = new java.io.StringWriter();
+		try (PrintWriter out = new PrintWriter(text)) {
+			save(out);
+		}
+		java.security.MessageDigest sha;
+		try {
+			sha = java.security.MessageDigest.getInstance("SHA-256");
+		} catch (java.security.NoSuchAlgorithmException ex) {
+			// every JRE ships SHA-256 (it is required by the platform spec)
+			throw new AssertionError(ex);
+		}
+		byte[] digest = sha.digest(text.toString()
+				.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+		StringBuilder hex = new StringBuilder(digest.length * 2);
+		for (byte b : digest) {
+			hex.append(Character.forDigit((b >> 4) & 0xf, 16));
+			hex.append(Character.forDigit(b & 0xf, 16));
+		}
+		return hex.toString();
+	} // end of stateHash method
 
 	/**
 	 * The save-format version a save of this circuit must declare: the

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1113,14 +1113,22 @@ public class Circuit implements Printable {
 	 */
 	public void save(PrintWriter output) {
 
+		// canonical newlines (#111, #166): println follows the platform
+		// line separator, but canonical bytes must be identical on every
+		// OS - a circuit saved on Windows must byte-match the same
+		// circuit saved on Linux, or determinism (and stateHash) would
+		// be platform-dependent. Wrap the writer so every println, here
+		// and in every element save method, terminates lines with '\n'.
+		PrintWriter out = canonicalNewlines(output);
+
 		// write header; a file-level save states the format version once
 		// at the top (issue #79) - nested subcircuit blocks, which are
 		// always saved through their imported circuit, never repeat it
 		if (isImported()) {
-			output.println("CIRCUIT " + subElement.getName());
+			out.println("CIRCUIT " + subElement.getName());
 		} else {
-			output.println("FORMAT " + formatVersionNeeded());
-			output.println("CIRCUIT " + name);
+			out.println("FORMAT " + formatVersionNeeded());
+			out.println("CIRCUIT " + name);
 		}
 
 		// canonical save order (#166): elements sorted by stable id,
@@ -1144,12 +1152,28 @@ public class Circuit implements Printable {
 
 		// save elements
 		for (Element el : ordered) {
-			el.save(output);
+			el.save(out);
 		}
 
 		// write trailer
-		output.println("ENDCIRCUIT");
+		out.println("ENDCIRCUIT");
+		out.flush();
 	} // end of save method
+
+	/**
+	 * Wrap a writer so println terminates lines with '\n' whatever the
+	 * platform line separator is. PrintWriter(Writer) adds no buffering,
+	 * so writes pass straight through to the wrapped writer.
+	 */
+	private static PrintWriter canonicalNewlines(PrintWriter output) {
+
+		return new PrintWriter(output) {
+			@Override
+			public void println() {
+				write('\n');
+			}
+		};
+	} // end of canonicalNewlines method
 
 	/**
 	 * A hash of this circuit's canonical serialized form (#166): equal

--- a/src/jls/FileAbstractor.java
+++ b/src/jls/FileAbstractor.java
@@ -218,7 +218,15 @@ public final class FileAbstractor {
 			raw.close();
 			throw ex;
 		}
-		return nonEmpty(new Scanner(new BoundedInputStream(xz),
+		// drain before returning: a Scanner over the live stream would
+		// keep the file open for as long as the caller holds it, and on
+		// Windows an open handle blocks deletion (issue #111) - the zip
+		// path already reads into memory, and the expansion is bounded
+		byte[] contents;
+		try (BoundedInputStream bounded = new BoundedInputStream(xz)) {
+			contents = bounded.readAllBytes();
+		}
+		return nonEmpty(new Scanner(new ByteArrayInputStream(contents),
 				StandardCharsets.UTF_8));
 	}
 
@@ -264,7 +272,19 @@ public final class FileAbstractor {
 					+ (MAX_CIRCUIT_TEXT_BYTES >> 20)
 					+ " MiB circuit size limit");
 		}
-		return nonEmpty(new Scanner(file, StandardCharsets.UTF_8));
+		// read into memory rather than scanning the file directly, so no
+		// handle stays open behind the returned Scanner (issue #111);
+		// decode strictly, as Scanner(File) did - the text probe is what
+		// rejects binary non-circuit files in the sniffing cascade
+		byte[] contents = Files.readAllBytes(file.toPath());
+		String text;
+		try {
+			text = StandardCharsets.UTF_8.newDecoder()
+					.decode(java.nio.ByteBuffer.wrap(contents)).toString();
+		} catch (java.nio.charset.CharacterCodingException ex) {
+			throw new IOException("not UTF-8 text");
+		}
+		return nonEmpty(new Scanner(text));
 	}
 
 	/**

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -21,7 +21,9 @@ import java.math.*;
 public class Element {
 
 	// saved properties
-	private int id; 						// unique for every element when written to file
+	private int id; 						// file-local reference index, reassigned on every save
+	private ElementId stableId = ElementId.mintFresh(); // permanent identity (#165)
+	private boolean stableIdFromFile = false; // whether stableId was declared by the loaded file
 	protected int x; 						// upper left corner of element
 	protected int y;						//   (snap-to position for most elements)
 	protected int width = 0; 				// size of element
@@ -204,6 +206,21 @@ public class Element {
 			protected void set(Element el, int value) { el.tracePosition = value; }
 			@Override
 			protected boolean omitted(Element el) { return el.tracePosition == -1; }
+		},
+		new Attribute.StringAttribute("sid") {
+			@Override
+			protected String get(Element el) { return el.stableId.toString(); }
+			@Override
+			protected void set(Element el, String value) {
+				el.stableId = ElementId.parse(value);
+				el.stableIdFromFile = true;
+			}
+			@Override
+			public void copy(Element from, Element to) {
+				// identity is never copied: a pasted element is a new
+				// element and keeps the fresh id minted at its
+				// construction (#165 P3)
+			}
 		}
 	);
 
@@ -462,6 +479,43 @@ public class Element {
 
 		this.id = id;
 	} // end of setID method
+
+	/**
+	 * Get this element's permanent identity (#165). Minted at creation,
+	 * persisted through saves, preserved by load and undo restore; a
+	 * copy gets a fresh one.
+	 *
+	 * @return the stable id.
+	 */
+	public ElementId getStableId() {
+
+		return stableId;
+	} // end of getStableId method
+
+	/**
+	 * Whether this element's stable id was declared by the file it was
+	 * loaded from, as opposed to minted at construction. Drives legacy
+	 * minting in Circuit.finishLoad: only elements without a
+	 * file-declared id get a deterministic legacy id.
+	 *
+	 * @return true if the id came from the loaded file.
+	 */
+	public boolean hasFileStableId() {
+
+		return stableIdFromFile;
+	} // end of hasFileStableId method
+
+	/**
+	 * Replace this element's stable id with a deterministically minted
+	 * legacy id (#165). Called only by Circuit.finishLoad for elements
+	 * read from files that predate stable ids.
+	 *
+	 * @param id The minted id.
+	 */
+	public void assignLegacyStableId(ElementId id) {
+
+		stableId = id;
+	} // end of assignLegacyStableId method
 
 	/**
 	 * Save all information about this element in a file.

--- a/src/jls/elem/ElementId.java
+++ b/src/jls/elem/ElementId.java
@@ -1,0 +1,159 @@
+package jls.elem;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * The permanent identity of an element (issue #165, collab Stage 0a):
+ * a replica id plus a creation counter. Unlike the save-time {@code int
+ * id} - a file-local reference index reassigned on every save - a stable
+ * id is minted once, when the element comes into existence, and then
+ * means the same element across save/load, undo restore, and checkpoint
+ * recovery. Replication and per-op addressing (issue #163) build on it.
+ *
+ * Two minting paths exist:
+ *
+ * <ul>
+ * <li>{@link #mintFresh()} - for elements created in this process
+ * (editor placement, paste, programmatic construction): a per-process
+ * random replica id plus a process-wide counter. When per-install
+ * identity keys land (issue #168), the replica id becomes the install's
+ * identity.</li>
+ * <li>{@link #legacy(long)} - for elements read from files that predate
+ * stable ids: the reserved replica id {@code legacy} plus the element's
+ * position in file order. File order is deterministic (issue #98), so
+ * two loads of the same legacy file mint identical ids - the property
+ * the deterministic-serialization work (issue #166) rests on.</li>
+ * </ul>
+ *
+ * The string form is {@code replica:counter}; the replica id is 1-64
+ * characters of {@code [0-9a-z]}, so the whole id survives the save
+ * format's string escaping untouched.
+ */
+public final class ElementId implements Comparable<ElementId> {
+
+	/** The reserved replica id for ids minted from pre-#165 files. */
+	private static final String LEGACY_REPLICA = "legacy";
+
+	/**
+	 * This process's replica id: 32 hex digits, drawn once per process
+	 * (a random UUID, which is itself SecureRandom-backed). Hex cannot
+	 * collide with the reserved "legacy" replica (it has no letter past
+	 * 'f').
+	 */
+	private static final String PROCESS_REPLICA =
+			java.util.UUID.randomUUID().toString().replace("-", "");
+
+	/** The process-wide creation counter for {@link #mintFresh()}. */
+	private static final AtomicLong NEXT_COUNTER = new AtomicLong();
+
+	private final String replica;
+	private final long counter;
+
+	private ElementId(String replica, long counter) {
+
+		this.replica = replica;
+		this.counter = counter;
+	} // end of constructor
+
+	/**
+	 * Mint the identity for an element being created right now, in this
+	 * process. Every call returns a distinct id.
+	 *
+	 * @return the new identity.
+	 */
+	public static ElementId mintFresh() {
+
+		return new ElementId(PROCESS_REPLICA, NEXT_COUNTER.getAndIncrement());
+	} // end of mintFresh method
+
+	/**
+	 * The identity for an element at the given file-order position of a
+	 * file that predates stable ids. Deterministic: the same file always
+	 * mints the same ids.
+	 *
+	 * @param counter The element's position in file order.
+	 *
+	 * @return the legacy identity.
+	 */
+	public static ElementId legacy(long counter) {
+
+		return new ElementId(LEGACY_REPLICA, counter);
+	} // end of legacy method
+
+	/**
+	 * Parse the {@code replica:counter} string form, as written by
+	 * {@link #toString()} into saved files.
+	 *
+	 * @param text The string form.
+	 *
+	 * @return the identity.
+	 *
+	 * @throws IllegalArgumentException if the text is not a well-formed
+	 *             stable id (the loader reports this as an element error,
+	 *             issue #52 taxonomy).
+	 */
+	public static ElementId parse(String text) {
+
+		int sep = text == null ? -1 : text.lastIndexOf(':');
+		if (sep < 1 || sep == text.length() - 1) {
+			throw new IllegalArgumentException("the stable id '" + text
+					+ "' is not in replica:counter form");
+		}
+		String replica = text.substring(0, sep);
+		if (!replica.matches("[0-9a-z]{1,64}")) {
+			throw new IllegalArgumentException("the stable id replica '"
+					+ replica + "' is not 1-64 characters of [0-9a-z]");
+		}
+		long counter;
+		try {
+			counter = Long.parseLong(text.substring(sep + 1));
+		} catch (NumberFormatException ex) {
+			throw new IllegalArgumentException("the stable id counter '"
+					+ text.substring(sep + 1) + "' is not a number");
+		}
+		if (counter < 0) {
+			throw new IllegalArgumentException("the stable id counter "
+					+ counter + " is negative");
+		}
+		return new ElementId(replica, counter);
+	} // end of parse method
+
+	/**
+	 * The canonical order (issue #166): by replica id, then by counter.
+	 */
+	@Override
+	public int compareTo(ElementId other) {
+
+		int byReplica = replica.compareTo(other.replica);
+		if (byReplica != 0) {
+			return byReplica;
+		}
+		return Long.compare(counter, other.counter);
+	} // end of compareTo method
+
+	@Override
+	public boolean equals(Object other) {
+
+		if (!(other instanceof ElementId)) {
+			return false;
+		}
+		ElementId id = (ElementId) other;
+		return counter == id.counter && replica.equals(id.replica);
+	} // end of equals method
+
+	@Override
+	public int hashCode() {
+
+		return replica.hashCode() * 31 + Long.hashCode(counter);
+	} // end of hashCode method
+
+	/**
+	 * The string form persisted in saved files: {@code replica:counter}.
+	 */
+	@Override
+	public String toString() {
+
+		return replica + ":" + counter;
+	} // end of toString method
+
+} // end of ElementId class

--- a/test/jls/AllElementsRoundTripTest.java
+++ b/test/jls/AllElementsRoundTripTest.java
@@ -151,95 +151,14 @@ class AllElementsRoundTripTest {
 
 	@Test
 	void saveLoadIsAFixedPointForEveryElementType() throws Exception {
+		// saves are canonical (#166): sorted by stable id, with ids and
+		// refs assigned in that order, so the fixed point holds
+		// byte-for-byte with no canonicalization
 		Circuit first = load(fixture());
 		String savedOnce = save(first);
 		Circuit second = load(savedOnce);
-		assertEquals(canonicalize(savedOnce), canonicalize(save(second)),
-				"save -> load -> save must be a fixed point");
-	}
-
-	/**
-	 * Reduce a saved file to a canonical form. Elements live in a HashSet,
-	 * so block order and the ids assigned at save time are not stable
-	 * across load instances; sort the blocks and renumber ids (and the
-	 * ref lines that use them) in sorted-block order.
-	 */
-	private static String canonicalize(String saved) {
-		// split into header and ELEMENT..END blocks
-		List<String> blocks = new ArrayList<String>();
-		StringBuilder current = null;
-		StringBuilder header = new StringBuilder();
-		for (String line : saved.split("\n")) {
-			if (line.startsWith("ELEMENT")) {
-				current = new StringBuilder();
-			}
-			if (current == null) {
-				header.append(line).append('\n');
-			} else {
-				current.append(line).append('\n');
-			}
-			if (line.equals("END") && current != null) {
-				blocks.add(current.toString());
-				current = null;
-			}
-		}
-		// sort by content with ids and ref targets masked
-		List<String> masked = new ArrayList<String>();
-		for (String b : blocks) {
-			masked.add(mask(b));
-		}
-		List<Integer> order = new ArrayList<Integer>();
-		for (int i = 0; i < blocks.size(); i++) {
-			order.add(i);
-		}
-		order.sort((a, b) -> masked.get(a).compareTo(masked.get(b)));
-		for (int i = 1; i < order.size(); i++) {
-			assertTrue(!masked.get(order.get(i - 1)).equals(masked.get(order.get(i))),
-					"fixture blocks must be pairwise distinct for canonicalization");
-		}
-		// renumber: old id -> position in sorted order
-		java.util.Map<String, String> newId = new java.util.HashMap<String, String>();
-		for (int pos = 0; pos < order.size(); pos++) {
-			String block = blocks.get(order.get(pos));
-			for (String line : block.split("\n")) {
-				if (line.startsWith(" int id ")) {
-					newId.put(line.substring(" int id ".length()).trim(),
-							Integer.toString(pos));
-				}
-			}
-		}
-		StringBuilder out = new StringBuilder(header);
-		for (int pos = 0; pos < order.size(); pos++) {
-			for (String line : blocks.get(order.get(pos)).split("\n")) {
-				if (line.startsWith(" int id ")) {
-					out.append(" int id ").append(pos).append('\n');
-				} else if (line.startsWith(" ref ")) {
-					String[] parts = line.trim().split("\\s+");
-					out.append(" ref ").append(parts[1]).append(' ')
-						.append(newId.get(parts[2])).append('\n');
-				} else {
-					out.append(line).append('\n');
-				}
-			}
-		}
-		return out.toString();
-	}
-
-	/** A block with its id and ref targets hidden, for stable sorting. */
-	private static String mask(String block) {
-		StringBuilder out = new StringBuilder();
-		for (String line : block.split("\n")) {
-			if (line.startsWith(" int id ")) {
-				continue;
-			}
-			if (line.startsWith(" ref ")) {
-				String[] parts = line.trim().split("\\s+");
-				out.append(" ref ").append(parts[1]).append(" ?\n");
-			} else {
-				out.append(line).append('\n');
-			}
-		}
-		return out.toString();
+		assertEquals(savedOnce, save(second),
+				"save -> load -> save must be a byte fixed point");
 	}
 
 	@Test

--- a/test/jls/AllElementsRoundTripTest.java
+++ b/test/jls/AllElementsRoundTripTest.java
@@ -262,11 +262,17 @@ class AllElementsRoundTripTest {
 				+ " checked only " + checked);
 	}
 
-	/** Saved text minus the id line, which save() writes but copy() skips. */
+	/**
+	 * Saved text minus the id and sid lines: save() writes both, but
+	 * copy() deliberately skips them (the save-time id is reassigned per
+	 * save; a copy is a new element with a freshly minted stable id,
+	 * issue #165 P3).
+	 */
 	private static String withoutId(String saved) {
 		List<String> kept = new ArrayList<String>();
 		for (String line : saved.split("\n")) {
-			if (!line.startsWith(" int id ")) {
+			if (!line.startsWith(" int id ")
+					&& !line.startsWith(" String sid ")) {
 				kept.add(line);
 			}
 		}

--- a/test/jls/CircuitRoundTripTest.java
+++ b/test/jls/CircuitRoundTripTest.java
@@ -77,14 +77,17 @@ class CircuitRoundTripTest {
 		Circuit second = load(new Scanner(savedOnce));
 		String savedTwice = save(second);
 
-		// Elements live in a HashSet, so block order and the ids assigned
-		// at save time are not stable across load instances; compare the
-		// order-independent, id-free canonical form instead.
-		assertEquals(FileFormatSupport.canonicalize(savedOnce),
-				FileFormatSupport.canonicalize(savedTwice),
-				"saving a reloaded circuit must reproduce the same content");
-		assertEquals(FileFormatSupport.canonicalize(CIRCUIT_TEXT),
-				FileFormatSupport.canonicalize(savedOnce),
+		// saves are canonical (#166): sorted by stable id, with ids and
+		// refs assigned in that order, so the fixed point holds
+		// byte-for-byte with no canonicalization
+		assertEquals(savedOnce, savedTwice,
+				"saving a reloaded circuit must reproduce the same bytes");
+
+		// and against the pre-#165 fixture text: identical except for
+		// the FORMAT header and the minted sid lines (legacy files mint
+		// ids in file order, so even block order is preserved)
+		assertEquals("FORMAT 1\n" + CIRCUIT_TEXT,
+				FileFormatSupport.stripStableIds(savedOnce),
 				"a loaded circuit must save back to its original content");
 	}
 

--- a/test/jls/CliTextSaveTest.java
+++ b/test/jls/CliTextSaveTest.java
@@ -68,11 +68,7 @@ class CliTextSaveTest {
 		return new String(in.readAllBytes(), StandardCharsets.UTF_8);
 	}
 
-	/**
-	 * A minimal circuit in the on-disk text form. Wire-free, so content
-	 * comparisons can use FileFormatSupport.canonicalize (ref lines
-	 * change with the unstable save-time ids).
-	 */
+	/** A minimal circuit in the on-disk text form. */
 	private static String circuitText(String name) {
 		return "CIRCUIT " + name + "\n"
 				+ "ELEMENT Constant\n"
@@ -126,8 +122,11 @@ class CliTextSaveTest {
 		Result r = run("-savetext", "in.jls", "sub/in.jls");
 		assertEquals(0, r.exit, r.stderr);
 
-		assertEquals(FileFormatSupport.canonicalize(circuitText("in")),
-				FileFormatSupport.canonicalize(
+		// saves are canonical (#166): legacy files mint stable ids in
+		// file order, so the output is the input plus the FORMAT header
+		// and the minted sid lines
+		assertEquals("FORMAT 1\n" + circuitText("in"),
+				FileFormatSupport.stripStableIds(
 						Files.readString(tmp.resolve("in.jls"))),
 				"the plain-text save must hold the identical circuit");
 
@@ -151,15 +150,14 @@ class CliTextSaveTest {
 		assertEquals(0, run("-savetext", "out.jls", "in.jls").exit);
 		String first = Files.readString(tmp.resolve("out.jls"));
 
-		// converting the output onto itself must preserve the content
-		// (canonicalized: element order and ids are not stable per load)
+		// converting the output onto itself must preserve the content -
+		// byte-for-byte, since saves are canonical (#166) and the first
+		// conversion persisted the stable ids
 		Result r = run("-savetext", "out.jls", "out.jls");
 		assertEquals(0, r.exit, r.stderr);
-		assertEquals(FileFormatSupport.canonicalize(first),
-				FileFormatSupport.canonicalize(
-						Files.readString(tmp.resolve("out.jls"))),
-				"plain-text re-save of a plain-text save must hold the "
-						+ "same circuit");
+		assertEquals(first, Files.readString(tmp.resolve("out.jls")),
+				"plain-text re-save of a plain-text save must be "
+						+ "byte-identical");
 	}
 
 	@Test

--- a/test/jls/DeterministicSaveTest.java
+++ b/test/jls/DeterministicSaveTest.java
@@ -103,6 +103,35 @@ class DeterministicSaveTest {
 	}
 
 	@Test
+	void canonicalBytesAreIdenticalWhateverThePlatformNewline()
+			throws Exception {
+		// #111 failure 1: println follows the platform line separator,
+		// so unwrapped saves would differ between Windows and Linux.
+		// Simulate a \r\n platform by overriding println() exactly the
+		// way PrintWriter specializes it per platform; the save path
+		// must never let it reach the output.
+		Circuit circuit = load(fixtureText());
+		StringWriter plain = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(plain)) {
+			circuit.save(writer);
+		}
+		StringWriter crlf = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(crlf) {
+			@Override
+			public void println() {
+				write("\r\n");
+			}
+		}) {
+			circuit.save(writer);
+		}
+		assertEquals(plain.toString(), crlf.toString(),
+				"canonical bytes must not depend on the platform line "
+						+ "separator");
+		assertTrue(plain.toString().indexOf('\r') < 0,
+				"canonical saves must use bare \\n line endings");
+	}
+
+	@Test
 	void stateHashIsContentDetermined() throws Exception {
 		String text = fixtureText();
 		Circuit first = load(text);

--- a/test/jls/DeterministicSaveTest.java
+++ b/test/jls/DeterministicSaveTest.java
@@ -1,0 +1,125 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.Element;
+
+/**
+ * Deterministic canonical serialization (issue #166, collab Stage 0c):
+ * a circuit's serialized form is a pure function of its content.
+ * Elements are emitted sorted by stable id (#165) with the file-local
+ * ids assigned in that same order, so two loads of the same file - in
+ * one process or two - save byte-identically, wires and refs included.
+ * Pre-change, the same fixture loaded twice saved differently in 261 of
+ * 276 lines (issue #166 observation 4). Canonical bytes are the
+ * convergence oracle for collaborative editing (#163), surfaced as
+ * {@link Circuit#stateHash()}.
+ */
+class DeterministicSaveTest {
+
+	/** The wire-and-ref-heavy fixture from the issue's probe. */
+	private static final Path FORK_FIXTURE =
+			Path.of("test", "fixtures", "fork-4.6-shiftregister.jls");
+
+	private static Circuit load(String text) throws Exception {
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString();
+	}
+
+	private static String fixtureText() throws Exception {
+		return Files.readString(FORK_FIXTURE, StandardCharsets.UTF_8);
+	}
+
+	@Test
+	void savingTheSameInstanceTwiceIsByteIdentical() throws Exception {
+		Circuit circuit = load(fixtureText());
+		assertEquals(save(circuit), save(circuit),
+				"saving one instance twice must be byte-identical");
+	}
+
+	@Test
+	void twoLoadInstancesSaveByteIdentically() throws Exception {
+		// the issue's probe (P1): pre-change, 261 of 276 lines differed
+		String text = fixtureText();
+		String first = save(load(text));
+		String second = save(load(text));
+		assertEquals(first, second,
+				"two load instances of the same file must save "
+						+ "byte-identically, wires and refs included");
+	}
+
+	@Test
+	void saveLoadSaveIsAByteFixedPoint() throws Exception {
+		// P2, on the wire-heavy fixture with no canonicalization at all
+		String savedOnce = save(load(fixtureText()));
+		String savedTwice = save(load(savedOnce));
+		assertEquals(savedOnce, savedTwice,
+				"save -> load -> save must be byte-identical");
+	}
+
+	@Test
+	void savedBlocksAreSortedByStableId() throws Exception {
+		Circuit circuit = load(fixtureText());
+		String saved = save(circuit);
+		String previous = null;
+		for (String line : saved.split("\n")) {
+			if (!line.startsWith(" String sid \"")) {
+				continue;
+			}
+			String sid = line.substring(" String sid \"".length(),
+					line.length() - 1);
+			if (previous != null) {
+				assertTrue(jls.elem.ElementId.parse(previous)
+						.compareTo(jls.elem.ElementId.parse(sid)) < 0,
+						"blocks must be emitted in stable-id order: '"
+								+ previous + "' before '" + sid + "'");
+			}
+			previous = sid;
+		}
+		assertTrue(previous != null, "the save must contain sid lines");
+	}
+
+	@Test
+	void stateHashIsContentDetermined() throws Exception {
+		String text = fixtureText();
+		Circuit first = load(text);
+		Circuit second = load(text);
+		assertEquals(first.stateHash(), second.stateHash(),
+				"identical content must hash identically across instances");
+
+		// and a real change must change the hash
+		String before = first.stateHash();
+		for (Element el : first.getElements()) {
+			if (el instanceof jls.elem.Wire) {
+				continue; // wires don't move (they follow their ends)
+			}
+			el.move(JLSInfo.spacing, 0);
+			break;
+		}
+		assertNotEquals(before, first.stateHash(),
+				"a moved element must change the state hash");
+	}
+}

--- a/test/jls/FileFormatSupport.java
+++ b/test/jls/FileFormatSupport.java
@@ -93,7 +93,10 @@ final class FileFormatSupport {
 			}
 			if (current == null) {
 				header.append(line).append('\n');
-			} else if (!line.startsWith(" int id ")) {
+			} else if (!line.startsWith(" int id ")
+					&& !line.startsWith(" String sid ")) {
+				// sid lines are dropped only so comparisons against
+				// pre-#165 fixture text (which has none) stay valid
 				current.append(line).append('\n');
 			}
 			if (line.equals("END") && current != null) {

--- a/test/jls/FileFormatSupport.java
+++ b/test/jls/FileFormatSupport.java
@@ -72,39 +72,20 @@ final class FileFormatSupport {
 	}
 
 	/**
-	 * Reduce a saved circuit file to a canonical form: ELEMENT..END blocks
-	 * sorted, save-order-dependent id lines removed, the FORMAT header
-	 * (byte-pinned by FormatHeaderTest) dropped. Elements live in a
-	 * HashSet, so block order and the ids assigned at save time are not
-	 * stable across load instances; comparisons of saved circuit content
-	 * must use this form. Only sound for circuits without id
-	 * cross-references (ref lines), since those change with the ids.
+	 * A saved circuit minus its " String sid " lines, for comparisons
+	 * against pre-#165 fixture text, which has none. Saves are otherwise
+	 * byte-deterministic (#166: canonical order sorted by stable id, ids
+	 * and refs assigned in that order), so this is the only masking a
+	 * saved-content comparison ever needs - and none is needed when both
+	 * sides went through a post-#165 save.
 	 */
-	static String canonicalize(String saved) {
-		java.util.List<String> blocks = new java.util.ArrayList<String>();
-		StringBuilder current = null;
-		StringBuilder header = new StringBuilder();
+	static String stripStableIds(String saved) {
+		StringBuilder kept = new StringBuilder();
 		for (String line : saved.split("\n")) {
-			if (line.startsWith("FORMAT ")) {
-				continue;
-			}
-			if (line.startsWith("ELEMENT")) {
-				current = new StringBuilder();
-			}
-			if (current == null) {
-				header.append(line).append('\n');
-			} else if (!line.startsWith(" int id ")
-					&& !line.startsWith(" String sid ")) {
-				// sid lines are dropped only so comparisons against
-				// pre-#165 fixture text (which has none) stay valid
-				current.append(line).append('\n');
-			}
-			if (line.equals("END") && current != null) {
-				blocks.add(current.toString());
-				current = null;
+			if (!line.startsWith(" String sid ")) {
+				kept.append(line).append('\n');
 			}
 		}
-		java.util.Collections.sort(blocks);
-		return header + String.join("", blocks);
+		return kept.toString();
 	}
 }

--- a/test/jls/FileHandleReleaseTest.java
+++ b/test/jls/FileHandleReleaseTest.java
@@ -1,0 +1,99 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The circuit-open path must not hold the file open behind the Scanner
+ * it returns (issue #111): on Windows an open handle blocks deletion,
+ * which both broke the test suite's @TempDir cleanup and would keep a
+ * user's circuit file locked for as long as it is open in the editor.
+ * The reader drains every container into memory (bounded, issue #38),
+ * so the handle's lifetime ends inside the open call.
+ *
+ * The observation is Linux-specific (/proc/self/fd), which is fine: the
+ * leak was platform-independent, only its delete-blocking symptom was
+ * Windows-only.
+ */
+class FileHandleReleaseTest {
+
+	@TempDir
+	Path tmp;
+
+	private static final String CIRCUIT_TEXT =
+			"CIRCUIT handles\n"
+			+ "ELEMENT Constant\n"
+			+ " int id 0\n int x 60\n int y 60\n int width 24\n int height 24\n"
+			+ " Int value 5\n int base 10\n String orient \"RIGHT\"\nEND\n"
+			+ "ENDCIRCUIT\n";
+
+	/** Whether any of this process's fds points at the given file. */
+	private static boolean fdOpenOn(Path file) throws IOException {
+		Path fdDir = Path.of("/proc/self/fd");
+		assumeTrue(Files.isDirectory(fdDir),
+				"fd observation needs /proc (Linux)");
+		String target = file.toAbsolutePath().toString();
+		try (Stream<Path> fds = Files.list(fdDir)) {
+			return fds.anyMatch(fd -> {
+				try {
+					return Files.readSymbolicLink(fd).toString()
+							.equals(target);
+				} catch (IOException gone) {
+					return false; // fd closed while listing
+				}
+			});
+		}
+	}
+
+	private void assertOpenReleasesTheFile(File file) throws Exception {
+		Scanner scanner = FileAbstractor.openCircuit(file.getAbsolutePath());
+		assertNotNull(scanner, () -> "open failed: " + JLSInfo.loadError);
+		try {
+			assertTrue(!fdOpenOn(file.toPath()),
+					"no file descriptor may remain open on "
+							+ file.getName()
+							+ " once openCircuit has returned");
+
+			// and the drained content still loads normally
+			Circuit circuit = new Circuit("handles");
+			assertTrue(circuit.load(scanner),
+					() -> "load failed: " + JLSInfo.loadError);
+			assertTrue(circuit.finishLoad(null),
+					() -> "finishLoad failed: " + JLSInfo.loadError);
+		} finally {
+			scanner.close();
+		}
+	}
+
+	@Test
+	void plainTextOpenHoldsNoHandle() throws Exception {
+		File file = tmp.resolve("text.jls").toFile();
+		FileFormatSupport.writeText(file, CIRCUIT_TEXT);
+		assertOpenReleasesTheFile(file);
+	}
+
+	@Test
+	void xzOpenHoldsNoHandle() throws Exception {
+		File file = tmp.resolve("xz.jls").toFile();
+		FileFormatSupport.writeXZ(file, CIRCUIT_TEXT);
+		assertOpenReleasesTheFile(file);
+	}
+
+	@Test
+	void zipOpenHoldsNoHandle() throws Exception {
+		File file = tmp.resolve("zip.jls").toFile();
+		FileFormatSupport.writeZip(file, CIRCUIT_TEXT);
+		assertOpenReleasesTheFile(file);
+	}
+}

--- a/test/jls/GenerativeRoundTripFuzzTest.java
+++ b/test/jls/GenerativeRoundTripFuzzTest.java
@@ -9,10 +9,6 @@ import java.awt.image.BufferedImage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Scanner;
 
@@ -59,10 +55,7 @@ class GenerativeRoundTripFuzzTest {
 	// generator
 	// ------------------------------------------------------------------
 
-	/**
-	 * One generated element block. Coordinates are unique per element
-	 * (the canonicalizer needs pairwise-distinct blocks).
-	 */
+	/** One generated element block. */
 	private static String el(String type, int id, int x, int y, String attrs) {
 		return "ELEMENT " + type + "\n int id " + id + "\n int x " + x
 				+ "\n int y " + y + "\n" + attrs + "END\n";
@@ -211,92 +204,6 @@ class GenerativeRoundTripFuzzTest {
 	}
 
 	// ------------------------------------------------------------------
-	// canonicalization (ref-aware; see AllElementsRoundTripTest)
-	// ------------------------------------------------------------------
-
-	/**
-	 * Canonical form for saves of circuits that may contain ref lines:
-	 * blocks sorted by ref-masked content, ids renumbered in sorted
-	 * order, ref targets rewritten to the new ids. Sound only when the
-	 * masked blocks are pairwise distinct, which the generator
-	 * guarantees by giving every element a unique x coordinate.
-	 */
-	private static String canonicalize(String saved, long seed) {
-		List<String> blocks = new ArrayList<String>();
-		StringBuilder current = null;
-		StringBuilder header = new StringBuilder();
-		for (String line : saved.split("\n")) {
-			if (line.startsWith("ELEMENT")) {
-				current = new StringBuilder();
-			}
-			if (current == null) {
-				header.append(line).append('\n');
-			} else {
-				current.append(line).append('\n');
-			}
-			if (line.equals("END") && current != null) {
-				blocks.add(current.toString());
-				current = null;
-			}
-		}
-		List<String> masked = new ArrayList<String>();
-		for (String b : blocks) {
-			masked.add(mask(b));
-		}
-		List<Integer> order = new ArrayList<Integer>();
-		for (int i = 0; i < blocks.size(); i++) {
-			order.add(i);
-		}
-		order.sort((a, b) -> masked.get(a).compareTo(masked.get(b)));
-		for (int i = 1; i < order.size(); i++) {
-			assertTrue(!masked.get(order.get(i - 1)).equals(masked.get(order.get(i))),
-					"seed " + seed + ": generated blocks must be pairwise"
-					+ " distinct for canonicalization");
-		}
-		Map<String, String> newId = new HashMap<String, String>();
-		for (int pos = 0; pos < order.size(); pos++) {
-			for (String line : blocks.get(order.get(pos)).split("\n")) {
-				if (line.startsWith(" int id ")) {
-					newId.put(line.substring(" int id ".length()).trim(),
-							Integer.toString(pos));
-				}
-			}
-		}
-		StringBuilder out = new StringBuilder(header);
-		for (int pos = 0; pos < order.size(); pos++) {
-			for (String line : blocks.get(order.get(pos)).split("\n")) {
-				if (line.startsWith(" int id ")) {
-					out.append(" int id ").append(pos).append('\n');
-				} else if (line.startsWith(" ref ")) {
-					String[] parts = line.trim().split("\\s+");
-					out.append(" ref ").append(parts[1]).append(' ')
-							.append(newId.get(parts[2])).append('\n');
-				} else {
-					out.append(line).append('\n');
-				}
-			}
-		}
-		return out.toString();
-	}
-
-	/** A block with its id and ref targets hidden, for stable sorting. */
-	private static String mask(String block) {
-		StringBuilder out = new StringBuilder();
-		for (String line : block.split("\n")) {
-			if (line.startsWith(" int id ")) {
-				continue;
-			}
-			if (line.startsWith(" ref ")) {
-				String[] parts = line.trim().split("\\s+");
-				out.append(" ref ").append(parts[1]).append(" ?\n");
-			} else {
-				out.append(line).append('\n');
-			}
-		}
-		return out.toString();
-	}
-
-	// ------------------------------------------------------------------
 	// harness
 	// ------------------------------------------------------------------
 
@@ -364,10 +271,11 @@ class GenerativeRoundTripFuzzTest {
 				fail("seed " + seed + ": a circuit that loaded and saved"
 						+ " must load again; got: " + JLSInfo.loadError);
 			}
-			assertEquals(canonicalize(savedOnce, seed),
-					canonicalize(save(second), seed),
+			// saves are canonical (#166), so the fixed point holds
+			// byte-for-byte with no canonicalization
+			assertEquals(savedOnce, save(second),
 					"seed " + seed + ": save -> load -> save must be a"
-					+ " fixed point");
+					+ " byte fixed point");
 		}
 		// guard the generator itself: if almost everything is rejected,
 		// the property above is vacuous and the generator has drifted

--- a/test/jls/StableElementIdTest.java
+++ b/test/jls/StableElementIdTest.java
@@ -1,0 +1,217 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.edit.CircuitSnapshot;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Wire;
+
+/**
+ * Stable element identity (issue #165, collab Stage 0a). Every element
+ * carries a permanent id minted at creation: elements loaded from files
+ * that predate the {@code sid} attribute get one minted deterministically
+ * in file order, saved files persist it, undo restore preserves it, and
+ * a copy is a new element with a fresh id. The historical {@code int id}
+ * stays what it always was - a file-local reference index reassigned on
+ * every save.
+ */
+class StableElementIdTest {
+
+	/** A legacy (pre-sid) circuit with wires, so refs are exercised. */
+	private static final String LEGACY_TEXT =
+			"CIRCUIT sids\n"
+			+ "ELEMENT Constant\n"
+			+ " int id 0\n int x 60\n int y 60\n int width 24\n int height 24\n"
+			+ " Int value 5\n int base 10\n String orient \"RIGHT\"\nEND\n"
+			+ "ELEMENT AndGate\n"
+			+ " int id 1\n int x 240\n int y 120\n int width 48\n int height 24\n"
+			+ " int bits 1\n int numInputs 2\n String orientation \"right\"\n int delay 10\nEND\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 2\n int x 120\n int y 72\n String put \"output\"\n"
+			+ " ref attach 0\n ref wire 3\nEND\n"
+			+ "ELEMENT WireEnd\n"
+			+ " int id 3\n int x 240\n int y 132\n String put \"input0\"\n"
+			+ " ref attach 1\n ref wire 2\nEND\n"
+			+ "ENDCIRCUIT\n";
+
+	private static Circuit load(String text) throws Exception {
+		Circuit circuit = new Circuit("sids");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString();
+	}
+
+	/**
+	 * The stable id of each saved element, keyed by its logical identity
+	 * (type and position) rather than block position - save order is not
+	 * part of this issue's contract.
+	 */
+	private static Map<String, String> sidsByLogicalElement(Circuit circuit) {
+		Map<String, String> sids = new HashMap<String, String>();
+		for (Element el : circuit.getElements()) {
+			if (el instanceof Wire) {
+				continue; // wires are reconstructed, never saved
+			}
+			String key = el.getClass().getSimpleName()
+					+ "@" + el.getX() + "," + el.getY();
+			assertFalse(sids.containsKey(key),
+					"fixture elements must be logically distinct: " + key);
+			sids.put(key, el.getStableId().toString());
+		}
+		return sids;
+	}
+
+	@Test
+	void legacyLoadsMintTheSameIdsInEveryInstance() throws Exception {
+		// P1: pre-change, ids differed between load instances; now the
+		// legacy minting is deterministic in file order
+		Map<String, String> first = sidsByLogicalElement(load(LEGACY_TEXT));
+		Map<String, String> second = sidsByLogicalElement(load(LEGACY_TEXT));
+		assertEquals(first, second,
+				"two loads of the same legacy file must mint identical "
+						+ "stable ids for the same logical elements");
+	}
+
+	@Test
+	void savedIdsSurviveReload() throws Exception {
+		Circuit first = load(LEGACY_TEXT);
+		Map<String, String> minted = sidsByLogicalElement(first);
+		String saved = save(first);
+		assertTrue(saved.contains(" String sid \""),
+				"a save must persist the stable ids:\n" + saved);
+		Map<String, String> reloaded = sidsByLogicalElement(load(saved));
+		assertEquals(minted, reloaded,
+				"stable ids must survive save -> load unchanged");
+	}
+
+	@Test
+	void undoRestorePreservesIds() throws Exception {
+		// P2: undo snapshots restore through the load path, so identity
+		// must ride along
+		Circuit circuit = load(LEGACY_TEXT);
+		Circuit restored = CircuitSnapshot.capture(circuit)
+				.restore("sids", null);
+		assertNotNull(restored, () -> "restore failed: " + JLSInfo.loadError);
+		assertEquals(sidsByLogicalElement(circuit),
+				sidsByLogicalElement(restored),
+				"undo restore must preserve every element's stable id");
+	}
+
+	@Test
+	void copyMintsAFreshId() throws Exception {
+		// P3: a pasted element is a new element
+		Circuit circuit = load(LEGACY_TEXT);
+		for (Element el : circuit.getElements()) {
+			Element copy = el.copy();
+			if (copy == null) {
+				continue; // wires/wire ends copy through the editor
+			}
+			assertNotEquals(el.getStableId(), copy.getStableId(),
+					copy.getClass().getSimpleName()
+							+ ": a copy must mint a fresh stable id");
+		}
+	}
+
+	@Test
+	void idsAreUniqueWithinACircuit() throws Exception {
+		Circuit circuit = load(LEGACY_TEXT);
+		Set<ElementId> seen = new HashSet<ElementId>();
+		for (Element el : circuit.getElements()) {
+			assertTrue(seen.add(el.getStableId()),
+					"duplicate stable id in circuit: " + el.getStableId());
+		}
+	}
+
+	@Test
+	void duplicateFileIdsAreRejected() throws Exception {
+		String duplicated = LEGACY_TEXT
+				.replace(" Int value 5\n", " Int value 5\n String sid \"legacy:7\"\n")
+				.replace(" int delay 10\n", " int delay 10\n String sid \"legacy:7\"\n");
+		Circuit circuit = new Circuit("sids");
+		assertTrue(circuit.load(new Scanner(duplicated)),
+				() -> "load failed early: " + JLSInfo.loadError);
+		assertFalse(circuit.finishLoad(null),
+				"a file declaring the same stable id twice must be refused");
+		assertNotNull(JLSInfo.lastLoadError,
+				"the refusal must publish a structured LoadError");
+		assertTrue(JLSInfo.lastLoadError.render().contains("legacy:7"),
+				"the error must name the duplicated id: "
+						+ JLSInfo.lastLoadError.render());
+	}
+
+	@Test
+	void mintedIdsSkipIdsTheFileAlreadyUses() throws Exception {
+		// a mixed file: one element already carries the id legacy minting
+		// would otherwise hand out first
+		String mixed = LEGACY_TEXT.replace(" Int value 5\n",
+				" Int value 5\n String sid \"legacy:0\"\n");
+		Circuit circuit = load(mixed);
+		Set<ElementId> seen = new HashSet<ElementId>();
+		for (Element el : circuit.getElements()) {
+			assertTrue(seen.add(el.getStableId()),
+					"minting must skip file-declared ids, got duplicate "
+							+ el.getStableId());
+		}
+	}
+
+	@Test
+	void malformedIdsAreClassifiedNotThrown() {
+		for (String bad : new String[] {"nocounter", ":", "up:down",
+				"UPPER:1", "legacy:-4", "legacy:", ":9",
+				"way too spacey:1"}) {
+			String text = LEGACY_TEXT.replace(" Int value 5\n",
+					" Int value 5\n String sid \"" + bad + "\"\n");
+			Circuit circuit = new Circuit("sids");
+			assertFalse(circuit.load(new Scanner(text)),
+					"sid '" + bad + "' must be refused");
+			assertNotNull(JLSInfo.lastLoadError,
+					"the refusal must publish a structured LoadError");
+		}
+	}
+
+	@Test
+	void parseIsTheInverseOfToString() {
+		for (String form : new String[] {"legacy:0", "legacy:41",
+				"0a1b2c3d4e5f6789:9007199254740991"}) {
+			assertEquals(form, ElementId.parse(form).toString());
+		}
+		assertThrows(IllegalArgumentException.class,
+				() -> ElementId.parse(null));
+	}
+
+	@Test
+	void freshMintsAreDistinctAndOrdered() {
+		ElementId a = ElementId.mintFresh();
+		ElementId b = ElementId.mintFresh();
+		assertNotEquals(a, b, "every fresh mint must be distinct");
+		assertTrue(a.compareTo(b) != 0, "distinct ids must order apart");
+		assertEquals(0, a.compareTo(ElementId.parse(a.toString())),
+				"an id must equal its parsed string form");
+	}
+}

--- a/test/jls/edit/CircuitSnapshotTest.java
+++ b/test/jls/edit/CircuitSnapshotTest.java
@@ -66,37 +66,11 @@ class CircuitSnapshotTest {
 		assertNotNull(restored, () -> "restore failed: " + JLSInfo.loadError);
 		assertEquals(circuit.getElements().size(), restored.getElements().size());
 
-		// elements live in a HashSet, so block order and the ids/refs
-		// assigned at save time differ between circuit instances; compare
-		// the order- and id-independent canonical form
-		assertEquals(canonicalize(before), canonicalize(save(restored)),
-				"a restored snapshot must save to equivalent content");
-	}
-
-	/**
-	 * Canonical form of a saved circuit: ELEMENT..END blocks sorted, with
-	 * save-order-dependent id and ref lines removed.
-	 */
-	private static String canonicalize(String saved) {
-		java.util.List<String> blocks = new java.util.ArrayList<>();
-		StringBuilder current = null;
-		StringBuilder header = new StringBuilder();
-		for (String line : saved.split("\n")) {
-			if (line.startsWith("ELEMENT")) {
-				current = new StringBuilder();
-			}
-			if (current == null) {
-				header.append(line).append('\n');
-			} else if (!line.startsWith(" int id ") && !line.startsWith(" ref ")) {
-				current.append(line).append('\n');
-			}
-			if (line.equals("END") && current != null) {
-				blocks.add(current.toString());
-				current = null;
-			}
-		}
-		java.util.Collections.sort(blocks);
-		return header + String.join("", blocks);
+		// saves are canonical (#166): stable ids survive the restore and
+		// determine block order, ids, and refs, so capture -> restore ->
+		// save reproduces the original save byte-for-byte
+		assertEquals(before, save(restored),
+				"a restored snapshot must save to identical bytes");
 	}
 
 	@Test
@@ -116,6 +90,20 @@ class CircuitSnapshotTest {
 		CircuitSnapshot second = CircuitSnapshot.capture(circuit);
 		assertTrue(first.sameAs(second),
 				"no-op changes must produce identical snapshots (undo skips them)");
+	}
+
+	@Test
+	void restoreDoesNotPerturbSnapshotIdentity() throws Exception {
+		// #166 P4: the undo stack drops no-op entries by byte equality,
+		// which must keep working across a restore - saves are canonical,
+		// so a restored circuit snapshots identically to its original
+		Circuit circuit = load(CIRCUIT_TEXT);
+		CircuitSnapshot first = CircuitSnapshot.capture(circuit);
+		Circuit restored = first.restore("snaptest", null);
+		assertNotNull(restored, () -> "restore failed: " + JLSInfo.loadError);
+		assertTrue(first.sameAs(CircuitSnapshot.capture(restored)),
+				"a restored circuit must snapshot identically (no-op "
+						+ "undo entries stay droppable across restores)");
 	}
 
 	@Test

--- a/test/jls/elem/AttributePersistenceTest.java
+++ b/test/jls/elem/AttributePersistenceTest.java
@@ -50,6 +50,9 @@ class AttributePersistenceTest {
 		Element constant = circuit.getElements().iterator().next();
 		constant.setID(0);
 
+		// the sid line is the one post-handwritten addition: permanent
+		// element identity (#165), minted deterministically at load for
+		// pre-sid files like this fixture
 		assertEquals("ELEMENT Constant\n"
 				+ " int id 0\n"
 				+ " int x 60\n"
@@ -58,6 +61,7 @@ class AttributePersistenceTest {
 				+ " int height 24\n"
 				+ " int fixed 1\n"
 				+ " int trpos 3\n"
+				+ " String sid \"legacy:0\"\n"
 				+ " Int value 255\n"
 				+ " int base 16\n"
 				+ " String orient \"LEFT\"\n"
@@ -109,7 +113,21 @@ class AttributePersistenceTest {
 		assertNotNull(copy);
 		constant.setID(0);
 		copy.setID(0);
-		assertEquals(saveElement(constant), saveElement(copy),
+		// the stable id is deliberately not field-equivalent: a copy is
+		// a new element and mints a fresh identity (#165 P3)
+		assertEquals(withoutSid(saveElement(constant)),
+				withoutSid(saveElement(copy)),
 				"a copy must serialize identically to its original");
+	}
+
+	/** Saved text minus the sid line, which copy() deliberately skips. */
+	private static String withoutSid(String saved) {
+		StringBuilder kept = new StringBuilder();
+		for (String line : saved.split("\n")) {
+			if (!line.startsWith(" String sid ")) {
+				kept.append(line).append('\n');
+			}
+		}
+		return kept.toString();
 	}
 }


### PR DESCRIPTION
Elements had no identity that survives serialization: the int id is
reassigned in HashSet iteration order on every save, so the same
logical element gets a different id on every load instance. Replication,
canonical serialization, and per-op addressing (#163) all need a name
that means the same element everywhere.

- ElementId (replica id + counter): minted fresh at element
  construction; files that predate the field mint deterministic
  "legacy:N" ids at load, in file order (deterministic per #98), so two
  loads of the same file always agree (P1).
- Persisted as a new base attribute `String sid`, driven by the #23
  attribute registry, so every element type saves and loads it through
  the existing paths. No FORMAT bump: per the docs/file-format.md §9
  policy, an ignorable attribute that cannot change simulation behavior
  does not gate the file (recorded in §8), so current saves stay
  readable by older post-versioning readers.
- Undo restore rides the save/load path, so identity survives it (P2);
  copy() deliberately never copies the id - a paste is a new element
  with a fresh mint (P3).
- finishLoad refuses files declaring the same sid twice and mints
  around ids the file already uses; malformed sids classify as element
  errors (#52/#58 taxonomy), never escape as exceptions.

The historical int id remains what it really was: a file-local
reference index for ref lines, untouched, so finishLoad ref resolution
is unchanged (the issue's H2 fallback; ref determinism lands with the
#166 canonical save order).

Existing tests intentionally updated, per the issue's completion
criteria: AttributePersistenceTest pins the new sid line in the
byte-exact format and excludes identity from copy field-equivalence
(P3); AllElementsRoundTripTest's copy comparison likewise;
FileFormatSupport.canonicalize drops sid lines only so comparisons
against pre-#165 fixture text stay valid. All simulation goldens pass
unchanged (P4).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AtKCxJwWvBw9tvcRo4jv9k