### PR TITLE
Make addToBook deterministic

### DIFF
--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -1735,8 +1735,12 @@ public class Circuit implements Printable {
 		// add this circuit
 		book.append(this, format);
 
+		// create a list of elements sorted by stable ID for deterministic order
+		List<Element> ordered = new ArrayList<>(elements);
+		ordered.sort(Comparator.comparing(Element::getStableId));
+
 		// add state machines
-		for (Element el : elements) {
+		for (Element el : ordered) {
 			if (el instanceof StateMachine) {
 				StateMachine sm = (StateMachine) el;
 				book.append(sm, format);
@@ -1747,7 +1751,7 @@ public class Circuit implements Printable {
 		}
 
 		// add truth tables
-		for (Element el : elements) {
+		for (Element el : ordered) {
 			if (el instanceof TruthTable) {
 				TruthTable tt = (TruthTable) el;
 				book.append(tt, format);
@@ -1755,7 +1759,7 @@ public class Circuit implements Printable {
 		}
 
 		// add subcircuits
-		for (Element el : elements) {
+		for (Element el : ordered) {
 			if (el instanceof SubCircuit) {
 				((SubCircuit) el).getSubCircuit().addToBook(book, format);
 			}


### PR DESCRIPTION
# Make addToBook deterministic

## Summary

The `addToBook` method in the `Circuit` class used a `HashSet` to iterate over elements, resulting in non-deterministic order of state machines, truth tables, and subcircuits in the print book. This change sorts the elements by their stable ID before iterating, ensuring a deterministic order.

Fixes #182

## Changes

- Modified `Circuit.addToBook` to create a sorted list of elements by stable ID and use it for iterating over state machines, truth tables, and subcircuits.

## Testing

- Verified the change compiles correctly.
- Ran the existing `PrintPathSmokeTest` to ensure no regression (test passed).
- Verified that the order of elements in the book is now deterministic by inspecting the output of a test circuit with multiple state machines, truth tables, and subcircuits.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
