### PR TITLE
Gate Windows in CI; protect goldens from CRLF checkout (#111)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Provision the Java 25 build baseline for Claude Code on the web
+# (issue #92: the pom enforces JDK [25,) via requireJavaVersion, but
+# the web session container ships JDK 21). Installs the Ubuntu
+# openjdk-25 packages once — the container state is cached after the
+# hook completes — and points JAVA_HOME at them for the session.
+# Local (non-web) sessions are left untouched.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+JVM_DIR=/usr/lib/jvm/java-25-openjdk-amd64
+if [ ! -d "$JVM_DIR" ]; then
+  # the image's package lists can be stale (404s on point releases);
+  # refresh best-effort — third-party PPA signature failures must not
+  # abort the JDK install
+  sudo apt-get update -qq || true
+  sudo apt-get install -y -qq openjdk-25-jdk-headless
+fi
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export JAVA_HOME=$JVM_DIR"
+    echo "export PATH=$JVM_DIR/bin:\$PATH"
+  } >> "$CLAUDE_ENV_FILE"
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -12,12 +12,15 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 JVM_DIR=/usr/lib/jvm/java-25-openjdk-amd64
-if [ ! -d "$JVM_DIR" ]; then
+if [ ! -f "$JVM_DIR/lib/libawt_xawt.so" ]; then
   # the image's package lists can be stale (404s on point releases);
   # refresh best-effort — third-party PPA signature failures must not
   # abort the JDK install
   sudo apt-get update -qq || true
-  sudo apt-get install -y -qq openjdk-25-jdk-headless
+  # the full (non-headless) JDK: the display-tagged UI suite needs
+  # libawt_xawt; xvfb + a font let it actually run (issue #162):
+  #   xvfb-run -a mvn -B test -Djls.test.headless=false
+  sudo apt-get install -y -qq openjdk-25-jdk xvfb fonts-dejavu-core
 fi
 
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,9 @@
 # determinism suites compare against. Never translate them.
 *.jls -text
 *.jls~ -text
+
+# Golden baselines are compared byte-for-byte against strings the
+# tests build with \n (issue #111): the orientation-geometry baseline
+# and the HDL export goldens would all mismatch on a Windows
+# autocrlf checkout if git rewrote their line endings.
+test/resources/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,32 @@ jobs:
               print(f"| {c.get('type')} | {cov} | {mis} | {pct:.1f}% |")
           EOF
 
+  # Windows test lane (issue #111): all three Windows-only failures
+  # (CRLF round-trip, held file handles blocking @TempDir cleanup,
+  # golden-file CRLF checkout) shipped because no Windows leg ran the
+  # suite. Runs headless — the display-tagged suite and the HDL
+  # simulator suites skip themselves — and skips the JaCoCo ratchet,
+  # whose floors are calibrated against the fuller Linux run.
+  # Advisory while it stabilizes (same promotion rule as gui-wayland:
+  # required once 20 consecutive runs show at most one failure).
+  windows:
+    name: Build (Windows, JDK 25)
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      - name: Build, lint, and analyze
+        shell: bash
+        run: mvn -B verify -Djacoco.skip=true
+
   # Machine-checked proofs (proofs/README.md): the Agda development in
   # proofs/ verifies the spatial-index query-parity and draw-culling
   # theorems the drag/drop hot path relies on; a non-zero exit means a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,20 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Documentation is now build-enforced: `mvn verify` runs a javadoc
+  doclint gate (all groups except unresolvable-by-design test
+  references) over the public/protected API with warnings as
+  failures, and a new package-info ratchet requires every package in
+  both trees to carry a package comment. The gate is scoped to API
+  visibility because under `-private` the standard doclet warns on
+  every test-tree `@see` target in a way doclint exclusions cannot
+  reach (verified empirically; recorded in the pom comment).
+  Fixed en route: eleven malformed doc comments the #186 pass left
+  behind - duplicated `@param v1` tags in five files, three stale
+  javadoc blocks orphaned above attribute tables by the #23
+  refactor, a mistyped `@returns`, two empty comments, and a VCD
+  format description whose angle-bracket placeholders parsed as
+  unclosed HTML.
 - Per-package coverage floors (#159): the JaCoCo ratchet now guards
   `jls`, `jls.sim`, `jls.elem`, and the new `jls.collab.op` package
   individually (instruction, line, and branch), so a regression in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Operation layer, first slice (#167, collaboration stage 0b): a new
+  `jls.collab.op` package reifies editor mutations as a closed, sealed
+  vocabulary of validated, invertible, serializable commands
+  (`CircuitOp`) applied through one entry point (`OpSink`), addressing
+  elements by stable id (#165) and verified against the canonical
+  serialization oracle (#166): apply-then-inverse restores the exact
+  prior bytes, rejected ops change nothing, and the strict reader
+  (`CircuitOpReader`) round-trips every kind byte-identically while
+  rejecting malformed input. Six op kinds exist (`ToggleWatched`,
+  `AttachProbe`/`RemoveProbe`, `RotateElement`, `FlipElement`,
+  `MoveElements`) and six editor gestures now go through the entry
+  point (watch toggles via ctrl-W and menu, rotate both directions,
+  flip, probe attach/remove); the full mutation-site inventory and
+  migration status live in `docs/operation-layer.md`. Snapshot undo
+  is unchanged - `OpSink.submit` still runs the existing
+  `markChanged` bookkeeping. An ArchUnit rule pins the #163 layering
+  from day one: no collab package outside `jls.collab.ui` may touch
+  Swing.
 - Stable element identity (#165, collaboration stage 0a): every
   element now carries a permanent id (`replica:counter`), minted at
   creation and persisted in the save format as a new `sid` base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ All notable changes to JLS are documented here. The format follows
   and release the file before returning. A `.gitattributes` entry
   additionally protects the byte-exact `.jls` fixtures from CRLF
   rewriting on Windows checkouts.
+- The remaining Windows test failure (#111) — the orientation-geometry
+  baseline "diverging" on Windows — was golden-file line endings, not
+  geometry: an `autocrlf` checkout rewrote `test/resources/` goldens
+  to CRLF while the tests compare against `\n`-joined strings. The
+  `.gitattributes` protection now covers `test/resources/**` (the
+  geometry baseline and all HDL export goldens). The `TriState
+  finishLoadError=invalid element` lines noted in the same report are
+  deliberate: collinear gate/control orientation pairs have always
+  been rejected, and the baseline records that. CI gains an advisory
+  `windows-latest` lane so `mvn verify` exercises Windows on every
+  build (promoted to required once stable, like the Wayland lane).
 - Printing a freshly loaded circuit containing a truth table no longer
   crashes with a NullPointerException: `TruthTable.print` assumed the
   table's display panel had been built by the edit dialog, which is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ All notable changes to JLS are documented here. The format follows
   its second seed.
 
 ### Added
+- Per-package coverage floors (#159): the JaCoCo ratchet now guards
+  `jls`, `jls.sim`, `jls.elem`, and the new `jls.collab.op` package
+  individually (instruction, line, and branch), so a regression in
+  the tested core can no longer hide behind coverage gains elsewhere
+  in the bundle - verified by a synthetic regression (deleting the
+  op-layer test class) that the bundle instruction/line floors do not
+  catch but the package floors do. `jls.edit` stays deliberately
+  unfloored until the UI-harness work makes editor code testable.
 - Operation layer, first slice (#167, collaboration stage 0b): a new
   `jls.collab.op` package reifies editor mutations as a closed, sealed
   vocabulary of validated, invertible, serializable commands

--- a/docs/operation-layer.md
+++ b/docs/operation-layer.md
@@ -1,0 +1,88 @@
+# The operation layer (issue #167, collab Stage 0b)
+
+Every editor mutation is being migrated from inline state-machine code
+to a closed vocabulary of validated, invertible, serializable commands
+(`jls.collab.op.CircuitOp`) applied through one entry point
+(`jls.collab.op.OpSink`). The collaboration program (#163) replicates
+exactly this vocabulary; precise undo, per-peer attribution, and
+targeted revert all build on it. During the migration the user-facing
+undo mechanism is unchanged: `SimpleEditor.markChanged()` still
+snapshots the whole circuit (#18), and `OpSink.submit` runs
+validate → apply → `markChanged()`.
+
+## Contract
+
+- `apply(Circuit, Graphics)` validates first and mutates only if the
+  whole op is valid — a rejected op leaves the circuit byte-identical
+  (`CircuitOpTest.rejectionsLeaveTheCircuitUnchanged`).
+- `invert(Circuit before)` is computed against the pre-apply circuit;
+  apply-then-inverse returns the canonical save (#166) to its prior
+  bytes, on live and on save/load-restored circuits alike.
+- `save(PrintWriter)` writes the save-format idiom; `CircuitOpReader`
+  is its exact inverse and is strict: unknown kinds, unknown fields,
+  malformed values, and oversized input are rejections, never repairs
+  (this grammar is the future network surface — #170 hardens it
+  further).
+- Ops address elements by stable id (#165), never by object reference.
+
+Serialized form:
+
+```
+OP <kind>
+ String id "<replica:counter>"     (repeatable where the kind takes a group)
+ String name "<escaped>"           (AttachProbe)
+ int dx <n>  /  int dy <n>         (MoveElements)
+ int cw <0|1>                      (RotateElement)
+END
+```
+
+## Mutation-site inventory (§7 step 1)
+
+The audit of every `markChanged()` call site in `SimpleEditor` (plus
+the dialog-commit paths), each mapped to an op kind. "Migrated" means
+the gesture now goes through `OpSink.submit`; line numbers are as of
+the migration commit.
+
+| Gesture (commit point) | Op kind | Status |
+| --- | --- | --- |
+| Watch toggle, ctrl-W key | `ToggleWatched` | **migrated** |
+| Watch toggle, context menu | `ToggleWatched` | **migrated** |
+| Rotate CW, context menu | `RotateElement(cw)` | **migrated** |
+| Rotate CCW, context menu | `RotateElement(ccw)` | **migrated** |
+| Flip, context menu | `FlipElement` | **migrated** |
+| Probe attach/remove, context menu | `AttachProbe` / `RemoveProbe` (name prompt stays in the gesture; ops are pure data) | **migrated** |
+| Move-selection commit (mouse release) | `MoveElements` | op implemented + tested; gesture still inline (live drag must become preview-then-commit) |
+| Placement drop (fixPosition + connect) | `AddElement` (+ implicit wiring) | deferred — needs the element-transplant machinery |
+| Matching JumpEnd creation, context menu | `AddElement` | deferred — same machinery |
+| Delete selection | `RemoveElements` | deferred — inverse must restore elements *and* their wires; snapshot-fallback inverse is the sanctioned interim (#167 §9) |
+| Paste | `PasteGroup` | deferred — same restore machinery as delete's inverse |
+| Wire-attach finish (mouse) | `AddWire` | deferred — wiring gestures become commit-time ops |
+| Wire-draw cancel (right button / end-wire key, two sites) | none — gesture-local cleanup of the in-progress wire; these `markChanged` calls compensate for live mutation and disappear when wiring is commit-time | deferred |
+| Quick attribute edit commit (`quickReset`) | `SetAttributes` (element-state replace) | deferred — dialog commits mutate in place today |
+| Element dialog commits (all element edit dialogs) | `SetAttributes` | deferred — same |
+| Ordered-row edits (state machine, truth table, sig-gen programs) | `EditOrderedRows` | deferred — Stage 2 sequence semantics (#163) |
+| Subcircuit import | `ImportSubcircuit` | deferred |
+
+H1 refinement: the audit confirms the ~10-kind estimate, with two
+notes — (1) the wire-draw *cancel* sites are not ops at all (they undo
+gesture-local live mutation), and (2) probe toggling splits into an
+attach/remove pair so each op stays pure data and the pair are exact
+mutual inverses.
+
+## Layering
+
+`jls.collab.op` depends on `jls` and `jls.elem` and on AWT (`Graphics`
+for geometry recomputation), never on Swing — enforced zero-tolerance
+by `ArchitectureRulesTest.collabLayersAreHeadless` (#163 dependency
+rule 2; only the future `jls.collab.ui` may touch Swing).
+
+## What lands next
+
+1. The element-transplant helper (serialize one element, load it into
+   a target circuit), which unlocks `AddElement`, `RemoveElements`
+   with true inverses, and `PasteGroup`.
+2. Preview-then-commit for the move and wiring gestures, anchored by
+   the #91 gesture harness (`EditorGestureTest`).
+3. `SetAttributes` from the dialog-commit paths.
+4. Op-inverse (precise) undo activation is explicitly *not* this
+   stage: snapshot undo stays user-facing until Stage 2 (#163).

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,115 @@
                     </limit>
                   </limits>
                 </rule>
+                <!-- Per-package floors (issue #159): the bundle floor
+                     alone lets a regression in a tested package hide
+                     behind gains elsewhere. These make the tested core
+                     un-regressable. Floors sit just under the headless
+                     measurement of 2026-07-18 (jls 52.5/50.9/56.6,
+                     jls.sim 45.0/44.6/35.3, jls.elem 42.6/41.6/36.3,
+                     jls.collab.op 90.9/92.2/74.0 - instruction/line/
+                     branch). jls.edit is deliberately unfloored until
+                     the #91/#84 work makes editor code testable; the
+                     same raise-with-your-PR convention applies here as
+                     to the bundle floors. Two verified-the-hard-way
+                     notes: include patterns must be dot-form package
+                     names (slash form silently matches nothing), and
+                     any floor experiment needs `mvn clean verify` -
+                     the agent appends to target/jacoco.exec, so an
+                     unclean rerun unions with prior coverage and
+                     floors can never trip. -->
+                <rule>
+                  <element>PACKAGE</element>
+                  <includes>
+                    <include>jls</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.510</minimum>
+                    </limit>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.495</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.550</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+                <rule>
+                  <element>PACKAGE</element>
+                  <includes>
+                    <include>jls.sim</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.435</minimum>
+                    </limit>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.430</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.340</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+                <rule>
+                  <element>PACKAGE</element>
+                  <includes>
+                    <include>jls.elem</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.410</minimum>
+                    </limit>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.400</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.350</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+                <rule>
+                  <element>PACKAGE</element>
+                  <includes>
+                    <include>jls.collab.op</include>
+                  </includes>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.880</minimum>
+                    </limit>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.890</minimum>
+                    </limit>
+                    <limit>
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.700</minimum>
+                    </limit>
+                  </limits>
+                </rule>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,46 @@
         </executions>
       </plugin>
       <plugin>
+        <!-- Documentation gate: every public and protected declaration
+             carries well-formed Javadoc (the #186 documentation pass
+             made this true tree-wide; this gate keeps the API half
+             true). doclint runs all groups except `reference`: the
+             generated @see tags point at the test tree, which is
+             deliberately not on the javadoc sourcepath, so reference
+             resolution cannot succeed there - those tags are
+             regenerated attribution, not an enforced invariant. Any
+             other warning fails the build.
+             Scope note, verified empirically: the gate runs at the
+             default protected visibility because under -private the
+             standard doclet itself (independent of doclint, so the
+             -reference exclusion cannot reach it) warns on every
+             test-tree @see target; private-level completeness stays a
+             convention of the periodic documentation pass.
+             -Xmaxwarns lifts javadoc's default 100-warning cap so a
+             regression cannot hide behind truncated output. -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.12.0</version>
+        <executions>
+          <execution>
+            <id>doclint-gate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>javadoc</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doclint>all,-reference</doclint>
+          <failOnWarnings>true</failOnWarnings>
+          <quiet>true</quiet>
+          <additionalOptions>
+            <additionalOption>-Xmaxwarns</additionalOption>
+            <additionalOption>10000</additionalOption>
+          </additionalOptions>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- CycloneDX SBOM with every build: target/bom.json/.xml
              (issue #65; publishing with releases rides #44) -->
         <groupId>org.cyclonedx</groupId>

--- a/src/jls/collab/op/AttachProbe.java
+++ b/src/jls/collab/op/AttachProbe.java
@@ -1,0 +1,73 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Wire;
+
+/**
+ * Attach a named probe to a wire (issue #167). The name is resolved
+ * before the op exists - prompting the user is the editor's business,
+ * never the op's - so the op is pure data. Inverse: {@link RemoveProbe}.
+ *
+ * @param id The stable id of the wire to probe.
+ * @param name The probe name; must be non-empty.
+ */
+public record AttachProbe(ElementId id, String name) implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Wire wire = resolveWire(circuit, id);
+		if (name == null || name.isEmpty()) {
+			throw new OpRejected("a probe needs a non-empty name");
+		}
+		if (wire.hasProbe()) {
+			throw new OpRejected("wire '" + id + "' already has a probe");
+		}
+		wire.attachProbe(name);
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Wire wire = resolveWire(before, id);
+		if (wire.hasProbe()) {
+			throw new OpRejected("wire '" + id + "' already has a probe");
+		}
+		return new RemoveProbe(id);
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP AttachProbe");
+		Ops.saveString(output, "id", id.toString());
+		Ops.saveString(output, "name", name);
+		output.println("END");
+	} // end of save method
+
+	/**
+	 * Resolve a stable id that must address a wire.
+	 *
+	 * @param circuit The circuit to search.
+	 * @param id The stable id.
+	 *
+	 * @return the wire.
+	 *
+	 * @throws OpRejected if the id is unknown or not a wire's.
+	 */
+	static Wire resolveWire(Circuit circuit, ElementId id)
+			throws OpRejected {
+
+		Element el = Ops.resolve(circuit, id);
+		if (!(el instanceof Wire)) {
+			throw new OpRejected("element '" + id + "' is not a wire");
+		}
+		return (Wire) el;
+	} // end of resolveWire method
+
+} // end of AttachProbe record

--- a/src/jls/collab/op/CircuitOp.java
+++ b/src/jls/collab/op/CircuitOp.java
@@ -1,0 +1,73 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+
+/**
+ * One editor mutation, reified as a validated, invertible, serializable
+ * command (issue #167, collab Stage 0b). The vocabulary is deliberately
+ * closed - a sealed interface over data-only records - because it is the
+ * future network surface of collaborative editing (issue #163): nothing
+ * in an op names a file path, a class, or code, and every kind validates
+ * the circuit's invariants before mutating anything.
+ *
+ * Contract:
+ *
+ * <ul>
+ * <li>{@link #apply} either performs the whole mutation or throws
+ * {@link OpRejected} having changed nothing (validate first, mutate
+ * after).</li>
+ * <li>{@link #invert} is computed against the pre-apply circuit; applying
+ * the op and then its inverse returns the circuit to its prior canonical
+ * bytes (issue #166 is the oracle).</li>
+ * <li>{@link #save} writes the save-format idiom (typed lines between
+ * {@code OP <kind>} and {@code END}); {@link CircuitOpReader} is its
+ * exact inverse.</li>
+ * </ul>
+ *
+ * Elements are addressed by stable id (issue #165), never by object
+ * reference, so an op means the same thing on a restored or replicated
+ * circuit as on the one it was recorded against.
+ */
+public sealed interface CircuitOp
+		permits ToggleWatched, AttachProbe, RemoveProbe, RotateElement,
+				FlipElement, MoveElements {
+
+	/**
+	 * Validate this op against the circuit and perform it. Validation
+	 * failures throw before any mutation happens.
+	 *
+	 * @param circuit The circuit to mutate.
+	 * @param g A graphics context for geometry recomputation (rotate and
+	 *            flip re-derive element size from font metrics), or null
+	 *            when the op kind needs none.
+	 *
+	 * @throws OpRejected if the op does not validate against this
+	 *             circuit; the circuit is unchanged.
+	 */
+	void apply(Circuit circuit, Graphics g) throws OpRejected;
+
+	/**
+	 * The op that undoes this one, computed from the circuit as it is
+	 * <em>before</em> this op is applied.
+	 *
+	 * @param before The pre-apply circuit.
+	 *
+	 * @return the inverse op.
+	 *
+	 * @throws OpRejected if this op would not validate against the given
+	 *             circuit (an op that cannot apply has no inverse).
+	 */
+	CircuitOp invert(Circuit before) throws OpRejected;
+
+	/**
+	 * Serialize this op in the save-format idiom. Deterministic: the
+	 * same op always writes the same bytes.
+	 *
+	 * @param output The output writer.
+	 */
+	void save(PrintWriter output);
+
+} // end of CircuitOp interface

--- a/src/jls/collab/op/CircuitOpReader.java
+++ b/src/jls/collab/op/CircuitOpReader.java
@@ -1,0 +1,254 @@
+package jls.collab.op;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import jls.elem.ElementId;
+
+/**
+ * Parse one serialized {@link CircuitOp} block (issue #167): the exact
+ * inverse of each op's {@code save}. Strict by design - this grammar is
+ * the future network surface (issues #163/#170), so unknown kinds,
+ * unknown fields, malformed lines, missing fields, and oversized input
+ * are all rejections, never best-effort repairs.
+ *
+ * Grammar (save-format idiom):
+ *
+ * <pre>
+ * OP &lt;kind&gt;
+ *  String &lt;key&gt; "&lt;escaped value&gt;"
+ *  int &lt;key&gt; &lt;value&gt;
+ * END
+ * </pre>
+ */
+public final class CircuitOpReader {
+
+	/** Hostile-input caps (issue #38 discipline). */
+	private static final int MAX_IDS = 10_000;
+	private static final int MAX_STRING = 10_000;
+	private static final int MAX_LINES = MAX_IDS + 16;
+
+	private CircuitOpReader() {
+
+	} // end of constructor
+
+	/**
+	 * Read the next op block from the scanner.
+	 *
+	 * @param input The input, positioned at an {@code OP} line.
+	 *
+	 * @return the parsed op.
+	 *
+	 * @throws OpRejected if the input is not a well-formed op block.
+	 */
+	public static CircuitOp read(Scanner input) throws OpRejected {
+
+		if (!input.hasNextLine()) {
+			throw new OpRejected("expected an OP line, found end of input");
+		}
+		String header = input.nextLine();
+		if (!header.startsWith("OP ")) {
+			throw new OpRejected("expected an OP line, found '"
+					+ clip(header) + "'");
+		}
+		String kind = header.substring(3).trim();
+
+		List<ElementId> ids = new ArrayList<ElementId>();
+		String name = null;
+		Integer dx = null;
+		Integer dy = null;
+		Integer cw = null;
+		int lines = 0;
+		while (true) {
+			if (!input.hasNextLine()) {
+				throw new OpRejected("op block for '" + kind
+						+ "' is missing its END line");
+			}
+			if (lines >= MAX_LINES) {
+				throw new OpRejected("op block for '" + kind
+						+ "' exceeds " + MAX_LINES + " lines");
+			}
+			String line = input.nextLine();
+			lines += 1;
+			if (line.equals("END")) {
+				break;
+			}
+			if (line.startsWith(" String id ")) {
+				if (ids.size() >= MAX_IDS) {
+					throw new OpRejected("op block for '" + kind
+							+ "' lists more than " + MAX_IDS + " ids");
+				}
+				ids.add(parseId(unquote(line.substring(11), "id")));
+			} else if (line.startsWith(" String name ")) {
+				if (name != null) {
+					throw new OpRejected("duplicate 'name' field");
+				}
+				name = unquote(line.substring(13), "name");
+			} else if (line.startsWith(" int dx ")) {
+				dx = parseInt(dx, line.substring(8), "dx");
+			} else if (line.startsWith(" int dy ")) {
+				dy = parseInt(dy, line.substring(8), "dy");
+			} else if (line.startsWith(" int cw ")) {
+				cw = parseInt(cw, line.substring(8), "cw");
+			} else {
+				throw new OpRejected("unrecognized line '" + clip(line)
+						+ "' in op block for '" + kind + "'");
+			}
+		}
+
+		switch (kind) {
+		case "ToggleWatched":
+			requireFields(kind, ids.size() == 1 && name == null
+					&& dx == null && dy == null && cw == null);
+			return new ToggleWatched(ids.get(0));
+		case "AttachProbe":
+			requireFields(kind, ids.size() == 1 && name != null
+					&& !name.isEmpty() && dx == null && dy == null
+					&& cw == null);
+			return new AttachProbe(ids.get(0), name);
+		case "RemoveProbe":
+			requireFields(kind, ids.size() == 1 && name == null
+					&& dx == null && dy == null && cw == null);
+			return new RemoveProbe(ids.get(0));
+		case "RotateElement":
+			requireFields(kind, ids.size() == 1 && name == null
+					&& dx == null && dy == null && cw != null
+					&& (cw == 0 || cw == 1));
+			return new RotateElement(ids.get(0), cw == 1);
+		case "FlipElement":
+			requireFields(kind, ids.size() == 1 && name == null
+					&& dx == null && dy == null && cw == null);
+			return new FlipElement(ids.get(0));
+		case "MoveElements":
+			requireFields(kind, !ids.isEmpty() && name == null
+					&& dx != null && dy != null && cw == null);
+			return new MoveElements(ids, dx, dy);
+		default:
+			throw new OpRejected("unknown op kind '" + clip(kind) + "'");
+		}
+	} // end of read method
+
+	/**
+	 * Reject a kind whose field combination is wrong.
+	 *
+	 * @param kind The op kind being parsed.
+	 * @param wellFormed Whether the fields match the kind's shape.
+	 *
+	 * @throws OpRejected if not well formed.
+	 */
+	private static void requireFields(String kind, boolean wellFormed)
+			throws OpRejected {
+
+		if (!wellFormed) {
+			throw new OpRejected("op block for '" + kind
+					+ "' does not have that kind's fields");
+		}
+	} // end of requireFields method
+
+	/**
+	 * Parse a stable id, converting the unchecked parse failure into a
+	 * rejection.
+	 *
+	 * @param text The id's string form.
+	 *
+	 * @return the id.
+	 *
+	 * @throws OpRejected if malformed.
+	 */
+	private static ElementId parseId(String text) throws OpRejected {
+
+		try {
+			return ElementId.parse(text);
+		} catch (IllegalArgumentException ex) {
+			throw new OpRejected(ex.getMessage());
+		}
+	} // end of parseId method
+
+	/**
+	 * Parse one int field value, rejecting duplicates and non-numbers.
+	 *
+	 * @param existing The previously seen value for this key, or null.
+	 * @param text The raw value text.
+	 * @param key The field name, for the message.
+	 *
+	 * @return the parsed value.
+	 *
+	 * @throws OpRejected on a duplicate or malformed value.
+	 */
+	private static Integer parseInt(Integer existing, String text,
+			String key) throws OpRejected {
+
+		if (existing != null) {
+			throw new OpRejected("duplicate '" + key + "' field");
+		}
+		try {
+			return Integer.valueOf(text.trim());
+		} catch (NumberFormatException ex) {
+			throw new OpRejected("the value of '" + key
+					+ "' should be an integer, but '" + clip(text)
+					+ "' is not");
+		}
+	} // end of parseInt method
+
+	/**
+	 * Decode a quoted, escaped string value: the single left-to-right
+	 * scan that exactly inverts the writer's escaping (issue #53).
+	 *
+	 * @param raw The rest of the line, including the surrounding quotes.
+	 * @param key The field name, for the message.
+	 *
+	 * @return the decoded string.
+	 *
+	 * @throws OpRejected if no quoted value is present or it is too long.
+	 */
+	private static String unquote(String raw, String key)
+			throws OpRejected {
+
+		int start = raw.indexOf('"');
+		int end = raw.lastIndexOf('"');
+		if (start < 0 || end <= start) {
+			throw new OpRejected("the value of '" + key
+					+ "' should be a quoted string, but '" + clip(raw)
+					+ "' is not");
+		}
+		String escaped = raw.substring(start + 1, end);
+		if (escaped.length() > MAX_STRING) {
+			throw new OpRejected("the value of '" + key + "' exceeds "
+					+ MAX_STRING + " characters");
+		}
+		StringBuilder value = new StringBuilder(escaped.length());
+		for (int i = 0; i < escaped.length(); i += 1) {
+			char ch = escaped.charAt(i);
+			if (ch == '\\' && i + 1 < escaped.length()) {
+				char next = escaped.charAt(i + 1);
+				if (next == 'n') {
+					value.append('\n');
+					i += 1;
+				} else if (next == '\\' || next == '"') {
+					value.append(next);
+					i += 1;
+				} else {
+					// not a writer-produced escape; keep it verbatim
+					value.append(ch);
+				}
+			} else {
+				value.append(ch);
+			}
+		}
+		return value.toString();
+	} // end of unquote method
+
+	/**
+	 * Clip untrusted text for an error message.
+	 *
+	 * @param text The text.
+	 *
+	 * @return at most 60 characters of it.
+	 */
+	private static String clip(String text) {
+
+		return text.length() <= 60 ? text : text.substring(0, 60) + "…";
+	} // end of clip method
+
+} // end of CircuitOpReader class

--- a/src/jls/collab/op/FlipElement.java
+++ b/src/jls/collab/op/FlipElement.java
@@ -1,0 +1,45 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+
+/**
+ * Flip (mirror) an element (issue #167). Self-inverse.
+ *
+ * @param id The stable id of the element to flip.
+ */
+public record FlipElement(ElementId id) implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Element el = Ops.resolve(circuit, id);
+		if (!el.canFlip()) {
+			throw new OpRejected("element '" + id + "' cannot flip");
+		}
+		el.flip(g);
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Element el = Ops.resolve(before, id);
+		if (!el.canFlip()) {
+			throw new OpRejected("element '" + id + "' cannot flip");
+		}
+		return this;
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP FlipElement");
+		Ops.saveString(output, "id", id.toString());
+		output.println("END");
+	} // end of save method
+
+} // end of FlipElement record

--- a/src/jls/collab/op/MoveElements.java
+++ b/src/jls/collab/op/MoveElements.java
@@ -1,0 +1,93 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Wire;
+
+/**
+ * Translate a group of elements by one delta (issue #167). The group is
+ * whatever the gesture committed - typically a selection including its
+ * attached wire ends. Inverse: the negated delta over the same group.
+ *
+ * Validation is atomic: every id must resolve and no element may end up
+ * with negative coordinates, checked before anything moves.
+ *
+ * @param ids The stable ids of the elements to move; no duplicates.
+ * @param dx The x delta in pixels.
+ * @param dy The y delta in pixels.
+ */
+public record MoveElements(List<ElementId> ids, int dx, int dy)
+		implements CircuitOp {
+
+	/**
+	 * Defensive copy: the record's list is immutable whatever the caller
+	 * passed (issue #94 discipline).
+	 */
+	public MoveElements {
+
+		ids = List.copyOf(ids);
+	} // end of compact constructor
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		if (ids.isEmpty()) {
+			throw new OpRejected("a move needs at least one element");
+		}
+		Set<ElementId> seen = new HashSet<ElementId>();
+		List<Element> targets = new ArrayList<Element>(ids.size());
+		for (ElementId id : ids) {
+			if (!seen.add(id)) {
+				throw new OpRejected("the move lists element '" + id
+						+ "' twice");
+			}
+			targets.add(Ops.resolve(circuit, id));
+		}
+		for (Element el : targets) {
+			// wires follow their ends; their own rect is derived
+			if (el instanceof Wire) {
+				continue;
+			}
+			Rectangle r = el.getRect();
+			if (r.x + dx < 0 || r.y + dy < 0) {
+				throw new OpRejected("moving element '" + el.getStableId()
+						+ "' by (" + dx + "," + dy
+						+ ") would leave the canvas");
+			}
+		}
+		for (Element el : targets) {
+			el.move(dx, dy);
+		}
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		for (ElementId id : ids) {
+			Ops.resolve(before, id);
+		}
+		return new MoveElements(ids, -dx, -dy);
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP MoveElements");
+		for (ElementId id : ids) {
+			Ops.saveString(output, "id", id.toString());
+		}
+		Ops.saveInt(output, "dx", dx);
+		Ops.saveInt(output, "dy", dy);
+		output.println("END");
+	} // end of save method
+
+} // end of MoveElements record

--- a/src/jls/collab/op/OpRejected.java
+++ b/src/jls/collab/op/OpRejected.java
@@ -1,0 +1,23 @@
+package jls.collab.op;
+
+/**
+ * Thrown when a {@link CircuitOp} fails validation against the circuit
+ * it is being applied to (issue #167): the addressed element does not
+ * exist, lacks the capability the op needs, or the mutation would break
+ * a model invariant. The circuit is unchanged when this is thrown.
+ */
+public class OpRejected extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Create a rejection with a human-readable reason.
+	 *
+	 * @param reason Why the op does not validate.
+	 */
+	public OpRejected(String reason) {
+
+		super(reason);
+	} // end of constructor
+
+} // end of OpRejected class

--- a/src/jls/collab/op/OpSink.java
+++ b/src/jls/collab/op/OpSink.java
@@ -1,0 +1,24 @@
+package jls.collab.op;
+
+/**
+ * The single entry point through which circuit mutations flow (issue
+ * #167): the editor submits ops here instead of mutating inline, and
+ * the collaboration layer (issue #163) observes the same entry point.
+ * An implementation validates and applies the op, then performs the
+ * change bookkeeping the surrounding application needs (undo snapshot,
+ * checkpoint, changed flag - {@code SimpleEditor.markChanged()} during
+ * the Stage 0b migration).
+ */
+public interface OpSink {
+
+	/**
+	 * Validate, apply, and record one operation.
+	 *
+	 * @param op The operation to perform.
+	 *
+	 * @throws OpRejected if the op does not validate against the current
+	 *             circuit; nothing is changed or recorded.
+	 */
+	void submit(CircuitOp op) throws OpRejected;
+
+} // end of OpSink interface

--- a/src/jls/collab/op/Ops.java
+++ b/src/jls/collab/op/Ops.java
@@ -1,0 +1,83 @@
+package jls.collab.op;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+
+/**
+ * Shared helpers for the op vocabulary (issue #167): stable-id
+ * resolution and the save-format string escaping. The escaping mirrors
+ * {@code Attribute.StringAttribute.save} and the loader's single
+ * left-to-right unescape scan (issue #53) exactly; issue #79 may later
+ * centralize both under the save-format stewardship work.
+ */
+final class Ops {
+
+	private Ops() {
+
+	} // end of constructor
+
+	/**
+	 * Find the element a stable id addresses.
+	 *
+	 * @param circuit The circuit to search.
+	 * @param id The stable id.
+	 *
+	 * @return the element.
+	 *
+	 * @throws OpRejected if no element in the circuit has that id.
+	 */
+	static Element resolve(Circuit circuit, ElementId id)
+			throws OpRejected {
+
+		for (Element el : circuit.getElements()) {
+			if (el.getStableId().equals(id)) {
+				return el;
+			}
+		}
+		throw new OpRejected("no element with stable id '" + id
+				+ "' exists in the circuit");
+	} // end of resolve method
+
+	/**
+	 * Escape a string value the way the save format's writer does:
+	 * backslash, quote and newline become two-character sequences.
+	 *
+	 * @param value The raw string.
+	 *
+	 * @return the escaped form, without surrounding quotes.
+	 */
+	static String escape(String value) {
+
+		String str = value.replace("\\", "\\\\");
+		str = str.replace("\"", "\\\"");
+		return str.replace("\n", "\\n");
+	} // end of escape method
+
+	/**
+	 * Write one {@code String} typed line in the save-format idiom.
+	 *
+	 * @param output The output writer.
+	 * @param key The field name.
+	 * @param value The raw (unescaped) value.
+	 */
+	static void saveString(java.io.PrintWriter output, String key,
+			String value) {
+
+		output.println(" String " + key + " \"" + escape(value) + "\"");
+	} // end of saveString method
+
+	/**
+	 * Write one {@code int} typed line in the save-format idiom.
+	 *
+	 * @param output The output writer.
+	 * @param key The field name.
+	 * @param value The value.
+	 */
+	static void saveInt(java.io.PrintWriter output, String key,
+			int value) {
+
+		output.println(" int " + key + " " + value);
+	} // end of saveInt method
+
+} // end of Ops class

--- a/src/jls/collab/op/RemoveProbe.java
+++ b/src/jls/collab/op/RemoveProbe.java
@@ -1,0 +1,46 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+import jls.elem.ElementId;
+import jls.elem.Wire;
+
+/**
+ * Remove the probe from a wire (issue #167). Inverse:
+ * {@link AttachProbe} carrying the removed probe's name.
+ *
+ * @param id The stable id of the probed wire.
+ */
+public record RemoveProbe(ElementId id) implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Wire wire = AttachProbe.resolveWire(circuit, id);
+		if (!wire.hasProbe()) {
+			throw new OpRejected("wire '" + id + "' has no probe");
+		}
+		wire.removeProbe();
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Wire wire = AttachProbe.resolveWire(before, id);
+		if (!wire.hasProbe()) {
+			throw new OpRejected("wire '" + id + "' has no probe");
+		}
+		return new AttachProbe(id, wire.getProbe());
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP RemoveProbe");
+		Ops.saveString(output, "id", id.toString());
+		output.println("END");
+	} // end of save method
+
+} // end of RemoveProbe record

--- a/src/jls/collab/op/RotateElement.java
+++ b/src/jls/collab/op/RotateElement.java
@@ -1,0 +1,51 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.elem.Element;
+import jls.elem.ElementId;
+
+/**
+ * Rotate an element a quarter turn (issue #167). Inverse: the opposite
+ * quarter turn.
+ *
+ * @param id The stable id of the element to rotate.
+ * @param clockwise True for clockwise, false for counterclockwise.
+ */
+public record RotateElement(ElementId id, boolean clockwise)
+		implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Element el = Ops.resolve(circuit, id);
+		if (!el.canRotate()) {
+			throw new OpRejected("element '" + id + "' cannot rotate");
+		}
+		el.rotate(clockwise ? JLSInfo.Orientation.RIGHT
+				: JLSInfo.Orientation.LEFT, g);
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Element el = Ops.resolve(before, id);
+		if (!el.canRotate()) {
+			throw new OpRejected("element '" + id + "' cannot rotate");
+		}
+		return new RotateElement(id, !clockwise);
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP RotateElement");
+		Ops.saveString(output, "id", id.toString());
+		Ops.saveInt(output, "cw", clockwise ? 1 : 0);
+		output.println("END");
+	} // end of save method
+
+} // end of RotateElement record

--- a/src/jls/collab/op/ToggleWatched.java
+++ b/src/jls/collab/op/ToggleWatched.java
@@ -1,0 +1,46 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+
+/**
+ * Toggle whether an element's value is watched during batch simulation
+ * (issue #167). Self-inverse.
+ *
+ * @param id The stable id of the element to toggle.
+ */
+public record ToggleWatched(ElementId id) implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Element el = Ops.resolve(circuit, id);
+		if (!el.canWatch()) {
+			throw new OpRejected("element '" + id + "' cannot be watched");
+		}
+		el.setWatched(!el.isWatched());
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Element el = Ops.resolve(before, id);
+		if (!el.canWatch()) {
+			throw new OpRejected("element '" + id + "' cannot be watched");
+		}
+		return this;
+	} // end of invert method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP ToggleWatched");
+		Ops.saveString(output, "id", id.toString());
+		output.println("END");
+	} // end of save method
+
+} // end of ToggleWatched record

--- a/src/jls/collab/op/package-info.java
+++ b/src/jls/collab/op/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * The operation layer of the collaborative-editing program (issue #167,
+ * collab Stage 0b): editor mutations reified as a closed vocabulary of
+ * validated, invertible, serializable commands. The sealed
+ * {@link jls.collab.op.CircuitOp} interface is the whole vocabulary -
+ * data-only records addressing elements by stable id
+ * ({@link jls.elem.ElementId}, issue #165) - and
+ * {@link jls.collab.op.OpSink} is the single entry point mutations flow
+ * through: the editor submits ops instead of mutating inline, and the
+ * future replication layer (issue #163) observes the same entry point.
+ * Every op validates before mutating (rejections throw
+ * {@link jls.collab.op.OpRejected} leaving the circuit untouched),
+ * computes an exact inverse against the pre-apply circuit (the
+ * canonical-serialization oracle of issue #166 verifies restoration to
+ * the byte), and round-trips through the strict
+ * {@link jls.collab.op.CircuitOpReader}, which rejects rather than
+ * repairs malformed input - this grammar is the future network surface
+ * (issue #170). No class here may depend on Swing; the architecture
+ * rules enforce that layering. The migration inventory and status live
+ * in {@code docs/operation-layer.md}.
+ */
+package jls.collab.op;

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -57,6 +57,14 @@ import jls.FileAbstractor;
 import jls.JLSInfo;
 import jls.TellUser;
 import jls.Util;
+import jls.collab.op.AttachProbe;
+import jls.collab.op.CircuitOp;
+import jls.collab.op.FlipElement;
+import jls.collab.op.OpRejected;
+import jls.collab.op.OpSink;
+import jls.collab.op.RemoveProbe;
+import jls.collab.op.RotateElement;
+import jls.collab.op.ToggleWatched;
 import jls.elem.Adder;
 import jls.elem.AndGate;
 import jls.elem.Binder;
@@ -820,14 +828,9 @@ public abstract class SimpleEditor extends JPanel {
 							if (!el.canWatch())
 								return;
 
-							// remove if watched, add if not
-							if (el.isWatched()) {
-								el.setWatched(false);
-							}
-							else {
-								el.setWatched(true);
-							}
-							markChanged();
+							// remove if watched, add if not (#167: through
+							// the op entry point)
+							submitOp(new ToggleWatched(el.getStableId()));
 
 							// clean up
 							clearSelected();
@@ -1631,14 +1634,15 @@ public abstract class SimpleEditor extends JPanel {
 					if (el.isUneditable())
 						return;
 
-					// remove if watched, add if not
-					if (el.isWatched()) {
-						el.setWatched(false);
-					}
-					else {
-						el.setWatched(true);
-					}
-					markChanged();
+					// do nothing if not watchable (the menu item only
+					// shows for watchable elements; this mirrors the
+					// ctrl-W path's guard)
+					if (!el.canWatch())
+						return;
+
+					// remove if watched, add if not (#167: through the
+					// op entry point)
+					submitOp(new ToggleWatched(el.getStableId()));
 
 					// clean up
 					clearSelected();
@@ -1822,8 +1826,8 @@ public abstract class SimpleEditor extends JPanel {
 					if(!enabled)
 						return;
 					Element el = (Element)(selected.toArray()[0]);
-					el.rotate(JLSInfo.Orientation.RIGHT, this.getGraphics());
-					markChanged();
+					// #167: through the op entry point
+					submitOp(new RotateElement(el.getStableId(), true));
 					clearSelected();
 					setState(State.idle);
 					repaint();
@@ -1836,8 +1840,8 @@ public abstract class SimpleEditor extends JPanel {
 					if(!enabled)
 						return;
 					Element el = (Element)(selected.toArray()[0]);
-					el.rotate(JLSInfo.Orientation.LEFT, this.getGraphics());
-					markChanged();
+					// #167: through the op entry point
+					submitOp(new RotateElement(el.getStableId(), false));
 					clearSelected();
 					setState(State.idle);
 					repaint();
@@ -1868,8 +1872,8 @@ public abstract class SimpleEditor extends JPanel {
 					if(!enabled)
 						return;
 					Element el = (Element)(selected.toArray()[0]);
-					el.flip(this.getGraphics());
-					markChanged();
+					// #167: through the op entry point
+					submitOp(new FlipElement(el.getStableId()));
 					clearSelected();
 					setState(State.idle);
 					repaint();
@@ -4060,16 +4064,32 @@ public abstract class SimpleEditor extends JPanel {
 						// get the single item in the selected set
 						Wire wire = (Wire)(selected.toArray()[0]);
 
-						// remove if wire has a probe, add if not
+						// remove if wire has a probe, add if not (#167:
+						// prompting stays here in the gesture - an op is
+						// pure data - and the mutation goes through the
+						// op entry point)
 						if (wire.hasProbe()) {
-							wire.removeProbe();
+							submitOp(new RemoveProbe(wire.getStableId()));
 						}
 						else {
-							wire.attachProbe(null);
+							String name = TellUser.prompt(null, "Name?");
+							while (name != null && name.isEmpty()) {
+								name = TellUser.prompt(null,
+										"Invalid name, try again");
+							}
+							if (name == null) {
+								// parity with the pre-op path: a
+								// cancelled prompt still marked the
+								// circuit changed
+								markChanged();
+							}
+							else {
+								submitOp(new AttachProbe(
+										wire.getStableId(), name));
+							}
 						}
 
 						// clean up
-						markChanged();
 						clearSelected();
 						setState(State.idle);
 						repaint();
@@ -4324,6 +4344,47 @@ public abstract class SimpleEditor extends JPanel {
 						}
 
 					} // end of markChanged method
+
+					/**
+					 * The single mutation entry point (issue #167, collab
+					 * Stage 0b): validate the op, apply it to the circuit,
+					 * then do the existing change bookkeeping (undo
+					 * snapshot, checkpoint, changed flag). The
+					 * collaboration layer (issue #163) will observe this
+					 * same entry point; gestures migrate to it one at a
+					 * time under the snapshot-undo safety net.
+					 */
+					private final OpSink opSink = new OpSink() {
+						@Override
+						public void submit(CircuitOp op) throws OpRejected {
+
+							op.apply(circuit, getGraphics());
+							markChanged();
+						}
+					};
+
+					/**
+					 * Submit a gesture's committed op, reporting a
+					 * rejection to the user. Rejections cannot happen from
+					 * correctly guarded gestures - the guards run before
+					 * the op is built - so a dialog here means a gesture
+					 * bug, not a user error.
+					 *
+					 * @param op The operation to perform.
+					 *
+					 * @return true if the op applied, false if rejected.
+					 */
+					private boolean submitOp(CircuitOp op) {
+
+						try {
+							opSink.submit(op);
+							return true;
+						} catch (OpRejected ex) {
+							TellUser.error(JLSInfo.frame, ex.getMessage(),
+									"Error");
+							return false;
+						}
+					} // end of submitOp method
 
 					/**
 					 * Push a copy of the circuit being edited on the undo stack.

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -3270,7 +3270,7 @@ public abstract class SimpleEditor extends JPanel {
 			 * @param end1 The wire end.
 			 * @param wire The wire.
 			 * 
-			 * @returns true if can connect, false if not.
+			 * @return true if can connect, false if not.
 			 */
 			public boolean canConnect(WireEnd end1, Wire wire) {
 

--- a/src/jls/elem/Adder.java
+++ b/src/jls/elem/Adder.java
@@ -261,12 +261,6 @@ public class Adder extends LogicElement {
 		
 	} // end of draw method
 	
-	/**
-	 * Set an int instance variable value (during a load).
-	 * 
-	 * @param name The instance variable name.
-	 * @param value The instance variable value.
-	 */
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -371,7 +371,7 @@ public class Element {
 	 * Set a pair of int instance variable values (during a load).
 	 * 
 	 * @param v1 The first value.
-	 * @param v1 The second value.
+	 * @param v2 The second value.
 	 */
 	public void setPair(int v1, int v2) {
 

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -353,12 +353,6 @@ public abstract class Gate extends LogicElement {
 		
 	} // end of draw method
 	
-	/**
-	 * Set an int instance variable value (during a load).
-	 * 
-	 * @param name The instance variable name.
-	 * @param value The instance variable value.
-	 */
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for the attributes shared by every gate kind.
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -265,7 +265,7 @@ public abstract class Group extends LogicElement {
 	 * Set a pair of int instance variable values (during a load).
 	 * 
 	 * @param v1 The first value.
-	 * @param v1 The second value.
+	 * @param v2 The second value.
 	 */
 	@Override
 	public void setPair(int v1, int v2) {

--- a/src/jls/elem/Pin.java
+++ b/src/jls/elem/Pin.java
@@ -141,12 +141,6 @@ public abstract class Pin extends LogicElement {
 		}
 	} // end of init method
 	
-	/**
-	 * Set an int instance variable value (during a load).
-	 * 
-	 * @param name The instance variable name.
-	 * @param value The instance variable value.
-	 */
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for the attributes shared by both pins.
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =

--- a/src/jls/elem/SigSim.java
+++ b/src/jls/elem/SigSim.java
@@ -216,7 +216,10 @@ public abstract class SigSim extends LogicElement {
 	} // end of react method
 
 	/**
-	 * 
+	 * Report an error in the signal-generator specification being
+	 * parsed. Subclasses decide how the message reaches the user.
+	 *
+	 * @param error The error message.
 	 */
 	protected abstract void specError(String error);
 

--- a/src/jls/elem/State.java
+++ b/src/jls/elem/State.java
@@ -676,7 +676,7 @@ public class State {
 	 * Set a pair of int instance variable values (during a load).
 	 * 
 	 * @param v1 The first value.
-	 * @param v1 The second value.
+	 * @param v2 The second value.
 	 */
 	public void setTransPair(int v1, int v2) {
 

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -589,7 +589,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * Set a pair of int instance variable values (during a load).
 	 * 
 	 * @param v1 The first value.
-	 * @param v1 The second value.
+	 * @param v2 The second value.
 	 */
 	@Override
 	public void setPair(int v1, int v2) {

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -375,7 +375,7 @@ public final class TruthTable extends LogicElement implements Printable {
 	 * Set a pair of int instance variable values (during a load).
 	 * 
 	 * @param v1 The first value.
-	 * @param v1 The second value.
+	 * @param v2 The second value.
 	 */
 	@Override
 	public void setPair(int v1, int v2) {

--- a/src/jls/sim/BatchSimulator.java
+++ b/src/jls/sim/BatchSimulator.java
@@ -627,9 +627,11 @@ public class BatchSimulator extends Simulator {
 	/**
 	 * One VCD value-change entry. JLS values are two-state plus HiZ,
 	 * so only 0, 1 and z ever appear ('x' never does): a single-bit
-	 * signal becomes 0<code>, 1<code> or z<code>; a multi-bit signal
-	 * becomes a binary vector b<value> <code> with leading zeros
-	 * omitted, or bz <code> when the whole signal is HiZ.
+	 * signal becomes its value directly followed by the identifier
+	 * code ({@code 0c}, {@code 1c} or {@code zc}); a multi-bit signal
+	 * becomes a binary vector {@code b<value> <code>} with leading
+	 * zeros omitted, or {@code bz <code>} when the whole signal is
+	 * HiZ.
 	 *
 	 * @param el The signal's element (for its bit width).
 	 * @param value The recorded value, with HiZ encoded as the trace's

--- a/src/jls/sim/MemTrace.java
+++ b/src/jls/sim/MemTrace.java
@@ -45,7 +45,7 @@ public final class MemTrace extends JFrame {
 	} // end of showit method
 	
 	/**
-	 *
+	 * Refresh the displayed text from the memory's activity trace.
 	 */
 	public void update() {
 		

--- a/test/jls/ArchitectureRulesTest.java
+++ b/test/jls/ArchitectureRulesTest.java
@@ -98,4 +98,26 @@ class ArchitectureRulesTest {
 						+ " grow it")
 				.check(classes);
 	}
+
+	/**
+	 * The collaboration layering rule from issue #163: everything under
+	 * jls.collab except the (future) jls.collab.ui package is headless -
+	 * ops, session, CRDT, and network code never touch Swing. UI effects
+	 * route through listeners marshalled onto the EDT by jls.collab.ui,
+	 * the one collab package allowed to import it. Zero-tolerance from
+	 * the start: the first collab package (jls.collab.op, issue #167)
+	 * is born clean.
+	 */
+	@Test
+	void collabLayersAreHeadless() {
+		noClasses()
+				.that().resideInAPackage("jls.collab..")
+				.and().resideOutsideOfPackage("jls.collab.ui..")
+				.should().dependOnClassesThat()
+				.resideInAPackage("javax.swing..")
+				.because("only jls.collab.ui may touch Swing; ops and"
+						+ " the replication stack are headless by"
+						+ " construction (issues #163/#167)")
+				.check(classes);
+	}
 }

--- a/test/jls/PackageInfoRatchetTest.java
+++ b/test/jls/PackageInfoRatchetTest.java
@@ -1,0 +1,52 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Package-documentation completeness ratchet: every package in the
+ * source and test trees carries a {@code package-info.java}. The #186
+ * documentation pass gave every package one; this keeps a new package
+ * from shipping without (which happened to {@code jls.collab.op},
+ * created between that pass's snapshot and its merge). Zero-tolerance:
+ * there is no exemption list - a package with code gets a package
+ * comment.
+ */
+class PackageInfoRatchetTest {
+
+	@Test
+	void everyPackageHasPackageInfo() throws IOException {
+		TreeSet<String> missing = new TreeSet<String>();
+		for (Path root : List.of(Path.of("src"), Path.of("test"))) {
+			try (Stream<Path> walk = Files.walk(root)) {
+				walk.filter(Files::isDirectory)
+						.filter(PackageInfoRatchetTest::hasJavaFiles)
+						.filter(dir -> !Files.exists(
+								dir.resolve("package-info.java")))
+						.forEach(dir -> missing.add(dir.toString()));
+			}
+		}
+		assertTrue(missing.isEmpty(),
+				"packages without package-info.java - document what the"
+						+ " package is for: " + missing);
+	}
+
+	private static boolean hasJavaFiles(Path dir) {
+		try (Stream<Path> files = Files.list(dir)) {
+			return files.anyMatch(f -> f.toString().endsWith(".java")
+					&& !f.getFileName().toString()
+							.equals("package-info.java"));
+		} catch (IOException e) {
+			throw new java.io.UncheckedIOException(e);
+		}
+	}
+
+} // end of PackageInfoRatchetTest class

--- a/test/jls/collab/op/CircuitOpTest.java
+++ b/test/jls/collab/op/CircuitOpTest.java
@@ -1,0 +1,338 @@
+package jls.collab.op;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Scanner;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Pin;
+import jls.elem.ShiftRegister;
+import jls.elem.Wire;
+
+/**
+ * The operation layer's contract (issue #167, collab Stage 0b), pinned
+ * against the canonical-serialization oracle (issue #166):
+ *
+ * <ul>
+ * <li>P1 - applying an op produces the same canonical bytes as the
+ * inline mutation it reifies;</li>
+ * <li>P2 - applying an op and then its inverse returns the canonical
+ * save to its prior bytes, on freshly loaded and on save/load-restored
+ * circuits alike (issue #167 section 10);</li>
+ * <li>P3 - op serialization round-trips through
+ * {@link CircuitOpReader}, and the reader rejects malformed input
+ * rather than repairing it;</li>
+ * <li>rejection - an op that fails validation leaves the circuit's
+ * bytes untouched, including when validation fails partway through a
+ * multi-element op.</li>
+ * </ul>
+ */
+class CircuitOpTest {
+
+	/** The wire-and-ref-heavy fixture (same as DeterministicSaveTest). */
+	private static final Path FORK_FIXTURE =
+			Path.of("test", "fixtures", "fork-4.6-shiftregister.jls");
+
+	private static Circuit load() throws Exception {
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(
+				Files.readString(FORK_FIXTURE, StandardCharsets.UTF_8))),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(graphics()),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/** A circuit restored through a save/load round trip (section 10). */
+	private static Circuit restored(Circuit circuit) throws Exception {
+		Circuit copy = new Circuit("");
+		assertTrue(copy.load(new Scanner(save(circuit))),
+				() -> "restore load failed: " + JLSInfo.loadError);
+		assertTrue(copy.finishLoad(graphics()),
+				() -> "restore finishLoad failed: " + JLSInfo.loadError);
+		return copy;
+	}
+
+	/**
+	 * A one-element circuit whose element is unwired, so rotate and
+	 * flip are permitted (both are rejected while puts are attached -
+	 * the same invariant the editor's menu enforces).
+	 */
+	private static Circuit loadAdder() throws Exception {
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(
+				"CIRCUIT ops\nELEMENT Adder\n int id 0\n int x 240\n"
+						+ " int y 240\n int bits 4\n String orient \"LEFT\"\n"
+						+ " int delay 10\nEND\nENDCIRCUIT\n")),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(graphics()),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString();
+	}
+
+	private static Graphics2D graphics() {
+		return new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB)
+				.createGraphics();
+	}
+
+	/**
+	 * The first matching element in canonical (stable-id) order, so
+	 * every run and every load picks the same one.
+	 */
+	private static Element find(Circuit circuit, Predicate<Element> p) {
+		List<Element> matches = new ArrayList<>();
+		for (Element el : circuit.getElements()) {
+			if (p.test(el)) {
+				matches.add(el);
+			}
+		}
+		matches.sort(Comparator.comparing(Element::getStableId));
+		assertTrue(!matches.isEmpty(), "fixture lacks a needed element");
+		return matches.get(0);
+	}
+
+	private static String serialize(CircuitOp op) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			op.save(writer);
+		}
+		return out.toString();
+	}
+
+	// ------------------------------------------------------------------
+	// P1: op-vs-inline parity
+	// ------------------------------------------------------------------
+
+	@Test
+	void toggleWatchedMatchesInlineMutation() throws Exception {
+		Circuit viaOp = load();
+		Circuit inline = load();
+		Element pin = find(viaOp, el -> el instanceof Pin && el.canWatch());
+		new ToggleWatched(pin.getStableId()).apply(viaOp, graphics());
+		Element inlinePin = find(inline,
+				el -> el instanceof Pin && el.canWatch());
+		inlinePin.setWatched(!inlinePin.isWatched());
+		assertEquals(save(inline), save(viaOp),
+				"op and inline watch toggle must produce identical bytes");
+	}
+
+	@Test
+	void rotateMatchesInlineMutation() throws Exception {
+		Circuit viaOp = loadAdder();
+		Circuit inline = loadAdder();
+		Element adder = find(viaOp, Element::canRotate);
+		new RotateElement(adder.getStableId(), true)
+				.apply(viaOp, graphics());
+		find(inline, Element::canRotate)
+				.rotate(JLSInfo.Orientation.RIGHT, graphics());
+		assertEquals(save(inline), save(viaOp),
+				"op and inline rotation must produce identical bytes");
+	}
+
+	// ------------------------------------------------------------------
+	// P2: apply then invert restores the canonical bytes
+	// ------------------------------------------------------------------
+
+	private static void assertInverseRestores(Circuit circuit,
+			CircuitOp op) throws Exception {
+		String before = save(circuit);
+		CircuitOp inverse = op.invert(circuit);
+		op.apply(circuit, graphics());
+		assertNotEquals(before, save(circuit),
+				"the op must change the canonical bytes");
+		inverse.apply(circuit, graphics());
+		assertEquals(before, save(circuit),
+				"applying the inverse must restore the canonical bytes");
+	}
+
+	@Test
+	void toggleWatchedInverseRestoresBytes() throws Exception {
+		Circuit circuit = load();
+		Element pin = find(circuit,
+				el -> el instanceof Pin && el.canWatch());
+		assertInverseRestores(circuit,
+				new ToggleWatched(pin.getStableId()));
+	}
+
+	@Test
+	void rotateInverseRestoresBytes() throws Exception {
+		Circuit circuit = loadAdder();
+		Element adder = find(circuit, Element::canRotate);
+		assertInverseRestores(circuit,
+				new RotateElement(adder.getStableId(), true));
+		assertInverseRestores(circuit,
+				new RotateElement(adder.getStableId(), false));
+	}
+
+	@Test
+	void flipInverseRestoresBytes() throws Exception {
+		Circuit circuit = loadAdder();
+		Element adder = find(circuit, Element::canFlip);
+		assertInverseRestores(circuit,
+				new FlipElement(adder.getStableId()));
+	}
+
+	@Test
+	void probeAttachAndRemoveAreMutualInverses() throws Exception {
+		Circuit circuit = load();
+		Element wire = find(circuit, el -> el instanceof Wire);
+		assertInverseRestores(circuit,
+				new AttachProbe(wire.getStableId(), "p0"));
+		// now with the probe attached, removal inverts back to it
+		new AttachProbe(wire.getStableId(), "p0")
+				.apply(circuit, graphics());
+		assertInverseRestores(circuit,
+				new RemoveProbe(wire.getStableId()));
+	}
+
+	@Test
+	void moveInverseRestoresBytes() throws Exception {
+		Circuit circuit = load();
+		Element reg = find(circuit, el -> el instanceof ShiftRegister);
+		assertInverseRestores(circuit, new MoveElements(
+				List.of(reg.getStableId()), 24, 12));
+	}
+
+	@Test
+	void inversesHoldOnARestoredCircuit() throws Exception {
+		// section 10 threat: ops validated on a live circuit may behave
+		// differently on a restored object graph
+		Circuit circuit = restored(load());
+		Element pin = find(circuit,
+				el -> el instanceof Pin && el.canWatch());
+		assertInverseRestores(circuit,
+				new ToggleWatched(pin.getStableId()));
+		Circuit adders = restored(loadAdder());
+		Element adder = find(adders, Element::canRotate);
+		assertInverseRestores(adders,
+				new RotateElement(adder.getStableId(), true));
+	}
+
+	// ------------------------------------------------------------------
+	// P3: serialization round-trips; the reader is strict
+	// ------------------------------------------------------------------
+
+	@Test
+	void serializationRoundTripsForEveryKind() throws Exception {
+		ElementId id = ElementId.parse("legacy:7");
+		ElementId other = ElementId.parse("legacy:9");
+		List<CircuitOp> ops = List.of(
+				new ToggleWatched(id),
+				new AttachProbe(id, "a \"quoted\\\" name\nwith lines"),
+				new RemoveProbe(id),
+				new RotateElement(id, true),
+				new RotateElement(id, false),
+				new FlipElement(id),
+				new MoveElements(List.of(id, other), -24, 36));
+		for (CircuitOp op : ops) {
+			String text = serialize(op);
+			CircuitOp parsed = CircuitOpReader.read(new Scanner(text));
+			assertEquals(op, parsed,
+					"parsed op must equal the one that was saved");
+			assertEquals(text, serialize(parsed),
+					"save -> read -> save must be byte-identical");
+		}
+	}
+
+	@Test
+	void readerRejectsMalformedInput() {
+		String[] hostile = {
+				// not an op block at all
+				"ELEMENT AndGate\nEND\n",
+				// unknown kind
+				"OP FormatDisk\n String id \"legacy:1\"\nEND\n",
+				// missing END
+				"OP ToggleWatched\n String id \"legacy:1\"\n",
+				// malformed id
+				"OP ToggleWatched\n String id \"::::\"\nEND\n",
+				// unknown field
+				"OP ToggleWatched\n String id \"legacy:1\"\n int evil 1\nEND\n",
+				// wrong field shape for the kind
+				"OP MoveElements\n String id \"legacy:1\"\n int dx 4\nEND\n",
+				// out-of-range rotate flag
+				"OP RotateElement\n String id \"legacy:1\"\n int cw 2\nEND\n",
+				// duplicate int field
+				"OP MoveElements\n String id \"legacy:1\"\n"
+						+ " int dx 4\n int dx 6\n int dy 0\nEND\n",
+				// probe without a name
+				"OP AttachProbe\n String id \"legacy:1\"\nEND\n",
+				// oversized string value
+				"OP AttachProbe\n String id \"legacy:1\"\n String name \""
+						+ "x".repeat(10_001) + "\"\nEND\n",
+		};
+		for (String text : hostile) {
+			assertThrows(OpRejected.class,
+					() -> CircuitOpReader.read(new Scanner(text)),
+					() -> "reader accepted: " + text.substring(0,
+							Math.min(40, text.length())));
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Rejection leaves the circuit untouched
+	// ------------------------------------------------------------------
+
+	@Test
+	void rejectionsLeaveTheCircuitUnchanged() throws Exception {
+		Circuit circuit = load();
+		String before = save(circuit);
+		ElementId unknown = ElementId.parse("nosuch:1");
+		Element pin = find(circuit,
+				el -> el instanceof Pin && el.canWatch());
+		Element wire = find(circuit, el -> el instanceof Wire);
+		Element constant = find(circuit,
+				el -> !el.canWatch() && !(el instanceof Wire)
+						&& !el.canRotate());
+
+		CircuitOp[] invalid = {
+				new ToggleWatched(unknown),
+				new ToggleWatched(constant.getStableId()),
+				new AttachProbe(pin.getStableId(), "p"),
+				new AttachProbe(wire.getStableId(), ""),
+				new RemoveProbe(wire.getStableId()),
+				new RotateElement(constant.getStableId(), true),
+				new FlipElement(constant.getStableId()),
+				new MoveElements(List.of(), 8, 8),
+				new MoveElements(List.of(pin.getStableId(),
+						pin.getStableId()), 8, 8),
+				new MoveElements(List.of(pin.getStableId(), unknown),
+						8, 8),
+				new MoveElements(List.of(pin.getStableId()),
+						-100_000, 0),
+		};
+		for (CircuitOp op : invalid) {
+			assertThrows(OpRejected.class,
+					() -> op.apply(circuit, graphics()));
+			assertEquals(before, save(circuit),
+					"a rejected op must not change the circuit");
+		}
+	}
+
+} // end of CircuitOpTest class

--- a/test/jls/collab/op/package-info.java
+++ b/test/jls/collab/op/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Test suite for {@code jls.collab.op}, the operation layer of the
+ * collaborative-editing program (issue #167). Pins the vocabulary's
+ * whole contract against the canonical-serialization oracle (issue
+ * #166): op-vs-inline byte parity, apply-then-inverse restoring the
+ * exact prior bytes on freshly loaded and save/load-restored circuits
+ * alike, save/read/save byte-identical serialization round-trips with
+ * strict rejection of malformed and oversized input, and atomicity -
+ * a rejected op leaves the circuit byte-identical, including when
+ * validation fails partway through a multi-element op. Fixtures are
+ * the wire-heavy fork shift-register file (shared with the
+ * determinism suite) and a minimal unwired-element circuit for the
+ * rotate/flip ops, whose validity requires detached puts.
+ */
+package jls.collab.op;

--- a/test/jls/ui/DialogCoverageRatchetTest.java
+++ b/test/jls/ui/DialogCoverageRatchetTest.java
@@ -1,0 +1,89 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+/**
+ * Completeness ratchet for the dialog-construction sweep (issue #162):
+ * every {@code ElementDialog} subclass in the compiled tree must be
+ * represented in {@link DialogConstructionSmokeTest} - directly, via a
+ * family representative, or through a documented exemption. A new
+ * element dialog that ships without sweep coverage fails here, in the
+ * headless run, before it can execute for the first time in front of a
+ * student.
+ *
+ * Headless by design: this test reads bytecode only (same importer as
+ * ArchitectureRulesTest) and never constructs a dialog.
+ */
+class DialogCoverageRatchetTest {
+
+	/**
+	 * Element classes the sweep constructs by name
+	 * ({@code constructAndCancel} calls). Keep in sync with
+	 * DialogConstructionSmokeTest - this list failing to match the
+	 * sweep is exactly the signal the ratchet exists to give.
+	 */
+	private static final Set<String> SWEPT = Set.of(
+			"Adder", "AndGate", "Binder", "Clock", "Constant", "Decoder",
+			"DelayGate", "Display", "Extend", "InputPin", "JumpEnd",
+			"JumpStart", "Memory", "Mux", "OutputPin", "Register",
+			"ShiftRegister", "SigGen", "Splitter", "StateMachine",
+			"SubCircuit", "Text", "TriState", "TruthTable");
+
+	/**
+	 * Dialog-owning classes covered through a subclass the sweep
+	 * constructs, or exempt for a stated structural reason. Shrink,
+	 * never grow, the exemptions.
+	 */
+	private static final Map<String, String> REPRESENTED = Map.of(
+			"Gate", "abstract; its dialog is swept via AndGate,"
+					+ " DelayGate, and Extend",
+			"Group", "abstract; its ranges dialog is swept via Binder"
+					+ " and Splitter",
+			"Pin", "abstract; its dialog is swept via InputPin and"
+					+ " OutputPin",
+			"Element", "DelayChange is an edit-time dialog on a placed"
+					+ " element, not a creation dialog; needs the"
+					+ " element-edit path - a known sweep gap, tracked"
+					+ " in #162",
+			"State", "constructed only inside StateMachine's"
+					+ " StateEditor, which the StateMachine sweep entry"
+					+ " opens");
+
+	@Test
+	void everyElementDialogIsSweptOrExempt() {
+		JavaClasses classes = new ClassFileImporter()
+				.importPath("target/classes");
+		Set<String> unrepresented = new TreeSet<String>();
+		for (JavaClass c : classes) {
+			if (!c.isAssignableTo("jls.elem.ElementDialog")
+					|| "jls.elem.ElementDialog".equals(c.getName())) {
+				continue;
+			}
+			// dialogs are inner classes; charge them to the top-level
+			// element that owns them
+			String owner = c.getName()
+					.replace("jls.elem.", "")
+					.replaceAll("[$.].*", "");
+			if (!SWEPT.contains(owner)
+					&& !REPRESENTED.containsKey(owner)) {
+				unrepresented.add(owner + " (" + c.getName() + ")");
+			}
+		}
+		assertTrue(unrepresented.isEmpty(),
+				"element dialogs with no construction coverage - add"
+						+ " them to DialogConstructionSmokeTest (and"
+						+ " this ratchet's SWEPT list) or document an"
+						+ " exemption: " + unrepresented);
+	}
+
+} // end of DialogCoverageRatchetTest class

--- a/test/jls/ui/KeyPadDismissalTest.java
+++ b/test/jls/ui/KeyPadDismissalTest.java
@@ -1,0 +1,166 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import jls.KeyPad;
+
+/**
+ * Pins the KeyPad's standard dismissal semantics (issue #86 H1, landed
+ * with the #103/#104 rebuild): Escape hides the keypad without
+ * touching the entered text (P1), focus loss hides it (the
+ * click-outside path - the listener is exercised at event level, since
+ * xvfb has no window manager to deliver real focus transitions), and
+ * the old hidden right-click-on-digit gesture is gone - no JLS mouse
+ * listener remains on the digit or reset buttons (P3).
+ *
+ * Same display tagging and headless discipline as
+ * {@link DialogConstructionSmokeTest}.
+ */
+@Tag("display")
+class KeyPadDismissalTest {
+
+	private JFrame owner;
+	private JTextField field;
+	private KeyPad pad;
+
+	@BeforeEach
+	void requireDisplay() throws Exception {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		SwingUtilities.invokeAndWait(() -> {
+			owner = new JFrame("keypad-test");
+			field = new JTextField(10);
+			pad = new KeyPad(field, 10, 0, owner);
+			owner.getContentPane().add(field);
+			owner.getContentPane().add(pad);
+			owner.pack();
+			owner.setVisible(true);
+		});
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			if (pad != null) {
+				pad.close();
+			}
+			if (owner != null) {
+				owner.dispose();
+			}
+		});
+	}
+
+	/** The keypad's popup window, reached through its private field. */
+	private JDialog padWindow() throws Exception {
+		Field win = KeyPad.class.getDeclaredField("win");
+		win.setAccessible(true);
+		return (JDialog) win.get(pad);
+	}
+
+	private void openPad() throws Exception {
+		SwingUtilities.invokeAndWait(() -> pad.doClick());
+	}
+
+	private boolean padVisible() throws Exception {
+		JDialog win = padWindow();
+		AtomicReference<Boolean> visible = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> visible.set(win.isVisible()));
+		return visible.get();
+	}
+
+	@Test
+	void escapeDismissesWithoutTouchingTheValue() throws Exception {
+		openPad();
+		assertTrue(padVisible(), "keypad should open on button click");
+		JDialog win = padWindow();
+
+		// enter a digit, then Escape
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : new Window[] { win }) {
+				assertNotNull(w);
+			}
+			// digit "3" is a child button labeled 3
+			clickDigit(win, "3");
+		});
+		assertEquals("3", field.getText(),
+				"digit buttons must keep filling the field");
+		SwingUtilities.invokeAndWait(() -> win.getRootPane()
+				.dispatchEvent(new KeyEvent(win.getRootPane(),
+						KeyEvent.KEY_PRESSED, System.currentTimeMillis(),
+						0, KeyEvent.VK_ESCAPE, KeyEvent.CHAR_UNDEFINED)));
+		assertFalse(padVisible(), "Escape must dismiss the keypad");
+		assertEquals("3", field.getText(),
+				"Escape must not change the entered text");
+	}
+
+	@Test
+	void focusLossDismisses() throws Exception {
+		openPad();
+		assertTrue(padVisible(), "keypad should open on button click");
+		JDialog win = padWindow();
+		SwingUtilities.invokeAndWait(() -> win.dispatchEvent(
+				new WindowEvent(win, WindowEvent.WINDOW_LOST_FOCUS)));
+		assertFalse(padVisible(),
+				"losing focus (clicking outside) must dismiss the keypad");
+	}
+
+	@Test
+	void noHiddenRightClickDismissalRemains() throws Exception {
+		// P3: the undiscoverable right-click-on-digit exit is gone -
+		// no JLS-defined mouse listener on any keypad button (only
+		// Swing's own plaf listeners remain)
+		JDialog win = padWindow();
+		SwingUtilities.invokeAndWait(() -> {
+			for (java.awt.Component c : win.getContentPane()
+					.getComponents()) {
+				if (!(c instanceof JButton)) {
+					continue;
+				}
+				for (MouseListener l : ((JButton) c)
+						.getMouseListeners()) {
+					assertFalse(l.getClass().getName()
+							.startsWith("jls."),
+							"keypad button still carries a JLS mouse"
+									+ " listener: " + l.getClass());
+				}
+			}
+		});
+	}
+
+	/** Click the digit button with the given label inside the window. */
+	private static void clickDigit(JDialog win, String label) {
+		for (java.awt.Component c : win.getContentPane()
+				.getComponents()) {
+			if (c instanceof JButton
+					&& label.equals(((JButton) c).getText())) {
+				((JButton) c).doClick();
+				return;
+			}
+		}
+		throw new AssertionError("no digit button labeled " + label);
+	}
+
+} // end of KeyPadDismissalTest class

--- a/test/jls/ui/package-info.java
+++ b/test/jls/ui/package-info.java
@@ -10,13 +10,19 @@
  * flag). See {@link jls.ui.CircuitAssert} and {@link jls.ui.GeometryAssert}.
  * No display, no Graphics, no Swing; safe on any CI runner.</li>
  *
- * <li><b>Layer 2 (future):</b> Swing-harness assertions -- menus, focus,
- * event dispatch, synthesized mouse/keyboard interaction driving the real
- * listener chain, run under Xvfb on CI. Candidates: AssertJ-Swing, with a
- * {@code java.awt.Robot} + {@code SwingUtilities.invokeAndWait} fallback.
- * New helpers for that layer belong in this package (e.g.
- * {@code EditorHarness}, {@code MenuAssert}) and must not be required by
- * Layer-1 tests.</li>
+ * <li><b>Layer 2 (present, growing):</b> Swing-harness assertions -- menus,
+ * focus, event dispatch, synthesized mouse/keyboard interaction driving the
+ * real listener chain. Substrate decision (issue #162, recorded per the
+ * 2026-07 library survey): a real display server via {@code xvfb-run} on
+ * CI ({@code -Djls.test.headless=false}, the {@code display}-tagged
+ * surefire execution), driven by plain JUnit with
+ * {@code SwingUtilities.invokeAndWait} and synthesized {@code AWTEvent}s
+ * ({@code java.awt.Robot} where true OS-level input is needed).
+ * AssertJ-Swing was rejected (unmaintained fork chain); Cacio-tta was
+ * rejected (JDK-internals coupling). See
+ * {@code DialogConstructionSmokeTest}, {@code EditorGestureTest},
+ * {@code KeyPadDismissalTest}; new helpers for this layer belong in this
+ * package and must not be required by Layer-1 tests.</li>
  *
  * <li><b>Layer 3 (future):</b> rendering assertions -- paint to a
  * BufferedImage without a window and make semantic checks (element paints


### PR DESCRIPTION
The last of the three Windows test failures — the orientation-geometry
baseline diverging — was never geometry: on an autocrlf checkout git
rewrites test/resources/ goldens to CRLF while the tests compare
against \n-joined strings built in memory. Extend the .gitattributes
byte-exactness protection from *.jls fixtures to all of
test/resources/** (geometry baseline, 39 HDL export goldens).

The TriState finishLoadError lines called out in the same report are
deliberate rejections of collinear gate/control orientation pairs,
recorded as such in the baseline.

Add an advisory windows-latest CI lane running mvn verify (JaCoCo
ratchet skipped: its floors are calibrated on the fuller Linux run)
so Windows regressions of this family surface on every build; same
stabilize-then-require promotion rule as the gui-wayland lane.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LUmBPJezviboHJQ6NzMtbY