### PR TITLE
Doclint gate made binding and tightened to private: -Werror, @jls.testedby tag, full javadoc debt retired (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,19 +110,32 @@ All notable changes to JLS are documented here. The format follows
 
 ### Added
 - Documentation is now build-enforced: `mvn verify` runs a javadoc
-  doclint gate (all groups except unresolvable-by-design test
-  references) over the public/protected API with warnings as
+  doclint gate over the public/protected API with warnings as
   failures, and a new package-info ratchet requires every package in
-  both trees to carry a package comment. The gate is scoped to API
-  visibility because under `-private` the standard doclet warns on
-  every test-tree `@see` target in a way doclint exclusions cannot
-  reach (verified empirically; recorded in the pom comment).
+  both trees to carry a package comment.
   Fixed en route: eleven malformed doc comments the #186 pass left
   behind - duplicated `@param v1` tags in five files, three stale
   javadoc blocks orphaned above attribute tables by the #23
   refactor, a mistyped `@returns`, two empty comments, and a VCD
   format description whose angle-bracket placeholders parsed as
   unclosed HTML.
+- The doclint gate is now actually binding (#192): as shipped it was
+  disarmed from birth — maven-javadoc-plugin's `failOnWarnings`
+  detects warnings by regex-matching javadoc's last output line
+  against `\d+ warnings?`, and javadoc 25 digit-groups the summary
+  ("1,509 warnings" at the gate's introduction), so any count of
+  1,000 or more passed silently. The gate now passes javadoc's own
+  `-Werror`, which fails on the tool's exit code and cannot be
+  defeated by output formatting. The 878 generated test-attribution
+  `@see` tags became a registered custom block tag (`@jls.testedby`,
+  rendered "Tested by:"), removing the 1,130 unresolvable-reference
+  warnings that had crossed the digit-grouping cliff — so doclint's
+  `reference` group is enforced again, and real broken `@see`/`@link`
+  references fail the build. The 292 genuine protected-scope warnings
+  the disarmed gate had accumulated (missing member comments, missing
+  `@param`/`@return`/`@throws`, undocumented default constructors)
+  are all retired; the gate is verified green and verified to fail on
+  a single reintroduced warning.
 - Per-package coverage floors (#159): the JaCoCo ratchet now guards
   `jls`, `jls.sim`, `jls.elem`, and the new `jls.collab.op` package
   individually (instruction, line, and branch), so a regression in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,17 @@ All notable changes to JLS are documented here. The format follows
   the disarmed gate had accumulated (missing member comments, missing
   `@param`/`@return`/`@throws`, undocumented default constructors)
   are all retired; the gate is verified green and verified to fail on
-  a single reintroduced warning.
+  a single reintroduced warning. With that in hand the gate is
+  tightened from protected to private visibility (#192's endgame):
+  the remaining 684 private/package-private-scope warnings are
+  retired, so every declaration in the main tree down to private
+  members now carries well-formed Javadoc, enforced on every build.
+  A third silent-disarm vector found and closed en route: the
+  plugin's stale-data up-to-date check compares only the javadoc
+  argument list (never source contents), so with unchanged options a
+  rerun after a source edit skipped generation and reported vacuous
+  success; a per-build nonce in the -bottom text now forces a real
+  javadoc run every time.
 - Per-package coverage floors (#159): the JaCoCo ratchet now guards
   `jls`, `jls.sim`, `jls.elem`, and the new `jls.collab.op` package
   individually (instruction, line, and branch), so a regression in

--- a/ISSUE-PROGRESS-2026-07-19.md
+++ b/ISSUE-PROGRESS-2026-07-19.md
@@ -1,0 +1,393 @@
+# Open-Issue Progress Pass — 2026-07-19
+
+Automated assess → adversarial-review → update pass over all 42 open issues, run
+against master HEAD `2eb3e0c` (post-#194 merge). Each issue was assessed by one
+agent (issue thread + codebase evidence), independently challenged by an adversarial
+reviewer that re-verified every claim against the tree and the thread, and only
+review-approved actions were executed on GitHub.
+
+**Outcome:** 22 issues received a verified status comment, 1 closed as completed (#79), 19 left untouched (thread already accurate), 0 failures.
+
+| Issue | Reviewer verdict | Action | Result |
+|---|---|---|---|
+| #192 | approve | comment | [comment](https://github.com/anadon/JLS/issues/192#issuecomment-5016281638) |
+| #191 | revise | comment | [comment](https://github.com/anadon/JLS/issues/191#issuecomment-5016279634) |
+| #190 | approve | no-action | no change |
+| #189 | revise | comment | [comment](https://github.com/anadon/JLS/issues/189#issuecomment-5016279576) |
+| #188 | revise | comment | [comment](https://github.com/anadon/JLS/issues/188#issuecomment-5016280548) |
+| #185 | approve | comment | [comment](https://github.com/anadon/JLS/issues/185#issuecomment-5016280509) |
+| #184 | revise | comment | [comment](https://github.com/anadon/JLS/issues/184#issuecomment-5016281302) |
+| #171 | approve | no-action | no change |
+| #170 | revise | comment | [comment](https://github.com/anadon/JLS/issues/170#issuecomment-5016282256) |
+| #169 | approve | no-action | no change |
+| #168 | approve | no-action | no change |
+| #167 | revise | comment | [comment](https://github.com/anadon/JLS/issues/167#issuecomment-5016282705) |
+| #163 | revise | comment | [comment](https://github.com/anadon/JLS/issues/163#issuecomment-5016283022) |
+| #162 | revise | comment | [comment](https://github.com/anadon/JLS/issues/162#issuecomment-5016283939) |
+| #161 | approve | no-action | no change |
+| #159 | revise | comment | [comment](https://github.com/anadon/JLS/issues/159#issuecomment-5016284081) |
+| #153 | approve | no-action | no change |
+| #136 | revise | comment | [comment](https://github.com/anadon/JLS/issues/136#issuecomment-5016284942) |
+| #134 | revise | comment | [comment](https://github.com/anadon/JLS/issues/134#issuecomment-5016285130) |
+| #101 | revise | comment | [comment](https://github.com/anadon/JLS/issues/101#issuecomment-5016286035) |
+| #100 | approve | no-action | no change |
+| #96 | approve | no-action | no change |
+| #95 | revise | comment | [comment](https://github.com/anadon/JLS/issues/95#issuecomment-5016286156) |
+| #94 | approve | no-action | no change |
+| #93 | revise | comment | [comment](https://github.com/anadon/JLS/issues/93#issuecomment-5016286955) |
+| #91 | approve | no-action | no change |
+| #86 | approve | no-action | no change |
+| #84 | revise | comment | [comment](https://github.com/anadon/JLS/issues/84#issuecomment-5016287844) |
+| #82 | approve | no-action | no change |
+| #79 | approve | close-completed | closed as completed — [comment](https://github.com/anadon/JLS/issues/79#issuecomment-5016287021) |
+| #78 | approve | no-action | no change |
+| #77 | approve | no-action | no change |
+| #76 | approve | no-action | no change |
+| #75 | approve | no-action | no change |
+| #74 | approve | comment | [comment](https://github.com/anadon/JLS/issues/74#issuecomment-5016288153) |
+| #73 | approve | comment | [comment](https://github.com/anadon/JLS/issues/73#issuecomment-5016288727) |
+| #63 | approve | comment | [comment](https://github.com/anadon/JLS/issues/63#issuecomment-5016289001) |
+| #62 | approve | comment | [comment](https://github.com/anadon/JLS/issues/62#issuecomment-5016289673) |
+| #61 | approve | comment | [comment](https://github.com/anadon/JLS/issues/61#issuecomment-5016290067) |
+| #59 | approve | no-action | no change |
+| #56 | approve | no-action | no change |
+| #33 | approve | no-action | no change |
+
+## Per-issue findings
+
+### #192
+
+The issue's endgame items (private-member doc pass completion, @see decision, gate flip to private) remain open, and the two prior comments accurately describe the slice work (jls.sim, jls.edit clean). However, investigation at master HEAD 2eb3e0c uncovered material new facts the thread does not know: (1) the doclint gate is currently not binding at all — maven-javadoc-plugin 3.12.0's failOnWarnings detects warnings by matching the last stderr line against the regex `\d+ warnings?`, and javadoc 25 prints the summary with digit grouping ("1,422 warnings"), so any count >= 1,000 silently passes; (2) the generated test-tree @see tags produce 1,130 doclet "reference not found" warnings at the gate's default protected visibility (not only under -private as the pom scope note and issue premise claim), which is what pushed the count over the 1,000 cliff; (3) protected level is not clean — 292 …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/192#issuecomment-5016281638
+
+### #191
+
+The issue asks for a measured (double-build) determination of dmg non-determinism, feasible normalization, and either a CI gate or a documented bounded residual. At master 2eb3e0c the groundwork is fully landed: docs/dmg-reproducibility.md (variance inventory E1/F1-F7, Route A/B normalization plan), scripts/measure-dmg-repro.sh (turnkey macOS double-build attribution harness), #188's shared SOURCE_DATE_EPOCH derivation + staged-tree mtime clamp in scripts/build-installer.sh, and a report-only CI probe (.github/workflows/repro-installers.yml) with a macos-latest dmg double-build + diffoscope leg. Not done: no P1/P2 measurement has actually been run or recorded, no normalization implemented, no CI gate, and docs/reproducibility.md §5 still (correctly) lists installers as not reproducible. Material change since the newest comment (2026-07-18T22:07Z): that comment placed the work on branch …
+
+Adversarial review corrections:
+- Draft comment (and claim 3) asserted a 'git commit-time fallback' in the SOURCE_DATE_EPOCH derivation chain; scripts/build-installer.sh lines 100-104 actually hard-error (exit 1) when the pom's project.build.outputTimestamp is missing — the only git-commit-time fallback is the now-dead msi-lane default at line 436. Corrected in the final comment.
+- Claim 8's evidence overstated: 'only JLS_SKIP_BUILD and JLS_SKIP_MSI_NORMALIZE exist as env switches' — APPIMAGETOOL, JLS_JBR_HOME, JLS_SIGN_KEY, and SOURCE_DATE_EPOCH are also env switches; the substantive point (no clamp opt-out) is correct. Internal claim only, not in posted text.
+- The P1-baseline sentence implied the probe workflow could simply be run 'at a pre-#194 commit', but repro-installers.yml itself only landed in PR #194, so a dispatch cannot target a pre-#194 tree directly; a local Mac run of scripts/measure-dmg-repro.sh at an older commit or a throwaway branch is needed. Clarified.
+- Cosmetic: claim 3 cites build-installer.sh lines 91-131 for the derivation; the code block actually spans ~96-131 (the section comment starts at 87).
+- Everything else verified: merge topology (aebeaa7/b23123a inside PR #194 branch, not on pre-merge master 957ad48), empty git log 34d92bf..2eb3e0c over the five dmg-relevant paths, all cited workflow/script/doc line references and line counts, the stale status block, the absence of any recorded measurement, and that the thread's single comment never mentions the macOS CI leg — so the comment adds …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/191#issuecomment-5016279634
+
+### #190
+
+The issue asks for a measured determinism story for the jpackage/WiX msi: enumerate the volatile bytes, normalize what is normalizable, then either a Windows double-build CI gate (byte-identical) or an honestly documented bounded residual. The current tree (HEAD 2eb3e0c) already contains the Linux-side apparatus: /home/user/JLS/scripts/normalize-msi.py (in-place, same-length rewrites of package code GUID, SummaryInformation FILETIMEs, CFB directory timestamps, CAB member times; --self-test; leaves ProductCode/UpgradeCode alone), integration into the Windows lane of /home/user/JLS/scripts/build-installer.sh (lines ~419-440, self-test before touching the real msi, JLS_SKIP_MSI_NORMALIZE=1 escape hatch), the volatile-set documentation in /home/user/JLS/docs/windows-msi-determinism.md (explicitly making no reproducibility claim per #188 §10), and a report-only double-build probe workflow …
+
+**Action:** no-action
+
+### #189
+
+The implementation described in the newest comment (2026-07-18T22:07Z) is fully merged to master at 2eb3e0c via PR #194 (commit 34d92bf is an ancestor of HEAD): scripts/build-installer.sh exports SOURCE_DATE_EPOCH (lines 96-117), clamps mtimes of input/, runtime/, and the AppDir (clamp_mtimes at lines 121-130, applied at 169, 242, 364), and builds the rpm under a staged .rpmmacros pinning %_buildhost/%use_source_date_epoch_as_buildtime/%clamp_mtime_to_source_date_epoch (lines 372-378). The CI gate exists as the installer-reproducibility job in .github/workflows/ci.yml (lines 342-388): double build, sha256 diff, diffoscope on mismatch, rpm installed so the rpm leg always runs. What changed since the newest comment: that comment named "gate green in CI (x86_64 and aarch64 legs)" as the remaining item and said the AppImage leg was never exercised (appimagetool download blocked in the …
+
+Adversarial review corrections:
+- Overclaim: the draft comment called the master runs "the first empirical confirmation of H1", but the gate job has no event condition and also ran green on the PR #194 branch runs 29664716829 (2026-07-18T23:12Z) and 29664959586 (23:20Z) before the master push run completed at 23:32Z; the master runs are therefore not literally the first green gate executions (all were still after the newest …
+- Minor evidence imprecision in the internal claims (not in the comment text): clamp_mtimes is defined at build-installer.sh lines 129-131 (CLAMP_STAMP at 121-122), not "121-130"; harmless since the posted comment cites only line 242, which is correct.
+- All other factual claims reproduced from primary evidence: ancestry of 34d92bf, script line numbers, rpm macros, ci.yml gate at 342-388 with rpm installed, both green master runs at 2eb3e0c (including verifying the scheduled run actually executed the gate job — it did, job 88165793540, unlike the other jobs which skip on schedule), repro-installers.yml zero runs with arm leg at line 44 and cron …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/189#issuecomment-5016279576
+
+### #188
+
+The issue's shared plumbing (§7 items 1-3) is fully merged to master (2eb3e0c via PR #194): scripts/build-installer.sh derives SOURCE_DATE_EPOCH from the pom's project.build.outputTimestamp and clamps all staged mtimes; .github/workflows/repro-installers.yml is the report-only 5-leg diffoscope probe; ci.yml has a hard Linux installer double-build gate. Since the newest comment (2026-07-18 22:07 UTC, written against branch tip 34d92bf): (1) PR #194 merged to master at 23:28 UTC, and (2) CI run 29676892246 on master (2026-07-19 06:43 UTC) ran the 'Linux installer reproducibility' job green — proving deb, rpm, AND AppImage byte-identical across two builds on ubuntu-latest, whereas the comment had only sandbox evidence for deb, an unverified rpm gate, and no AppImage measurement at all (appimagetool was proxy-blocked in its sandbox). This confirms H1 for all three Linux formats and P1 for …
+
+Adversarial review corrections:
+- Claim 1 misstates PR #194's tip: the merge commit 2eb3e0c's second parent is 9114898, not 34d92bf — three commits (1e7d26a CHANGELOG, e807068 CI/CodeQL fixes, 9114898 AEAD swap) landed on the branch after 34d92bf and before merge. The issue comment was written at tip 34d92bf, but 'tip 34d92bf merged' is wrong. (The draft comment text itself never cites 34d92bf, so this was latent, not public.)
+- The draft comment's '#189 looks ready to close against its own criteria' overclaims: #189 §10 explicitly asserts reproducibility per arch on its own leg, and the aarch64 leg has never been measured — the hard gate runs only on ubuntu-latest x86_64 and the repro-installers.yml probe (which carries the ubuntu-24.04-arm leg) has zero runs. #189's P3 (contents unchanged) also has no recorded …
+- Misquote: docs/reproducibility.md's §1 table cell reads '**No** — see §5', not '**No** — not reproducible'; the 'not reproducible' wording is §5 prose. Adjusted so quoted text matches the file.
+- Line-citation drift: the staged .rpmmacros block is build-installer.sh lines 372-377 (macro at 376), not 370-376. Corrected.
+- Verified (not problems, for the record): run 29676892246 job 88165793540 logs show identical sha256 for deb, rpm, AND AppImage across both builds on master 2eb3e0c; repro-installers.yml has total_count 0 runs; sub_issues_summary is 0/3; the comment adds genuinely new information over the 2026-07-18T22:07Z comment (which had only sandbox deb evidence, an unverified rpm gate, and no AppImage …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/188#issuecomment-5016280548
+
+### #185
+
+The work described in the issue landed on master: PR #194 merged branch claude/advance-github-issues-hjrpyq, making HEAD 2eb3e0c. The tree now contains (a) the upgraded reproducibility gate in .github/workflows/ci.yml (job "reproducibility", lines ~267-341): same-runner double-build pre-filter plus an independent perturbed rebuild (different workspace path, TZ=Pacific/Kiritimati, LC_ALL=C, umask 077) that requires jar AND bom.json to match byte-for-byte and uploads diverged jars for diffoscope; (b) release.yml runs maven-artifact-plugin:3.6.0:buildinfo in the same Maven session, adds the .buildinfo to SHA256SUMS, and uploads it as a release asset; (c) docs/reproducibility.md declares the reproducible set (jar, BOM), the per-release toolchain-record policy (exact JDK/Maven pinned in each release's .buildinfo), third-party verification recipes, and the #184/#189 boundary for …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/185#issuecomment-5016280509
+
+### #184
+
+All three findings are implemented in the current tree at 2eb3e0c: (C) the CI reproducibility job builds and diffs bom.json alongside the jar, including a same-runner rebuild and an independent perturbed rebuild (.github/workflows/ci.yml lines 283-342); (B) resources/packaging/Dockerfile pins apt installs to snapshot.ubuntu.com at APT_SNAPSHOT=20260716T000000Z (lines 33-63) and scripts/build-container.sh exports SOURCE_DATE_EPOCH as a build-arg plus rewrite-timestamp=true on the buildx push path (lines 46-51, 82); (A) scripts/build-installer.sh derives and exports SOURCE_DATE_EPOCH from the pom's outputTimestamp with caller override (lines 96-117), and README.md frames installer integrity as attestation-backed, not byte-reproducible (lines 51-60). Since the newest comment (2026-07-18T22:07:54Z, which said the issue stays open pending P2 container validation and CI-green confirmation), …
+
+Adversarial review corrections:
+- Refuted: the claim that both reproducibility jobs succeeded twice. On scheduled run 29676892246 the 'Reproducible build check' job (88165793798) was SKIPPED, not successful — ci.yml line 285 gates it with `if: github.event_name != 'schedule'`. Only 'Linux installer reproducibility' ran and passed on the scheduled run; the jar/BOM job passed once, on push run 29665293624. The draft comment's …
+- Overstatement: 'validation lands with the next release's container-image job' — the container-image job also builds (without pushing) on workflow_dispatch dry runs of release.yml, and a single release build exercises the pin but does not itself demonstrate P2, which as written requires comparing layer digests across two builds.
+- Trivial imprecision: the installer-reproducibility job spans ci.yml lines 349-388, not 349-386 (evidence citation only; not in the comment text).
+- All other claims verified against the repo tree at 2eb3e0c, the full issue thread (1 comment), GitHub Actions runs/jobs, release history, and commit 7edd009.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/184#issuecomment-5016281302
+
+### #171
+
+The issue asks for full Stage 2 simultaneous editing: per-kind CRDT merge rules, anti-entropy resync, log compaction/snapshots, OpSink gossip integration (token retirement), collaborative undo with an ARCHITECTURE.md decision entry, and the P1-P4 convergence suite against the #166 oracle. The current tree (master, 2eb3e0c) contains only the replication substrate groundwork: src/jls/collab/crdt/ with VectorClock, OpId, OpEnvelope, CausalBuffer plus 22 tests in test/jls/collab/crdt/ — exactly what the single existing comment (2026-07-18, the newest) already reports. Since that comment, the only changes were: PR #194 (the branch the comment cites) merging into master, a CI test-table fix (e807068), and an AEAD swap from ChaCha20-Poly1305 to AES-256-GCM in src/jls/collab/net/ (9114898) — the latter belongs to the #168/#170 transport/hardening scope, not this issue's crdt work; …
+
+**Action:** no-action
+
+### #170
+
+The single existing comment (2026-07-18 22:08Z) describes #170's H1/P1/P3/P4 groundwork as "integrated on branch claude/advance-github-issues-hjrpyq, tip 34d92bf". That branch has since merged to master via PR #194 (merge commit 2eb3e0c, 2026-07-18 23:28Z — after the comment), so everything the comment describes is now on master: ElementVocabulary allowlist + TestGen witness test, CollabSecurityRatchetTest/SocketConfinementRatchetTest/ArchitectureRulesTest ratchets, docs/collab-vocabulary.md, SECURITY.md threat entries, and ElementBlocks routing through requireAllowed + the #78 registry. Three post-comment commits landed on the PR (CHANGELOG, CodeQL/CI fixes, ChaCha20→AES-256-GCM AEAD swap) — all #168 transport scope, none touching #170 surface. Additionally, several H2 bounds already exist on master (SecureLink 1 MiB frame cap, CausalBuffer 10,000-op backlog cap, …
+
+Adversarial review corrections:
+- Draft comment claims all three post-comment commits (1e7d26a, e807068, 9114898) 'are #168 transport scope' — only 9114898 (AEAD swap) is; e807068 touches src/jls/hdl/scan/* and test/jls/ui/MenuBarSpecTest.java, and 1e7d26a is CHANGELOG-only. The substantive claim (none touch #170 surface) is correct, but the scoping label is wrong.
+- Draft comment lists 'boundary-value tests for the cap set' as still open — refuted: SecureLinkTest exercises at-cap and over-cap frames (MAX_PAYLOAD_BYTES and MAX_PAYLOAD_BYTES+1, lines 70/177/180), CausalBufferTest.pendingOverflowIsRefused fills the buffer to exactly 10,000 and asserts refusal of the next envelope, and CircuitOpTest pins the MAX_IDS '>=' boundary (~line 415). Posting this …
+- Minor evidence drift in the internal claims (not in posted text): SecureLink cap enforcement is at lines 150 and 194-197, not 190-197; the misbehavior grep under src/jls/collab also hits a CausalBuffer javadoc reference to a future misbehavior policy, not solely VectorClock 'counter' semantics. Claim substance (no implementation exists) still holds.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/170#issuecomment-5016282256
+
+### #169
+
+The issue asks for a full shared-session v1: replicated roster lifecycle, heartbeat reachability, snapshot broadcast via markChanged, token-gated write path, presence overlays, peer panel, any-member forwarding, chaos-tested loopback schedules, and a manual three-machine session. The tree at HEAD 2eb3e0c has the transport-free session-state core: /home/user/JLS/src/jls/collab/session/ (Roster, SessionEntry, EntryKind with ADMIT/LEAVE/EJECT/TOKEN_GRANT/TOKEN_CLAIM, PeerId, ReachabilityTracker) with tests RosterTest, RosterConvergenceTest (1000 seeded schedules, SCHEDULES=1000), and ReachabilityTrackerTest under /home/user/JLS/test/jls/collab/session/. Not yet implemented: snapshot broadcast wiring in SimpleEditor.markChanged (only comment references to the future collab layer), token gating in OpSink, presence, peer panel, transport binding, and the manual session. Since the newest …
+
+**Action:** no-action
+
+### #168
+
+Stage 1a's headless core is on master at 2eb3e0c (merge of PR #194): jls.collab.net contains IdentityKey, Handshake, Crypto (AES-256-GCM per the correction comment), Sas (7 glyphs from a 64-word table), SecureLink, KnownPeers, plus HandshakeRejected/FrameRejected; tests exist for each (test/jls/collab/net/), the socket-confinement ratchet (test/jls/SocketConfinementRatchetTest.java) is in place, and SECURITY.md has the "Collaboration transport (issue #168, Stage 1a)" section. Still missing, exactly as the newest comment's remaining-work list states: no socket/listener code (grep for Socket under src/jls/collab hits only package-info.java prose), no jls.collab.ui join/verify/key-change dialogs, no bundled glyph images, no two-machine LAN record, no §13 second-reader handshake review. The only change since the newest comment (2026-07-18 23:17 UTC) is the merge of that same branch to …
+
+**Action:** no-action
+
+### #167
+
+The issue asks for a closed CircuitOp vocabulary behind one OpSink entry point, migrated gesture-by-gesture. Master (2eb3e0c) now has: the sealed CircuitOp/OpSink/OpRejected/CircuitOpReader core plus 8 op kinds (ToggleWatched, AttachProbe/RemoveProbe, RotateElement, FlipElement, MoveElements, AddElements, RemoveElements) with ElementBlocks/ElementVocabulary transplant machinery in src/jls/collab/op/; six gestures migrated through submitOp in SimpleEditor; 21 tests in test/jls/collab/op/CircuitOpTest.java covering P1 parity, P2 inverse-restores-bytes, P3 round-trips and hostile rejections; and the in-tree inventory docs/operation-layer.md. Still open: wiring vocabulary (AddWire/RemoveWire), preview-then-commit migration of move/placement/paste/delete gestures (their ops exist but gestures mutate inline), SetAttributes for dialog commits, EditOrderedRows, ImportSubcircuit. Material change …
+
+Adversarial review corrections:
+- Draft claims 'two commits between branch tip 34d92bf and the merge'; git log --graph 34d92bf..2eb3e0c shows three branch-side commits: 1e7d26a (CHANGELOG record), e807068 (CI/CodeQL fixes), 9114898 (AEAD swap). The empty diff over the op-layer paths still covers all three, so the conclusion survives but the count had to be corrected.
+- Draft comment presents 'EditOrderedRows and ImportSubcircuit' as item (4) of docs/operation-layer.md's 'What lands next' order; the doc's actual item 4 is the deferral of precise (op-inverse) undo to Stage 2, and EditOrderedRows/ImportSubcircuit appear only as deferred rows in the mutation-site inventory table. Corrected the attribution.
+- Minor: the claim '15 source files ... (+ package-info.java)' describes 16 files in src/jls/collab/op/; the enumeration itself is complete so this is wording only, and the test package also contains ElementVocabularyTest.java beyond the cited CircuitOpTest.java (the comment's '21 tests in CircuitOpTest' is accurate as written). Neither required a change to the comment text.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/167#issuecomment-5016282705
+
+### #163
+
+The newest comment (2026-07-18 22:08) described the multi-agent session's work as sitting on branch claude/advance-github-issues-hjrpyq at tip 34d92bf, pending merge. Since then, PR #194 merged that branch to master (HEAD 2eb3e0c), carrying two post-comment commits: e807068 (CI + CodeQL fixes) and 9114898 (AEAD cipher changed from ChaCha20-Poly1305 to AES-256-GCM by owner decision, frame format unchanged). Master now contains all four collab packages (jls.collab.net/session/op/crdt, 36 source files), their test suites, the ArchUnit layering rules, docs/operation-layer.md, and SECURITY.md collab entries. Sub-issues #165/#166 are closed-completed; #167–#171 remain open with substantial work (full op vocabulary, transport wiring, session UI, CRDT replication). The tracking issue is nowhere near complete, so no close; but the thread's newest comment is now stale on merge status and records …
+
+Adversarial review corrections:
+- Draft says 'two post-comment commits' but three commits post-date the 22:08 UTC comment: the changelog commit 1e7d26a (22:13 UTC) also landed after it, alongside e807068 and 9114898. Corrected the comment wording to 'two substantive changes' so it no longer implies only two commits landed.
+- The internal notes claim the newest comment 'records the wrong AEAD cipher' — overstated: that comment says only 'AEAD framing' and never names ChaCha20-Poly1305; the pre-swap cipher was recorded in repo docs at 34d92bf, not in the thread. The posted text itself makes no such misattribution, so no substantive change was needed there.
+- All other claims reproduced from evidence: merge of PR #194 at 2eb3e0c (23:28 UTC > comment's 22:08 UTC); commit 9114898's message confirms the CodeQL-allowlist rationale, owner decision, and unchanged 32-byte key / 12-byte counter-nonce / 16-byte tag frame shape; Crypto.java lines 23/85/120 and SECURITY.md reference AES-256-GCM with no residual ChaCha mentions; 36 .java files across the four …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/163#issuecomment-5016283022
+
+### #162
+
+Every item on the issue's §7 method checklist is now on master (HEAD 2eb3e0c = merge of PR #194): xvfb substrate decision wired in pom.xml (display-tests surefire execution gated on jls.test.headless, main execution stays headless and excludes the display group) and ci.yml (best-effort xvfb install, xvfb-run wrapper); package-info.java layer-2 edit recording the survey rejections; DialogConstructionSmokeTest (24 dialog families) plus DialogCoverageRatchetTest (bytecode completeness ratchet over all ElementDialog subclasses with two documented exemptions); EdtViolationDetector/EdtViolationDetectorTest (P2); InteractiveSimulatorSmokeTest (P3, @Tag("display")); RenderAssert/RenderBoundsTest (layer-3 starter). Material changes since the newest comment (2026-07-18 22:12Z, which described branch tip 34d92bf): PR #194 merged to master at 23:28Z, including post-comment commit e807068 that fixed …
+
+Adversarial review corrections:
+- Opening sentence implies all thread-described work was branch-only until PR #194 merged; in fact the substrate/sweep/ratchet work from the first two comments had already merged to master via PRs #176 (2026-07-17) and #193 (2026-07-18 15:17Z) — only the newest comment's batch (34d92bf plus fix e807068) arrived via #194.
+- Claim 'every §7 checklist item is on master' overstates: the first §7 checkbox explicitly includes 'record stability over repeated runs (H2's criterion)', which is not done — only the decision/documentation half of that checkbox is met, as the draft's own remaining list concedes.
+- All other factual claims reproduced from the repo tree and issue thread: merge timing (2eb3e0c at 23:28Z vs newest comment 22:12Z), e807068 file list, ratchet structure (24 swept, 3 represented, 2 exemptions), 23 ElementDialog source files, pom.xml/ci.yml wiring, package-info contents, display tag placement — no refutations.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/162#issuecomment-5016283939
+
+### #161
+
+The issue gates PIT adoption on 50% line coverage; the gate was crossed 2026-07-17 (first comment) and the scoped trial was completed 2026-07-18 (second/newest comment). Everything that comment describes is present on master at 2eb3e0c via the PR #194 merge: the trial record docs/mutation-testing-trial-2026-07.md (with the ready-to-paste pitest pom profile), the Adopt verdict in the PIT row of docs/library-survey-2026-07.md (line 266), and the 13 new killing tests (test/jls/sim/SimEventContractTest.java, test/jls/BitSetUtilsSumCarryTest.java, additions to BitSetUtilsCreateTest.java and test/jls/collab/op/CircuitOpTest.java). Exactly as the comment states as "remaining for closure", pom.xml still has no pitest profile and no junit-platform-launcher test dependency (0 matches; only a comment at line ~306 referencing the gate), and no .github/workflows file mentions pitest/mutation. …
+
+**Action:** no-action
+
+### #159
+
+All structural items of §7 are complete on master at HEAD 2eb3e0c: the bundle rule has a BRANCH limit (pom.xml minimum 0.365 alongside INSTRUCTION 0.420 / LINE 0.400), per-package PACKAGE-element floors exist for jls (0.510/0.495/0.550), jls.sim (0.435/0.430/0.340), jls.elem (0.410/0.400/0.350), and jls.collab.op (0.880/0.890/0.700) with dot-form includes, and the climb convention is contributor-visible in CONTRIBUTING.md ("Coverage ratchet" section). What changed since the newest comment (2026-07-18 22:09 UTC): PR #194 merged to master (2eb3e0c, 23:28 UTC same day), carrying the described increment (TruthTable model extraction + TruthTableModelTest, CONTRIBUTING section) plus two post-comment commits (e807068 touching jls.hdl.scan and a UI test; 9114898 swapping the collab AEAD in jls.collab.net) — but the floor raise the comment prescribed for merge time was NOT applied: bundle floors …
+
+Adversarial review corrections:
+- Slack figure misstated: draft comment said floors sit 'about 2.5 points' below the last measurement, but actual slack at HEAD is 3.2/3.2/3.7 points for the bundle (45.20/43.24/40.18 measured vs 0.420/0.400/0.365 floors) and 4.1 points for jls.elem line (44.1 vs 0.400); the 2.5 figure conflated the suggested-raise delta with the measured slack — corrected to '3-4 points'.
+- Minor unflagged ambiguity: the pom ratchet comment ties the 50% PIT gate to the display-substrate number, while CONTRIBUTING.md and the two newest thread comments pin it to the headless figure; the draft follows the headless convention, which is the governing (newest, contributor-visible) one, so no change made.
+- All other claims reproduced from evidence: merge 2eb3e0c (PR #194, 23:28 UTC, after the 22:09 UTC comment, 34d92bf ancestor), pom floor values and line numbers, dot-form PACKAGE includes, jls.edit unfloored, CONTRIBUTING.md line 59 section content, TruthTableModelTest.java existence, e807068/9114898 file stats not touching floored packages or pom.xml, and comment 5013112790's numbers …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/159#issuecomment-5016284081
+
+### #153
+
+The evaluation the issue asks for is complete and merged to master (HEAD 2eb3e0c via PR #194, which merged branch claude/advance-github-issues-hjrpyq tip 34d92bf — the exact branch the newest comment cites). docs/flatlaf-evaluation-2026-07.md contains the full measured evaluation (jar size, zero transitive deps, JDK 25 headless install + runtime light/dark switching, comparables rejected, hardcoded-color audit) with verdict "recommend ADOPT, gated on the cross-OS screenshot matrix"; the -Djls.laf=metal|system|<class> seam is in src/jls/JLSStart.java (default still Metal, broken selection warns and falls back instead of exiting) and is pinned by test/jls/LookAndFeelPolicyTest.java. FlatLaf is NOT yet a dependency (no flatlaf entry in pom.xml). Remaining work is exactly what the comment listed: cross-OS visual QA (needs real Windows/macOS/Linux displays), the adopt decision, and the …
+
+**Action:** no-action
+
+### #136
+
+The issue asks for a key-custody decision, then GPG signing of the rpm (rpmsign) and AppImage (appimagetool --sign). All code scaffolding is now on master: PR #194 (merge commit 2eb3e0c, 2026-07-18 23:28 UTC) merged branch claude/advance-github-issues-hjrpyq, adding the release.yml "Import release signing key" and "Verify release signatures" steps, JLS_SIGN_KEY-gated rpmsign and appimagetool --sign in scripts/build-installer.sh, and README/CHANGELOG documentation. Everything is inert until the RELEASE_GPG_KEY/RELEASE_GPG_PASSPHRASE secrets and resources/packaging/RELEASE-KEY.asc exist — the key has not been generated (no RELEASE-KEY.asc in the tree; README still shows FINGERPRINT-PENDING). The newest existing comment (2026-07-18 22:09 UTC) predates the merge and described the work as sitting on the unmerged branch, so "the diff is now on master" is materially new. The blocking item is …
+
+Adversarial review corrections:
+- Draft comment asserted 'the RELEASE_GPG_KEY/RELEASE_GPG_PASSPHRASE secrets are unset' as verified fact; repository secrets cannot be read via the API and this was not (and cannot be) reproduced from evidence. Reworded to rest on what is verifiable: no RELEASE-KEY.asc committed and the README fingerprint still FINGERPRINT-PENDING, i.e. no key has been generated.
+- Partial duplication with the newest existing comment (2026-07-18 22:09 UTC), which already lists the same release.yml/build-installer.sh/README content and the same blocking decision; retained the comment because the merged-to-master fact (PR #194, merge 2eb3e0c, ~80 minutes after that comment) materially corrects the thread's stale 'integrated on branch, tip 34d92bf' state, but tightened the …
+- Minor attribution fix: the 'ordered before attestation/checksums' property holds because signing runs inside the Build-installer step and the attestation step (release.yml line 524) runs after — moved that clause so it is not attributed to build-installer.sh alone.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/136#issuecomment-5016284942
+
+### #134
+
+The CI side of the issue is fully implemented on master at HEAD 2eb3e0c: .github/workflows/release.yml contains secret-gated SignPath signing steps on both Windows legs (upload unsigned msi with retention-days:1, Sign msi via SignPath action SHA-pinned at v2.2, signed re-upload), placed before attestation/checksums (H2 ordering), a force-sign workflow_dispatch input, an actions:read job permission, and a strict two-msi verify-windows-signatures job using osslsigncode; README.md:29-37 replaces the "Run anyway" SmartScreen guidance with the SignPath Foundation publisher expectation. All steps skip cleanly until SIGNPATH_API_TOKEN/SIGNPATH_ORGANIZATION_ID secrets exist. What changed since the newest comment (2026-07-18T22:09:33Z, which located the work on branch claude/advance-github-issues-hjrpyq tip 34d92bf): PR #194 merged that branch to master at 2026-07-18T23:28:35Z (merge commit …
+
+Adversarial review corrections:
+- Factual error in the assessment's evidence: it asserts the latest release is v5.0.3, but the GitHub releases API shows v5.0.4 (published 2026-07-16T15:16:17Z) is the latest. v5.0.4 still predates the signing merge, so the substantive conclusion (no signed release exists, signing never executed) survives, but the stated fact is wrong and must not propagate into a posted comment.
+- Substantial duplication: about 80% of the draft comment restates implementation details already present in the newest issue comment (2026-07-18T22:09:33Z) — signing-step placement before attestation/checksums, force-sign input, retention-days: 1, actions: read grant, verify-windows-signatures job, README SignPath Foundation wording, skip-until-enrolled behavior, and a near-verbatim copy of that …
+- Minor line-number imprecision: 'Upload unsigned msi for signing (line ~483)' — the step name is at line 481 (483 is its if: guard); immaterial given the tilde, and the corrected comment cites no fragile line numbers.
+- All other claims verified against the repo tree, git history, PR #194 API data, and the full issue thread: merge timestamp 23:28:35Z postdates newest comment 22:09:33Z; c149533 is an ancestor of 2eb3e0c; CHANGELOG line 32 records the scaffolding; close-completed is correctly ruled out (issue §13 requires recorded P1/P2 on a signed release — secrets absent, no release tagged since the merge).
+
+**Action:** comment — https://github.com/anadon/JLS/issues/134#issuecomment-5016285130
+
+### #101
+
+The issue asks for a Wayland GUI CI rig (headless sway + JBR WLToolkit, screenshot, P1/P2 assertions, first-light report). Master at 2eb3e0c already contains the full rig: scripts/wayland-rig.sh (headless sway, HelloSwingControl control step with exit-code failure classification per section 9, window-presence assertion via swaymsg/jq, grim screenshots, pixel-diff with PIXEL_DIFF_MIN gate), scripts/HelloSwingControl.java, a gui-wayland job in .github/workflows/ci.yml (lines 155-245) with SHA-pinned actions, artifact upload, and a nightly cron (17 4 * * *) that runs only this lane, plus README documentation. What remains: the JBR_SHA256 pin in ci.yml:187 is still the fail-closed UNVERIFIED placeholder, so the lane skips at the download step and no first-light run/report exists yet; P3's 20-run record has not started. Material change since the newest comment (2026-07-18 22:09 UTC): that …
+
+Adversarial review corrections:
+- Refuted: the claim that the nightly cron 'runs only gui-wayland'. The installer-reproducibility job (.github/workflows/ci.yml line 349) has no `if: github.event_name != 'schedule'` gate and no `needs`, so it also runs on schedule events — contradicting the draft (claim 4 cites gates at lines 30/116/140/285 but misses the job at 349) and ci.yml's own header comment ('every other job skips on …
+- Stale framing: the draft comment predicts 'the very next push or nightly run' as future, but the first nightly had already fired before this review (run 29676892246, schedule event on 2eb3e0c, 2026-07-19 06:43 UTC) — gui-wayland ran, the download step emitted the placeholder ::notice and skipped, exactly as designed. The comment should cite this observed run rather than predict it.
+- Rendering bug in draft text: `&lt;JBR_URL&gt;` HTML entities inside a backtick code span are not decoded by GitHub Markdown and would display literally; must be real angle brackets.
+- Minor evidence imprecision (not in posted text): git log --follow shows scripts/wayland-rig.sh last modified in 90489ce (created in 83cd4d6, also touched by 7a06c2b), not 'last change in 83cd4d6'; README's Wayland section starts at line 162, not 165.
+- All other claims verified: merge 2eb3e0c at 2026-07-18 23:28:35 UTC postdates newest comment (22:09:36 UTC); rig files present (301/57 lines); ci.yml lines 12-13, 24, 166, 169, 187, 193, 214-218, 237, 239-245 all exact; e807068/9114898 touch no rig files; no ci.yml/scripts changes in 34d92bf..2eb3e0c; master is the default branch; JBR CDN 403 reproduced live on 2026-07-19.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/101#issuecomment-5016286035
+
+### #100
+
+Issue #100 is the Wayland-native GUI tracking issue. Sub-issues #102-#105 are closed (4/5 complete per sub_issues_summary); only #101 (CI rig first light) remains. At HEAD 2eb3e0c the code side is done exactly as the newest comment (2026-07-18) states: the three banned APIs (MouseInfo.getPointerInfo, getLocationOnScreen, getScreenSize) are at 0 in src/ and ratcheted; toolkit auto-selection, Placement, KeyPad rebuild, census doc, README supported-desktop matrix, and docs/wayland-desktop-checklist.md all exist. The sole blocker remains the JBR_SHA256 placeholder in .github/workflows/ci.yml (line 187), which requires a maintainer to compute the checksum from an open network. The only commits since the tip that comment described (34d92bf → 2eb3e0c: e807068, 9114898) touch collab crypto (AES-256-GCM), HDL scanners, and a menu test — nothing relevant to this issue. The JBR URL is still …
+
+**Action:** no-action
+
+### #96
+
+Tracking issue for the Java-25/Kotlin-practices program. Sub-issue #92 (Java 25 baseline) is closed and verified in-tree; #93/#94/#95 are open and in progress. The newest comment (2026-07-18 22:09Z) accurately describes the in-progress state: NullAway+JSpecify on the default build with jls.sim and jls.util @NullMarked, SimEvent immutability pinned by SimEventDedupTest, Trace.Change as a record, sealed Element hierarchy pinned by SealedHierarchyTest. The only change since that comment is that the branch it references (claude/advance-github-issues-hjrpyq) merged to master as PR #194 (merge commit 2eb3e0c, ~80 minutes after the comment) with two follow-up commits (CI/CodeQL fixes and an unrelated collab AEAD swap). No tracker-level status change: still 1 of 4 sub-issues complete, program correctly in "watch sub-issues to completion" mode.
+
+**Action:** no-action
+
+### #95
+
+The core sealing work is done and now on master. The newest issue comment (2026-07-18 22:09 UTC) reported the sealing integrated on branch claude/advance-github-issues-hjrpyq at tip 34d92bf; since then, PR #194 merged that branch into master (merge commit 2eb3e0c, 2026-07-18 23:28 UTC), so the work is no longer branch-only. Verified on master: Element/LogicElement/Gate/Group/Pin/SigSim/DisplayElement and separate root Put are sealed with explicit permits per the adjudicated 2026-07-17 tree; SealedHierarchyTest pins it; HdlExporter.gateOp is an exhaustive no-default pattern switch over sealed Gate. Also landed in the same merge: #78's Orientation unification (single JLSInfo.Orientation, Gate.Orientation deleted), which unblocks the "Orientation sweep after #78" item the comment listed as gated. Still outstanding on master: SimEvent.todo remains an untyped Object (no sealed …
+
+Adversarial review corrections:
+- Draft comment claimed 'the two commits added after tip 34d92bf inside that merge (e807068, 9114898) touched collab crypto and the HDL scanners only' — refuted: git log shows three post-tip branch commits (1e7d26a, e807068, 9114898), and git diff 34d92bf..2eb3e0c also touches CHANGELOG.md and SECURITY.md in addition to the collab crypto files, HDL scanners, package-info, and MenuBarSpecTest. The …
+- Minor (assessment notes only, not the posted text): the 'Still outstanding' list partially duplicates the prior comment's own 'Remaining:' line; retained because it is now re-verified against master rather than the branch, and the master-merge + #78-unblock facts are genuinely new to the thread.
+- All other claims reproduced from evidence: sealed permits tree on master (Element.java:21-22, LogicElement, Gate, Group, Pin, SigSim, DisplayElement, Put.java:14), SealedHierarchyTest reflection pin, HdlExporter.gateOp:683 exhaustive no-default switch, single JLSInfo.Orientation with Gate.java:4 import, SimEvent.java:25 untyped Object todo, instanceof counts (SimpleEditor 88 / Circuit 17 / …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/95#issuecomment-5016286156
+
+### #94
+
+Increment 1 described in the newest comment (2026-07-18 22:10) is fully present in master at 2eb3e0c: the branch claude/advance-github-issues-hjrpyq it referenced was merged via PR #194, which is exactly the current HEAD. SimEvent remains a plain final class with final fields and an explanatory comment (src/jls/sim/SimEvent.java); the dedup regression test exists (test/jls/sim/SimEventDedupTest.java); Trace.Change, SimpleEditor.WireStart, ToolkitPolicy.Decision are records; TraceSample record exists (src/jls/sim/TraceSample.java); CONTRIBUTING.md carries the value-semantics convention. The remaining candidates the comment lists (LoadError, HdlModel.Port/Net/Operand, HdlExporter.Result, Help.TocEntry) are all still plain final classes — i.e. still pending, exactly as stated. The only commits after the comment (e807068 CI/CodeQL fixes, 9114898 collab AEAD swap, merge 2eb3e0c) touch collab …
+
+**Action:** no-action
+
+### #93
+
+The issue's first-tranche work is fully landed on master. The newest comment (2026-07-18 22:10 UTC) described the work as "integrated on branch claude/advance-github-issues-hjrpyq, tip 34d92bf" — i.e. on a branch, pending merge. Since then, that branch merged to master via PR #194 (merge commit 2eb3e0c, 2026-07-18 23:28 UTC), so everything the comment claims is now on the default branch: Error Prone 2.50.0 + NullAway 0.13.7 on the default -Werror compile with OnlyNullMarked+JSpecifyMode, JSpecify 1.0.0 dependency, @NullMarked on jls.sim and jls.util, NullMarkedRatchetTest + SimulatorNullContractTest, and the CONTRIBUTING ratchet convention. The two post-comment commits inside the PR (e807068 CI/CodeQL fix, 9114898 collab AEAD swap) do not touch the nullness setup. Remaining scope is real: src/jls/package-info.java is not @NullMarked, JLSInfo.java has zero @Nullable annotations, and …
+
+Adversarial review corrections:
+- Draft comment substantially re-enumerates the previous comment's content (versions, compiler flags, package list, test names, CONTRIBUTING) when the only genuinely new fact is the merge to master; trimmed to avoid near-duplication of the thread.
+- Minor citation drift: CONTRIBUTING.md ratchet section spans roughly lines 43-51, not 44-50 as the evidence stated (immaterial; the section exists as described).
+- All other factual claims reproduced exactly: timestamps (comment 22:10:22Z vs merge 23:28:35Z), 34d92bf ancestry of 2eb3e0c, pom.xml line 163 NullAway args, EP 2.50.0 / NullAway 0.13.7 / jspecify 1.0.0, @NullMarked exactly on jls.sim and jls.util, both tests present, ratchet MARKED list, jls root package-info unmarked, JLSInfo with zero @Nullable, and the two post-comment commits (e807068, …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/93#issuecomment-5016286955
+
+### #91
+
+The issue's layered UI-test harness is substantially built and the thread tracks it accurately. At HEAD 2eb3e0c (merge of PR #194, tip 34d92bf): Layer 1 model assertions (P1) exist in test/jls/ui/CircuitAssert.java, GeometryAssert.java, UiHarnessPilotTest.java; Layer 2 synthetic-event gesture tests exist in EditorGestureTest.java + EditorGestureSupport.java (landed b80cd6a); P3 menu-bar expectation-table test exists as MenuBarSpecTest.java; Layer-3 starter exists as RenderAssert.java + RenderBoundsTest.java. Still outstanding, exactly as the newest comment states: P2 (Robot-driven palette click + canvas drop — no Robot test exists; EditorGestureSupport.java:32 explicitly defers palette placement), P4 (blocked on #86's context menus), P5's 20-consecutive-run promotion of the display suite to a required CI gate (.github/workflows/ci.yml lines 5, 113, 165 document the bar as pending; …
+
+**Action:** no-action
+
+### #86
+
+Of the issue's three verified defects, two are fixed and test-pinned on master HEAD 2eb3e0c: (H1/P1-P3) the KeyPad has Esc-on-root-pane dismissal, focus-loss/click-outside dismissal via WindowFocusListener, and no BUTTON3 listener remains (src/jls/KeyPad.java:124-131; pinned by test/jls/ui/KeyPadDismissalTest.java); (H2/P4) the parent editor shows a prominent bold warning-yellow banner naming parent and subcircuit while disabled, cleared on re-enable (src/jls/edit/SimpleEditor.java:142,417-425,654-676,4590; src/jls/edit/Editor.java:371-375; pinned by test/jls/ui/SubcircuitDisabledBannerTest.java). (H3/P5) Action-layer context menus remain unimplemented — only the legacy optionMenu/newMenu popups exist (SimpleEditor.java:820,845), and the stated dependency #75 is still open. Nothing material changed since the newest comment (2026-07-18 22:10 UTC): it described exactly this state on …
+
+**Action:** no-action
+
+### #84
+
+Issue asks for staged decomposition of SimpleEditor (Action layer, State-machine extraction, UndoManager, palette via #78 registry, #86 context menus) with a <~1,500-line target. Current tree (master 2eb3e0c): UndoManager step is DONE and merged — /home/user/JLS/src/jls/edit/UndoManager.java (239 lines, IntSupplier depth degrading to JLSInfo.undoStackDepth as the #76 seam), CircuitSnapshot.java, and /home/user/JLS/test/jls/edit/UndoManagerTest.java (8 @Test methods); SimpleEditor delegates via a single undoManager field. Viewport.java (#74) and DeleteKeyPolicy.java are also extracted. Still remaining: the 9-state enum State is still inside SimpleEditor (:704) with setState on EditWindow; the source== popup dispatcher (the #37 failure site) is intact at :2170-2427 with 19 getSource()== branches; makeElements() still hand-enumerates the toolbar palette (:1543); SimpleEditor is now 5,155 …
+
+Adversarial review corrections:
+- Key-binding AbstractAction range misstated: draft comment says :1011-1331, but the Action definitions extend through flipKey at :1477 (approx :1011-1490); corrected.
+- Claim that the Action-layer step 'reduces to converting this one popup dispatcher' oversimplifies: section 7 requires shared Action objects joint with #75, and the existing key-binding AbstractActions were not verified to be shareable with menu/popup paths; reworded to the verified fact that all 19 remaining getSource()== sites are in the popup dispatcher.
+- Growth attribution incomplete: draft credits only #75/#86/#192 (net +260 in SimpleEditor), but most of the 4,477 -> 5,155 growth came from the repo-wide Javadoc pass (c4f3e6f, e1597ee) and the #167 operation-layer slice (4e843a9) earlier on the same branch; also the evidence's '+179 lines' for 8e75454 is total changed lines (143 insertions / 36 deletions, net +107). The #84 increment a47a1fa was …
+- ElementRegistry attribution: it was added in commit 6092703 ('Advance #78'), not 34d92bf (which only routed ElementBlocks through it); citation fixed to the PR and the adding commit.
+- Dispatcher range ':2170-2427' imprecise: branch heads span :2179-2425 and the actionPerformed method ends at :2444; restated precisely.
+
+**Action:** comment — https://github.com/anadon/JLS/issues/84#issuecomment-5016287844
+
+### #82
+
+The issue asks for jpackage installers per OS with .jls file association shipped from the tag-triggered release pipeline. The current tree at HEAD 2eb3e0c already has: /home/user/JLS/scripts/build-installer.sh (jar → jdeps module derivation → jlink runtime → jpackage with .jls file association, JBR bundling for Linux with pinned jbrsdk-25.0.3 but UNVERIFIED-PLACEHOLDER sha256s and JLS_JBR_HOME override), /home/user/JLS/scripts/GenerateIcons.java (checked-in icon generation), a five-leg installer matrix in /home/user/JLS/.github/workflows/release.yml (Linux deb/rpm verified, msi/dmg/Windows legs still experimental: true with continue-on-error), and README install docs including the macOS "unsigned by choice" stance (README.md:38-41). The newest comment (2026-07-18 22:10 UTC) describes exactly this state, including the remaining work: arm the JBR sha256 pins, Wayland-verify a JBR-bundled …
+
+**Action:** no-action
+
+### #79
+
+The issue asked for (1) a FORMAT version header with negotiation, (2) a normative save-format spec, (3) type tags decoupled from Java class names, plus legacy-4.1 characterization (P3/P4). At HEAD 2eb3e0c (merge of PR #194) all three code/doc items are present in master: Circuit.java writes a FORMAT header and refuses newer versions with a NEWER_FORMAT error (headerless = v0), docs/file-format.md is a full normative spec (containers, grammar, escaping, 31/32-tag table, version history 0/1/2, evolution policy incl. the #47 RLE caveat and tag-stability rule) linked from README, and tag resolution routes through jls.elem.SaveTags (frozen tag table + alias map) and ElementRegistry.forTag — Class.forName("jls.elem."+tag) is gone from the save-file load path. Tests FormatHeaderTest, FileFormatSpecTest, SaveTagsTest, ElementRegistryTest guard all of it. The residual P3/P4 legacy-corpus work …
+
+**Action:** close-completed — https://github.com/anadon/JLS/issues/79#issuecomment-5016287021
+
+### #78
+
+The issue's first two staged slices are complete and in master at 2eb3e0c: (1) core ElementType + ElementRegistry covering all 33 loadable types, with Circuit.load routed through it (Class.forName hardcode removed, Circuit.java:879-884) and an ElementRegistryTest integrity suite; (2) H3 orientation unification — only JLSInfo.Orientation remains (JLSInfo.java:86), the lowercase Gate.Orientation duplicate is deleted. Still outstanding, exactly as the newest comment lists: palette/toolbar generation from descriptors (SimpleEditor.makeElements() at line 1543 is still hand-enumerated), H2 abstract-ification (throw/print stubs remain at Element.java:387 and LogicElement.java:432), capability interfaces (none of Rotatable/Timed/Watchable/QuickEditable/Editable exist; instanceof Memory branch still at Element.java:856), pin faces, and the #79 alias-table doc. The only change since the newest …
+
+**Action:** no-action
+
+### #77
+
+The issue asks for an enforced-headless jls.core (model + simulation + persistence with zero AWT/Swing/jls.edit imports), decomposition of JLSInfo, and a Circuit model/render split. At HEAD 2eb3e0c the work is partially done and in active progress: the HeadlessCoreRatchetTest architecture ratchet exists and is enforced; Simulator and BatchSimulator are clean of AWT/Swing/jls.edit (batch trace printing extracted to GUI-side BatchTracePrinter over a core TraceSample record, pinned by BatchTracePrinterTest); the ratchet baseline still grandfathers 57 files (Circuit, 53 jls.elem files, InteractiveSimulator/MemTrace/Trace). Circuit still holds the Editor back-reference (setEditor/getEditor) and JLSInfo remains a mutable static hub (frame still used ~43 times as dialog parent). The newest comment (2026-07-18, posted from branch tip 34d92bf) already describes exactly this state; that branch …
+
+**Action:** no-action
+
+### #76
+
+Issue #76 asks for CVD-safe semantic colors with a second visual channel, HiDPI/system L&F work, dark mode, and persistent preferences. The newest comment (2026-07-18T22:11Z) already reports the first implementation slice, and every claim in it verifies at HEAD 2eb3e0c: Theme record with Okabe-Ito palette and classic-scheme fallback (src/jls/Theme.java), the H1 dichromacy-simulation test (test/jls/ThemeTest.java), second channel (thick non-zero / dashed HiZ strokes in src/jls/elem/Wire.java:124-145; ring glyph in src/jls/elem/WireEnd.java:234), java.util.prefs-backed UserPrefs with in-memory fallback persisting theme + grid/background colors (src/jls/UserPrefs.java), and the -Djls.laf=metal|system|<class> policy with fallback instead of System.exit(1) (src/jls/JLSStart.java:760-823, test/jls/LookAndFeelPolicyTest.java). The comment's remaining-work list is still accurate: no FlatLaf in …
+
+**Action:** no-action
+
+### #75
+
+The issue asks for keyboard operability: menu accelerators/mnemonics, a fixed focus model, rotate/flip bindings, platform-convention fixes, and (H2) keyboard-only circuit construction. The H1 slice shipped and is on master at 2eb3e0c (merge of PR #194 from branch claude/advance-github-issues-hjrpyq, tip 34d92bf): a headless-testable MenuAcceleratorPolicy class with tests, File-menu accelerators (Cmd/Ctrl N/O/S/Shift+S/Q) wired WHEN_IN_FOCUSED_WINDOW, mnemonics on all four menus and every item, the mouseEntered focus-follows-mouse grab removed (canvas now focusable on click/tab-select), rotate R/Shift+R and flip F bound and shown in menu items, macOS redo = Shift+Cmd+Z with Cmd+Y alias, and dialog accessible descriptions in ElementDialog. Still open: H2 keyboard-only construction (behind a feasibility spike), the shared Action layer that #73/#84/#86 consume, the File>Close accelerator …
+
+**Action:** no-action
+
+### #74
+
+The issue asks for editor zoom/pan (Viewport transform) plus canvas auto-grow replacing the fixed 1000px square and manual 10% grow button. Current master (2eb3e0c) contains the Viewport coordinate core: `src/jls/edit/Viewport.java` (pure, headless-testable class encoding the adjudicated decisions — [0.25,4.0] clamp, 1.15x cursor-centered wheel step, 25-400% keyboard ladder, fit-to-circuit, model-space hit-testing contract) and `test/jls/edit/ViewportTest.java` (25 @Test methods). Editor wiring is NOT done: `SimpleEditor` never references `Viewport` (its only "viewport" is the JScrollPane's, line 4790), there is no MouseWheelListener/zoom handling, the 10% grow button and `increaseSize()` remain (SimpleEditor.java:441-453, 599-606), and `JLSInfo.circuitsize` is still the fixed 1000 (JLSInfo.java:48). Material change since the newest comment (2026-07-18 22:11 UTC): that comment placed …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/74#issuecomment-5016288153
+
+### #73
+
+The tutorial-refresh slice (the minimal in-scope tutorial work per the 2026-07-17 decisions comment) is fully landed at master HEAD 2eb3e0c: Tutorial.java has Previous/Next navigation, per-page titles, a 760x640 initial size, and no isDemo parameter; the orphaned 21 KB tutorial.html is deleted; no applet/network references remain in src/jls/tutorial (prediction P3 satisfied); TutorialContentTest and TutorialNavigationTest guard it. Everything else in the issue remains open: no welcome/empty-state panel, no resources/samples directory or File→Open Sample menu item, README has zero screenshots (only the OpenSSF Scorecard badge), no feature-overview/positioning paragraph, no Edit menu (menu bar is File/Simulator/Global/Help), and the usability trial has not run. Material change since the newest comment (2026-07-18T22:11Z): that comment reported the work as "integrated on branch …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/73#issuecomment-5016288727
+
+### #63
+
+Issue asks for a full Stage-3 black-box HDL component: header scanners, Yosys fallback, component element with failure-state UX (P4-P6), subprocess harness/transport, event-loop integration, x/z coercion, parity/latency evidence. Current tree (master HEAD 2eb3e0c) contains only §7 items 1-2: the header scanners in /home/user/JLS/src/jls/hdl/scan (VerilogHeaderScanner, VhdlEntityScanner, ScannedModule, ScannedPort, HdlScanException), their tests in /home/user/JLS/test/jls/hdl/scan (21 + 15 test methods), and the Yosys cross-check corpus in /home/user/JLS/test/resources/hdl/scan. No component element, no co-simulation/transport/harness code, no production Yosys fallback exists (grep for cosim/HdlComponent hits only javadoc). Material change since the newest comment (posted 22:11 UTC 2026-07-18): PR #194 merged to master at 23:28 UTC (commit 2eb3e0c), so the work the comment placed on …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/63#issuecomment-5016289001
+
+### #62
+
+The issue asks for a layout seam plus a heuristic layered layouter (later adjudicated to an out-of-process ELK runner instead), a quantified rubric harness, goldens, and #61 integration. Current master (2eb3e0c) already contains the engine-neutral layout seam and executable rubric: src/jls/hdl/layout/ (SchematicLayouter, LayoutGraph, LayoutResult, LayoutInvariants, LayoutMetrics, LayoutException; 1173 lines) with 25 tests under test/jls/hdl/layout/. Per the 2026-07-17 adjudication no Sugiyama layouter was or will be written. Still absent: any SchematicLayouter implementation (the ELK runner), the test/resources/hdl/layout-goldens/ directory and three MTU-sourced goldens, #61 importer integration, and the corpus metrics run. Material change since the newest comment (2026-07-18 22:11Z): the branch that comment cited (claude/advance-github-issues-hjrpyq, tip 34d92bf) merged to master ~77 …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/62#issuecomment-5016289673
+
+### #61
+
+The issue asks for full Verilog import via external Yosys write_json netlists. Current tree (master HEAD 2eb3e0c) contains only the front-end groundwork described in the newest comment (2026-07-18): package src/jls/hdl/yosys/ with JsonValue.java (strict JSON subset parser), YosysNetlist.java (typed netlist model with 0/1/x/z bit sentinels and src attributes), NetlistFormatException.java, CellValidator.java + CellViolation.java (restricted-cell validator with teachable reject messages for async reset, set/reset storage, $mul/$div/$mod/$pow, clocked/multi-port memories), YosysVersion.java (0.38 minimum floor) and YosysLocator.java (PATH detection), plus 40 @Test unit tests in test/jls/hdl/yosys/. Still absent: cancellable Yosys subprocess runner, jls_map.v techmap library, cell-to-element mapper, Splitter/Binder mesh synthesis, save-format emission, import UI (File > Import > Verilog), …
+
+**Action:** comment — https://github.com/anadon/JLS/issues/61#issuecomment-5016290067
+
+### #59
+
+Issue #59 is the staged HDL-interop tracking issue (parent #33; sub-issues #60-#63, 1 of 4 complete). Stage 1 export is shipped and incrementally growing: /home/user/JLS/src/jls/hdl/ contains HdlExporter/HdlModel/VerilogEmitter/VhdlEmitter plus the newer Mux/Decoder SelectStatement support described in the newest comment (2026-07-18 22:12 UTC), with goldens for mux/mux3/decoder in both languages under /home/user/JLS/test/resources/hdl/ and tests in /home/user/JLS/test/jls/hdl/ (golden, policy, CLI, iverilog/ghdl-gated compile tests). The element policy in HdlExporter.java still rejects SubCircuit, Memory, StateMachine, TruthTable — exactly the remaining Stage-1 ledger the newest comment lists. Sub-issue infrastructure for #61/#62/#63 (src/jls/hdl/yosys, layout, scan) is also in tree. The only changes since the newest comment: the branch it described (claude/advance-github-issues-hjrpyq, …
+
+**Action:** no-action
+
+### #56
+
+Nearly all of the issue's checklist has landed on master (2eb3e0c): edge-trigger/latch-discriminator goldens and a 3-state StateMachine golden (test/jls/SequentialGoldenTest.java), the .gitignore fixture exemption (!test/fixtures/**/*.jls at .gitignore:10), JaCoCo wired with @{argLine}-prefixed surefire argLine (pom.xml:248,261,270), CLI smoke/flag/image-export tests (test/jls/CliSmokeTest.java, CliFlagTableTest.java, CliImageExportTest.java), headless printing coverage (test/jls/PrintPathSmokeTest.java, PrintPageOrderTest.java), and the editor-level open→edit→save + clipboard smoke test (test/jls/ui/EditorSaveAndClipboardTest.java on the #91 Layer-2 harness). Remaining, exactly as the newest comment (2026-07-18T22:12Z) states: (1) an authentic JLS 4.1 legacy corpus — the only committed fixture is test/fixtures/fork-4.6-shiftregister.jls, which is this fork's own writer output and …
+
+**Action:** no-action
+
+### #33
+
+Tracker #33 has 28 sub-issues, 24 closed; the four open children are #56 (test-suite gaps), #59 (HDL umbrella), #185 (reproducible builds), #188 (deterministic installers) — exactly what the newest comment (2026-07-18 22:12 UTC) reports. The program's substance is done: v5.0.0–v5.0.4 shipped, the #66 coverage ratchet is enforced in pom.xml, version/license identity is pinned by VersionIdentityTest/FormatHeaderTest, and pinned regression tests for the critical/high findings exist in test/jls. What remains to close the tracker is owner bookkeeping already proposed twice in-thread (ship-policy amendment, label taxonomy/milestone, #80 deprecation-window note, disposition/reparenting of #185/#188). Since the newest comment, only three commits landed (e807068 CI/CodeQL fixes, 9114898 collab AES-GCM swap, merge 2eb3e0c) — none touch the four open children or change any claim in the thread.
+
+**Action:** no-action

--- a/pom.xml
+++ b/pom.xml
@@ -449,22 +449,25 @@
       </plugin>
       <plugin>
         <!-- Documentation gate: every public and protected declaration
-             carries well-formed Javadoc (the #186 documentation pass
-             made this true tree-wide; this gate keeps the API half
-             true). doclint runs all groups except `reference`: the
-             generated @see tags point at the test tree, which is
-             deliberately not on the javadoc sourcepath, so reference
-             resolution cannot succeed there - those tags are
-             regenerated attribution, not an enforced invariant. Any
-             other warning fails the build.
-             Scope note, verified empirically: the gate runs at the
-             default protected visibility because under -private the
-             standard doclet itself (independent of doclint, so the
-             -reference exclusion cannot reach it) warns on every
-             test-tree @see target; private-level completeness stays a
-             convention of the periodic documentation pass.
-             -Xmaxwarns lifts javadoc's default 100-warning cap so a
-             regression cannot hide behind truncated output. -->
+             carries well-formed Javadoc; any javadoc warning fails the
+             build. Two mechanisms make that binding (issue #192):
+             - javadoc's own -Werror turns any warning into a nonzero
+               exit, which fails the goal on the exit code. The plugin's
+               failOnWarnings alone is NOT sufficient: it detects
+               warnings by regex-matching the last output line against
+               `\d+ warnings?`, and javadoc 25 digit-groups the summary
+               ("1,422 warnings"), so any count >= 1,000 slipped through
+               unseen. failOnWarnings stays as a second net for counts
+               the regex does still catch.
+             - doclint runs ALL groups including `reference`: test
+               attribution uses the custom @jls.testedby block tag
+               (registered below), whose content is plain text, so it
+               needs no reference resolution against the test tree and
+               real broken @see/@link references are caught again.
+             -Xmaxwarns lifts javadoc's default 100-warning cap so the
+             full regression list is always visible in the log.
+             Private-level completeness stays a convention of the
+             periodic documentation pass (#192 tracks tightening). -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
@@ -478,10 +481,18 @@
           </execution>
         </executions>
         <configuration>
-          <doclint>all,-reference</doclint>
+          <doclint>all</doclint>
           <failOnWarnings>true</failOnWarnings>
           <quiet>true</quiet>
+          <tags>
+            <tag>
+              <name>jls.testedby</name>
+              <placement>a</placement>
+              <head>Tested by:</head>
+            </tag>
+          </tags>
           <additionalOptions>
+            <additionalOption>-Werror</additionalOption>
             <additionalOption>-Xmaxwarns</additionalOption>
             <additionalOption>10000</additionalOption>
           </additionalOptions>

--- a/pom.xml
+++ b/pom.xml
@@ -448,9 +448,9 @@
         </executions>
       </plugin>
       <plugin>
-        <!-- Documentation gate: every public and protected declaration
-             carries well-formed Javadoc; any javadoc warning fails the
-             build. Two mechanisms make that binding (issue #192):
+        <!-- Documentation gate: every declaration down to private
+             members carries well-formed Javadoc; any javadoc warning
+             fails the build. Two mechanisms make that binding (#192):
              - javadoc's own -Werror turns any warning into a nonzero
                exit, which fails the goal on the exit code. The plugin's
                failOnWarnings alone is NOT sufficient: it detects
@@ -465,9 +465,7 @@
                needs no reference resolution against the test tree and
                real broken @see/@link references are caught again.
              -Xmaxwarns lifts javadoc's default 100-warning cap so the
-             full regression list is always visible in the log.
-             Private-level completeness stays a convention of the
-             periodic documentation pass (#192 tracks tightening). -->
+             full regression list is always visible in the log. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
@@ -482,6 +480,7 @@
         </executions>
         <configuration>
           <doclint>all</doclint>
+          <show>private</show>
           <failOnWarnings>true</failOnWarnings>
           <quiet>true</quiet>
           <tags>
@@ -496,6 +495,18 @@
             <additionalOption>-Xmaxwarns</additionalOption>
             <additionalOption>10000</additionalOption>
           </additionalOptions>
+          <!-- The build timestamp in -bottom is a per-build nonce that
+               defeats the plugin's stale-data up-to-date check. That
+               check compares only the javadoc argument list (never
+               source contents or mtimes), so with unchanged options a
+               rerun after a source edit skips generation entirely and
+               reports vacuous success - the same class of silent
+               disarm as the failOnWarnings regex. A varying argument
+               forces a real javadoc run every time. The bottom text
+               only appears in the throwaway gate output under
+               target/reports/apidocs; no release artifact contains
+               it. -->
+          <bottom>Copyright &#169; 2026. All rights reserved. Doclint gate run ${maven.build.timestamp}.</bottom>
         </configuration>
       </plugin>
       <plugin>

--- a/src/jls/BatchTracePrinter.java
+++ b/src/jls/BatchTracePrinter.java
@@ -102,7 +102,7 @@ public final class BatchTracePrinter {
 	 *
 	 * @return a Printable rendering all traces onto a single page.
 	 *
-	 * @see jls.BatchTracePrinterTest#tracePrintableRendersTheRecordedSamples()
+	 * @jls.testedby jls.BatchTracePrinterTest#tracePrintableRendersTheRecordedSamples()
 	 */
 	static Printable tracePrintable(
 			final Map<LogicElement,List<TraceSample>> eventTrace) {

--- a/src/jls/BitSetUtils.java
+++ b/src/jls/BitSetUtils.java
@@ -24,11 +24,11 @@ public final class BitSetUtils {
 	 * 
 	 * @throws IllegalArgumentException if value is negative
 	 *
-	 * @see jls.BitSetUtilsCreateTest#assertRoundTrip()
-	 * @see jls.BitSetUtilsCreateTest#negativeValuesAreRejected()
-	 * @see jls.BitSetUtilsCreateTest#zeroYieldsEmptyBitSet()
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.BitSetUtilsCreateTest#assertRoundTrip()
+	 * @jls.testedby jls.BitSetUtilsCreateTest#negativeValuesAreRejected()
+	 * @jls.testedby jls.BitSetUtilsCreateTest#zeroYieldsEmptyBitSet()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	public static BitSet Create(long value) {
 		
@@ -141,17 +141,17 @@ public final class BitSetUtils {
      * 
      * @return the corresponding long.
      *
-     * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-     * @see jls.BatchSimulationGoldenTest#simulate()
-     * @see jls.BitSetUtilsCreateTest#assertRoundTrip()
-     * @see jls.ElementSimulationGoldenTest#pinValue()
-     * @see jls.SequentialGoldenTest#simulate()
-     * @see jls.SequentialGoldenTest#simulateWithVectors()
-     * @see jls.ShiftRegisterTest#pinValue()
-     * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-     * @see jls.SimulationSemanticsRegressionTest#pinValue()
-     * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
-     * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+     * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+     * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+     * @jls.testedby jls.BitSetUtilsCreateTest#assertRoundTrip()
+     * @jls.testedby jls.ElementSimulationGoldenTest#pinValue()
+     * @jls.testedby jls.SequentialGoldenTest#simulate()
+     * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+     * @jls.testedby jls.ShiftRegisterTest#pinValue()
+     * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+     * @jls.testedby jls.SimulationSemanticsRegressionTest#pinValue()
+     * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+     * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
      */
     public static long ToLong(BitSet bs) {
     	

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -53,22 +53,33 @@ import jls.elem.WireNet;
 public class Circuit implements Printable {
 
 	// properties
+	/** The circuit name (becomes the file name after appending .jls). */
 	private String name = null; // will be the file name after appending .jls
+	/** The directory the circuit's file is in. */
 	private String dir = ""; // the directory the file is in
+	/** All elements (logic elements, wires and wire ends) in this circuit. */
 	private Set<Element> elements = new HashSet<Element>();
+	/** The subcircuit element referring to this circuit, or null if none. */
 	private SubCircuit subElement = null; // the element referring to this
 											// circuit
+	/** This circuit's editor, or null if it has none. */
 	private Editor editor = null; // this circuit's editor (null if none)
+	/** All element names in use, so element names can be kept unique. */
 	private Set<String> namesUsed = new HashSet<String>(); // so element names
 															// can be unique
+	/** The jump starts in this circuit, keyed and sorted by name. */
 	private SortedMap<String, JumpStart> starts = new TreeMap<String, JumpStart>(); // jumpstarts
+	/** True when the circuit has been modified since the last save. */
 	private boolean changed = false;
+	/** The on-disk container format saves of this circuit use (#129). */
 	private FileAbstractor.Container saveContainer =
 			FileAbstractor.Container.XZ; // on-disk container saves use (#129)
 
+	/** Grid index over element bounds (#3, #17). */
 	private final SpatialIndex index = new SpatialIndex(); // grid index over
 															// element bounds
 															// (#3, #17)
+	/** The elements currently drawn highlighted. */
 	private final Set<Element> highlighted = new HashSet<Element>(); // elements
 																		// currently
 																		// drawn
@@ -76,13 +87,17 @@ public class Circuit implements Printable {
 
 	// insertion (file) order, so wire-net construction in finishLoad -
 	// and with it multi-driver resolution - is deterministic (#98, S1)
+	/** Elements read from the file so far, in file order. */
 	private Set<Element> loadedElements = new LinkedHashSet<Element>(); // for loading
+	/** True once a draw-time finishLoad failure has been reported (#58). */
 	private boolean deferredFinishReported = false; // draw-time finishLoad failure (#58)
 																	// from file
+	/** Map from file-local element id to element, used while loading from a file. */
 	private Map<Integer, Element> elementMap = new HashMap<Integer, Element>(); // for
 																				// loading
 																				// from
 																				// file
+	/** The current line number, to report errors when reading a circuit file. */
 	private static int lineNumber; // to report errors when reading circuit file
 
 	/**
@@ -499,6 +514,8 @@ public class Circuit implements Printable {
 	/**
 	 * Refresh one moved element in the index, along with the wires whose
 	 * bounds follow it if it is a wire end.
+	 *
+	 * @param el The element that moved.
 	 */
 	private void reindexMoved(Element el) {
 
@@ -1486,6 +1503,10 @@ public class Circuit implements Printable {
 	 * Wrap a writer so println terminates lines with '\n' whatever the
 	 * platform line separator is. PrintWriter(Writer) adds no buffering,
 	 * so writes pass straight through to the wrapped writer.
+	 *
+	 * @param output The writer to wrap.
+	 *
+	 * @return the wrapping writer.
 	 */
 	private static PrintWriter canonicalNewlines(PrintWriter output) {
 
@@ -1654,6 +1675,11 @@ public class Circuit implements Printable {
 	/**
 	 * Whether an element could draw inside the clip. The margin generously
 	 * covers labels drawn near (but outside) an element's bounds.
+	 *
+	 * @param el The element to test.
+	 * @param clip The clip rectangle.
+	 *
+	 * @return true if the element's margin-padded bounds intersect the clip.
 	 */
 	private static boolean mayBeVisible(Element el, Rectangle clip) {
 

--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -104,87 +104,87 @@ public class Circuit implements Printable {
 	 * @param name
 	 *            The name of this circuit.
 	 *
-	 * @see jls.AllElementsRoundTripTest#load()
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
-	 * @see jls.CircuitChangedFlagTest#newCircuitStartsUnchanged()
-	 * @see jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
-	 * @see jls.CircuitLoadErrorTest#rejectAndGetError()
-	 * @see jls.CircuitLoadErrorTest#unknownElementTypeIsRejected()
-	 * @see jls.CircuitRoundTripTest#load()
-	 * @see jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
-	 * @see jls.ContainerMutationFuzzTest#loadMutant()
-	 * @see jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
-	 * @see jls.DeterministicSaveTest#load()
-	 * @see jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
-	 * @see jls.ElementDrawSmokeTest#load()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.FileAbstractorTest#aFreshCircuitDefaultsToTheXZContainer()
-	 * @see jls.FileFormatSpecTest#load()
-	 * @see jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
-	 * @see jls.FormatHeaderTest#failToLoad()
-	 * @see jls.FormatHeaderTest#load()
-	 * @see jls.GenerativeRoundTripFuzzTest#loadClassified()
-	 * @see jls.LoadErrorReportingTest#loadErrorIsResetBetweenLoads()
-	 * @see jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
-	 * @see jls.LoadErrorReportingTest#reject()
-	 * @see jls.LoadErrorReportingTest#unknownElementTypeReportsItsOwnError()
-	 * @see jls.PrintPathSmokeTest#load()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#load()
-	 * @see jls.SimulationSemanticsRegressionTest#load()
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
-	 * @see jls.SizeMeasurement#measure()
-	 * @see jls.SpatialIndexTest#loadWired()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.StableElementIdTest#duplicateFileIdsAreRejected()
-	 * @see jls.StableElementIdTest#load()
-	 * @see jls.StableElementIdTest#malformedIdsAreClassifiedNotThrown()
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.SvgExportTest#load()
-	 * @see jls.UntrustedFileHardeningTest#rleIsBoundedByDeclaredCapacity()
-	 * @see jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
-	 * @see jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
-	 * @see jls.UtilFunctionsTest#partitionRebuildsWireNets()
-	 * @see jls.UtilFunctionsTest#source()
-	 * @see jls.VcdExportGoldenTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
-	 * @see jls.edit.CtrlWGestureTest#oneConstant()
-	 * @see jls.edit.DragCandidateBoundTest#grid()
-	 * @see jls.edit.SaveAsNameCheckTest#distinctSiblingWithSameNameIsStillACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
-	 * @see jls.edit.SaveAsNameCheckTest#savingUnderAnotherEditorsNameIsACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#savingUnderOwnCurrentNameIsNotACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#unusedNameIsNotACollision()
-	 * @see jls.edit.TriStateBundleConnectTest#load()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
-	 * @see jls.edit.WireSweepSymmetryTest#withConstant()
-	 * @see jls.elem.AttributePersistenceTest#load()
-	 * @see jls.elem.DialogValidationTest#loadExpectingFailure()
-	 * @see jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
-	 * @see jls.elem.GroupOrientationTest#load()
-	 * @see jls.elem.HollowVsFilledCollisionTest#build()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
-	 * @see jls.elem.MemoryInitEncodingTest#load()
-	 * @see jls.elem.MuxSymbolTest#render()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.elem.ParameterValidationTest#loadExpectingFailure()
-	 * @see jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
-	 * @see jls.elem.ParameterValidationTest#validValuesStillLoad()
-	 * @see jls.hdl.HdlCircuitBuilder#load()
-	 * @see jls.ui.DialogConstructionSmokeTest#constructAndCancel()
-	 * @see jls.ui.EditorGestureSupport#EditorGestureSupport()
-	 * @see jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
-	 * @see jls.ui.EditorGestureTest#oneGate()
-	 * @see jls.ui.UiHarnessPilotTest#load()
+	 * @jls.testedby jls.AllElementsRoundTripTest#load()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#newCircuitStartsUnchanged()
+	 * @jls.testedby jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
+	 * @jls.testedby jls.CircuitLoadErrorTest#rejectAndGetError()
+	 * @jls.testedby jls.CircuitLoadErrorTest#unknownElementTypeIsRejected()
+	 * @jls.testedby jls.CircuitRoundTripTest#load()
+	 * @jls.testedby jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#loadMutant()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
+	 * @jls.testedby jls.DeterministicSaveTest#load()
+	 * @jls.testedby jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
+	 * @jls.testedby jls.ElementDrawSmokeTest#load()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.FileAbstractorTest#aFreshCircuitDefaultsToTheXZContainer()
+	 * @jls.testedby jls.FileFormatSpecTest#load()
+	 * @jls.testedby jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
+	 * @jls.testedby jls.FormatHeaderTest#failToLoad()
+	 * @jls.testedby jls.FormatHeaderTest#load()
+	 * @jls.testedby jls.GenerativeRoundTripFuzzTest#loadClassified()
+	 * @jls.testedby jls.LoadErrorReportingTest#loadErrorIsResetBetweenLoads()
+	 * @jls.testedby jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
+	 * @jls.testedby jls.LoadErrorReportingTest#reject()
+	 * @jls.testedby jls.LoadErrorReportingTest#unknownElementTypeReportsItsOwnError()
+	 * @jls.testedby jls.PrintPathSmokeTest#load()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#load()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#load()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SizeMeasurement#measure()
+	 * @jls.testedby jls.SpatialIndexTest#loadWired()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.StableElementIdTest#duplicateFileIdsAreRejected()
+	 * @jls.testedby jls.StableElementIdTest#load()
+	 * @jls.testedby jls.StableElementIdTest#malformedIdsAreClassifiedNotThrown()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.SvgExportTest#load()
+	 * @jls.testedby jls.UntrustedFileHardeningTest#rleIsBoundedByDeclaredCapacity()
+	 * @jls.testedby jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
+	 * @jls.testedby jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
+	 * @jls.testedby jls.UtilFunctionsTest#partitionRebuildsWireNets()
+	 * @jls.testedby jls.UtilFunctionsTest#source()
+	 * @jls.testedby jls.VcdExportGoldenTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#oneConstant()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#grid()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#distinctSiblingWithSameNameIsStillACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#savingUnderAnotherEditorsNameIsACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#savingUnderOwnCurrentNameIsNotACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#unusedNameIsNotACollision()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#load()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#withConstant()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#load()
+	 * @jls.testedby jls.elem.DialogValidationTest#loadExpectingFailure()
+	 * @jls.testedby jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.elem.GroupOrientationTest#load()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#build()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#load()
+	 * @jls.testedby jls.elem.MuxSymbolTest#render()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.elem.ParameterValidationTest#loadExpectingFailure()
+	 * @jls.testedby jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
+	 * @jls.testedby jls.elem.ParameterValidationTest#validValuesStillLoad()
+	 * @jls.testedby jls.hdl.HdlCircuitBuilder#load()
+	 * @jls.testedby jls.ui.DialogConstructionSmokeTest#constructAndCancel()
+	 * @jls.testedby jls.ui.EditorGestureSupport#EditorGestureSupport()
+	 * @jls.testedby jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
+	 * @jls.testedby jls.ui.EditorGestureTest#oneGate()
+	 * @jls.testedby jls.ui.UiHarnessPilotTest#load()
 	 */
 	public Circuit(String name) {
 
@@ -217,9 +217,9 @@ public class Circuit implements Printable {
 	 * 
 	 * @return the name of this circuit.
 	 *
-	 * @see jls.FormatHeaderTest#headerlessLegacyTextStillLoads()
-	 * @see jls.ui.CircuitAssert#assertElementPresent()
-	 * @see jls.ui.EditorGestureSupport#EditorGestureSupport()
+	 * @jls.testedby jls.FormatHeaderTest#headerlessLegacyTextStillLoads()
+	 * @jls.testedby jls.ui.CircuitAssert#assertElementPresent()
+	 * @jls.testedby jls.ui.EditorGestureSupport#EditorGestureSupport()
 	 */
 	public String getName() {
 
@@ -243,7 +243,7 @@ public class Circuit implements Printable {
 	 *
 	 * @return the save container.
 	 *
-	 * @see jls.FileAbstractorTest#aFreshCircuitDefaultsToTheXZContainer()
+	 * @jls.testedby jls.FileAbstractorTest#aFreshCircuitDefaultsToTheXZContainer()
 	 */
 	public FileAbstractor.Container getSaveContainer() {
 
@@ -269,10 +269,10 @@ public class Circuit implements Printable {
 	 * 
 	 * @return true if the circuit has changed, false if not.
 	 *
-	 * @see jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
-	 * @see jls.CircuitChangedFlagTest#newCircuitStartsUnchanged()
-	 * @see jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
-	 * @see jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#newCircuitStartsUnchanged()
+	 * @jls.testedby jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
 	 */
 	public boolean hasChanged() {
 
@@ -283,9 +283,9 @@ public class Circuit implements Printable {
 	 * Mark this circuit as changed. If it is a subcircuit, mark the circuit it
 	 * is in as changed too. If a simulator is running, stop it.
 	 *
-	 * @see jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
-	 * @see jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
-	 * @see jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#serializationDoesNotClearChangedFlag()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
 	 */
 	public void markChanged() {
 
@@ -304,7 +304,7 @@ public class Circuit implements Printable {
 	 * actually been written to disk, so a failed write keeps the
 	 * unsaved-changes protection alive.
 	 *
-	 * @see jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
+	 * @jls.testedby jls.CircuitChangedFlagTest#clearChangedClearsTheFlag()
 	 */
 	public void clearChanged() {
 
@@ -329,12 +329,12 @@ public class Circuit implements Printable {
 	 * @param el
 	 *            The element to add.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wire()
-	 * @see jls.elem.HollowVsFilledCollisionTest#build()
-	 * @see jls.elem.HollowVsFilledCollisionTest#corner()
-	 * @see jls.elem.HollowVsFilledCollisionTest#edge()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wire()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#build()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#corner()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#edge()
 	 */
 	public void addElement(Element el) {
 
@@ -362,67 +362,69 @@ public class Circuit implements Printable {
 	 * iterates; mutation goes through addElement/remove so the circuit
 	 * controls its own membership (and future indexes stay coherent).
 	 *
-	 * @see jls.AllElementsRoundTripTest#copyPreservesEverySavedAttribute()
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.CircuitRoundTripTest#assertLoadsViaSniffer()
-	 * @see jls.CircuitRoundTripTest#saveLoadIsAFixedPoint()
-	 * @see jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
-	 * @see jls.DeterministicSaveTest#stateHashIsContentDetermined()
-	 * @see jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
-	 * @see jls.ElementDrawSmokeTest#theFixtureCoversEveryDrawableElementType()
-	 * @see jls.ElementSimulationGoldenTest#pinValue()
-	 * @see jls.FormatHeaderTest#headeredTextLoads()
-	 * @see jls.FormatHeaderTest#headerlessLegacyTextStillLoads()
-	 * @see jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
-	 * @see jls.ProofBridgeTest#a5DrawMarginAndMayBeVisibleMatchModel()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#forkAuthoredCircuitLoadsWiresAndSimulatesEquivalently()
-	 * @see jls.ShiftRegisterTest#pinValue()
-	 * @see jls.SimulationSemanticsRegressionTest#find()
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-	 * @see jls.SimulationSemanticsRegressionTest#pinValue()
-	 * @see jls.SpatialIndexTest#bruteForceNear()
-	 * @see jls.SpatialIndexTest#everyContainingElementIsACandidate()
-	 * @see jls.SpatialIndexTest#everyInsideElementIsACandidate()
-	 * @see jls.SpatialIndexTest#queriesMatchBruteForceOnWiredCircuit()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
-	 * @see jls.StableElementIdTest#copyMintsAFreshId()
-	 * @see jls.StableElementIdTest#idsAreUniqueWithinACircuit()
-	 * @see jls.StableElementIdTest#mintedIdsSkipIdsTheFileAlreadyUses()
-	 * @see jls.StableElementIdTest#sidsByLogicalElement()
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
-	 * @see jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
-	 * @see jls.UtilFunctionsTest#partitionRebuildsWireNets()
-	 * @see jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
-	 * @see jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
-	 * @see jls.edit.CtrlWGestureTest#hoverSelect()
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
-	 * @see jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
-	 * @see jls.edit.DragCandidateBoundTest#candidateSetPerNetEndIsBoundedIndependentOfCircuitSize()
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
-	 * @see jls.edit.DragCandidateBoundTest#putLocations()
-	 * @see jls.edit.TriStateBundleConnectTest#elementAt()
-	 * @see jls.edit.WireSweepSymmetryTest#constantIn()
-	 * @see jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
-	 * @see jls.elem.AttributePersistenceTest#defaultsAreOmittedExactlyAsBefore()
-	 * @see jls.elem.AttributePersistenceTest#legacyLongValueStillLoads()
-	 * @see jls.elem.AttributePersistenceTest#savedBytesMatchTheHandwrittenFormat()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
-	 * @see jls.elem.GroupOrientationTest#group()
-	 * @see jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
-	 * @see jls.elem.MuxSymbolTest#render()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.ui.CircuitAssert#assertElementPresent()
-	 * @see jls.ui.CircuitAssert#reaches()
-	 * @see jls.ui.EditorGestureTest#rightClickDeleteRemovesTheElement()
-	 * @see jls.ui.EditorGestureTest#undoRestoresADeletedElementAndRedoRemovesItAgain()
+	 * @return an unmodifiable view of the circuit's element set.
+	 *
+	 * @jls.testedby jls.AllElementsRoundTripTest#copyPreservesEverySavedAttribute()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.CircuitRoundTripTest#assertLoadsViaSniffer()
+	 * @jls.testedby jls.CircuitRoundTripTest#saveLoadIsAFixedPoint()
+	 * @jls.testedby jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
+	 * @jls.testedby jls.DeterministicSaveTest#stateHashIsContentDetermined()
+	 * @jls.testedby jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
+	 * @jls.testedby jls.ElementDrawSmokeTest#theFixtureCoversEveryDrawableElementType()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#pinValue()
+	 * @jls.testedby jls.FormatHeaderTest#headeredTextLoads()
+	 * @jls.testedby jls.FormatHeaderTest#headerlessLegacyTextStillLoads()
+	 * @jls.testedby jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
+	 * @jls.testedby jls.ProofBridgeTest#a5DrawMarginAndMayBeVisibleMatchModel()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#forkAuthoredCircuitLoadsWiresAndSimulatesEquivalently()
+	 * @jls.testedby jls.ShiftRegisterTest#pinValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#find()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pinValue()
+	 * @jls.testedby jls.SpatialIndexTest#bruteForceNear()
+	 * @jls.testedby jls.SpatialIndexTest#everyContainingElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#everyInsideElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#queriesMatchBruteForceOnWiredCircuit()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
+	 * @jls.testedby jls.StableElementIdTest#copyMintsAFreshId()
+	 * @jls.testedby jls.StableElementIdTest#idsAreUniqueWithinACircuit()
+	 * @jls.testedby jls.StableElementIdTest#mintedIdsSkipIdsTheFileAlreadyUses()
+	 * @jls.testedby jls.StableElementIdTest#sidsByLogicalElement()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
+	 * @jls.testedby jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
+	 * @jls.testedby jls.UtilFunctionsTest#partitionRebuildsWireNets()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#hoverSelect()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#candidateSetPerNetEndIsBoundedIndependentOfCircuitSize()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#putLocations()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#elementAt()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#constantIn()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#defaultsAreOmittedExactlyAsBefore()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#legacyLongValueStillLoads()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#savedBytesMatchTheHandwrittenFormat()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.elem.GroupOrientationTest#group()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.elem.MuxSymbolTest#render()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.ui.CircuitAssert#assertElementPresent()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.ui.EditorGestureTest#rightClickDeleteRemovesTheElement()
+	 * @jls.testedby jls.ui.EditorGestureTest#undoRestoresADeletedElementAndRedoRemovesItAgain()
 	 */
 	public Set<Element> getElements() {
 
@@ -440,9 +442,9 @@ public class Circuit implements Printable {
 	 *
 	 * @return a fresh list of every element, sorted by stable id.
 	 *
-	 * @see jls.PrintPageOrderTest#bookedPagesFollowStableIdOrder()
-	 * @see jls.SimulationSeedOrderTest#stableOrderIsSortedByStableId()
-	 * @see jls.SimulationSeedOrderTest#initSimIsSeededInStableIdOrder()
+	 * @jls.testedby jls.PrintPageOrderTest#bookedPagesFollowStableIdOrder()
+	 * @jls.testedby jls.SimulationSeedOrderTest#stableOrderIsSortedByStableId()
+	 * @jls.testedby jls.SimulationSeedOrderTest#initSimIsSeededInStableIdOrder()
 	 */
 	public java.util.List<Element> getElementsInStableOrder() {
 
@@ -457,7 +459,7 @@ public class Circuit implements Printable {
 	 * paths don't cover (rotate, flip, size change, aborted move). The next
 	 * spatial query rebuilds it in one pass.
 	 *
-	 * @see jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
+	 * @jls.testedby jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
 	 */
 	public void invalidateIndex() {
 
@@ -472,8 +474,8 @@ public class Circuit implements Printable {
 	 *
 	 * @param moved The elements the editor just moved.
 	 *
-	 * @see jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
-	 * @see jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
+	 * @jls.testedby jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
+	 * @jls.testedby jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
 	 */
 	public void reindexAfterMove(Set<Element> moved) {
 
@@ -521,12 +523,12 @@ public class Circuit implements Printable {
 	 *
 	 * @return the candidate elements.
 	 *
-	 * @see jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
-	 * @see jls.SpatialIndexTest#assertQueryParity()
-	 * @see jls.SpatialIndexTest#everyInsideElementIsACandidate()
-	 * @see jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
-	 * @see jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
-	 * @see jls.elem.HollowVsFilledCollisionTest#indexShortlistsMatchOutlineGeometry()
+	 * @jls.testedby jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
+	 * @jls.testedby jls.SpatialIndexTest#assertQueryParity()
+	 * @jls.testedby jls.SpatialIndexTest#everyInsideElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#indexShortlistsMatchOutlineGeometry()
 	 */
 	public Set<Element> elementsNear(Rectangle rect) {
 
@@ -546,10 +548,10 @@ public class Circuit implements Printable {
 	 *
 	 * @return the candidate elements.
 	 *
-	 * @see jls.SpatialIndexTest#everyContainingElementIsACandidate()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
-	 * @see jls.edit.DragCandidateBoundTest#worstCandidateCount()
+	 * @jls.testedby jls.SpatialIndexTest#everyContainingElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#worstCandidateCount()
 	 */
 	public Set<Element> elementsAt(int x, int y) {
 
@@ -579,7 +581,7 @@ public class Circuit implements Printable {
 	 *
 	 * @return the highlighted elements at this moment.
 	 *
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
 	 */
 	public Set<Element> getHighlighted() {
 
@@ -594,66 +596,66 @@ public class Circuit implements Printable {
 	 * 
 	 * @return false if there were problems, true if load was successful.
 	 *
-	 * @see jls.AllElementsRoundTripTest#load()
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.CircuitLoadErrorTest#rejectAndGetError()
-	 * @see jls.CircuitLoadErrorTest#unknownElementTypeIsRejected()
-	 * @see jls.CircuitRoundTripTest#load()
-	 * @see jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
-	 * @see jls.ContainerMutationFuzzTest#loadMutant()
-	 * @see jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
-	 * @see jls.DeterministicSaveTest#load()
-	 * @see jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
-	 * @see jls.ElementDrawSmokeTest#load()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.FileFormatSpecTest#load()
-	 * @see jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
-	 * @see jls.FormatHeaderTest#failToLoad()
-	 * @see jls.FormatHeaderTest#load()
-	 * @see jls.GenerativeRoundTripFuzzTest#loadClassified()
-	 * @see jls.LoadErrorReportingTest#loadErrorIsResetBetweenLoads()
-	 * @see jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
-	 * @see jls.LoadErrorReportingTest#reject()
-	 * @see jls.LoadErrorReportingTest#unknownElementTypeReportsItsOwnError()
-	 * @see jls.PrintPathSmokeTest#load()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#load()
-	 * @see jls.SimulationSemanticsRegressionTest#load()
-	 * @see jls.SizeMeasurement#measure()
-	 * @see jls.SpatialIndexTest#loadWired()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.StableElementIdTest#duplicateFileIdsAreRejected()
-	 * @see jls.StableElementIdTest#load()
-	 * @see jls.StableElementIdTest#malformedIdsAreClassifiedNotThrown()
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.SvgExportTest#load()
-	 * @see jls.UntrustedFileHardeningTest#rleIsBoundedByDeclaredCapacity()
-	 * @see jls.UtilFunctionsTest#source()
-	 * @see jls.VcdExportGoldenTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
-	 * @see jls.edit.CtrlWGestureTest#oneConstant()
-	 * @see jls.edit.DragCandidateBoundTest#grid()
-	 * @see jls.edit.TriStateBundleConnectTest#load()
-	 * @see jls.edit.WireSweepSymmetryTest#withConstant()
-	 * @see jls.elem.AttributePersistenceTest#load()
-	 * @see jls.elem.DialogValidationTest#loadExpectingFailure()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
-	 * @see jls.elem.GroupOrientationTest#load()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
-	 * @see jls.elem.MemoryInitEncodingTest#load()
-	 * @see jls.elem.MuxSymbolTest#render()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.elem.ParameterValidationTest#loadExpectingFailure()
-	 * @see jls.elem.ParameterValidationTest#validValuesStillLoad()
-	 * @see jls.hdl.HdlCircuitBuilder#load()
-	 * @see jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
-	 * @see jls.ui.EditorGestureTest#oneGate()
-	 * @see jls.ui.UiHarnessPilotTest#load()
+	 * @jls.testedby jls.AllElementsRoundTripTest#load()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.CircuitLoadErrorTest#rejectAndGetError()
+	 * @jls.testedby jls.CircuitLoadErrorTest#unknownElementTypeIsRejected()
+	 * @jls.testedby jls.CircuitRoundTripTest#load()
+	 * @jls.testedby jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#loadMutant()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
+	 * @jls.testedby jls.DeterministicSaveTest#load()
+	 * @jls.testedby jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
+	 * @jls.testedby jls.ElementDrawSmokeTest#load()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.FileFormatSpecTest#load()
+	 * @jls.testedby jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
+	 * @jls.testedby jls.FormatHeaderTest#failToLoad()
+	 * @jls.testedby jls.FormatHeaderTest#load()
+	 * @jls.testedby jls.GenerativeRoundTripFuzzTest#loadClassified()
+	 * @jls.testedby jls.LoadErrorReportingTest#loadErrorIsResetBetweenLoads()
+	 * @jls.testedby jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
+	 * @jls.testedby jls.LoadErrorReportingTest#reject()
+	 * @jls.testedby jls.LoadErrorReportingTest#unknownElementTypeReportsItsOwnError()
+	 * @jls.testedby jls.PrintPathSmokeTest#load()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#load()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#load()
+	 * @jls.testedby jls.SizeMeasurement#measure()
+	 * @jls.testedby jls.SpatialIndexTest#loadWired()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.StableElementIdTest#duplicateFileIdsAreRejected()
+	 * @jls.testedby jls.StableElementIdTest#load()
+	 * @jls.testedby jls.StableElementIdTest#malformedIdsAreClassifiedNotThrown()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.SvgExportTest#load()
+	 * @jls.testedby jls.UntrustedFileHardeningTest#rleIsBoundedByDeclaredCapacity()
+	 * @jls.testedby jls.UtilFunctionsTest#source()
+	 * @jls.testedby jls.VcdExportGoldenTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#oneConstant()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#grid()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#load()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#withConstant()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#load()
+	 * @jls.testedby jls.elem.DialogValidationTest#loadExpectingFailure()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.elem.GroupOrientationTest#load()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#load()
+	 * @jls.testedby jls.elem.MuxSymbolTest#render()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.elem.ParameterValidationTest#loadExpectingFailure()
+	 * @jls.testedby jls.elem.ParameterValidationTest#validValuesStillLoad()
+	 * @jls.testedby jls.hdl.HdlCircuitBuilder#load()
+	 * @jls.testedby jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
+	 * @jls.testedby jls.ui.EditorGestureTest#oneGate()
+	 * @jls.testedby jls.ui.UiHarnessPilotTest#load()
 	 */
 	public boolean load(Scanner input) {
 
@@ -940,7 +942,9 @@ public class Circuit implements Printable {
 	 * 
 	 * @param el
 	 *            An empty object to load.
-	 * 
+	 * @param input
+	 *            The scanner to read the element's values from.
+	 *
 	 * @return false if the file is not in the right format, true if it is.
 	 */
 	public boolean loadElement(Element el, Scanner input) {
@@ -1211,55 +1215,57 @@ public class Circuit implements Printable {
 	 * 
 	 * @return false if any exceptions occur
 	 * @throws Exception
+	 *             declared for callers; assembly problems are in fact
+	 *             caught and reported by returning false.
 	 *
-	 * @see jls.AllElementsRoundTripTest#load()
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.CircuitRoundTripTest#load()
-	 * @see jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
-	 * @see jls.ContainerMutationFuzzTest#loadMutant()
-	 * @see jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
-	 * @see jls.DeterministicSaveTest#load()
-	 * @see jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
-	 * @see jls.ElementDrawSmokeTest#load()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.FileFormatSpecTest#load()
-	 * @see jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
-	 * @see jls.FormatHeaderTest#load()
-	 * @see jls.GenerativeRoundTripFuzzTest#loadClassified()
-	 * @see jls.PrintPathSmokeTest#load()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#load()
-	 * @see jls.SimulationSemanticsRegressionTest#load()
-	 * @see jls.SizeMeasurement#measure()
-	 * @see jls.SpatialIndexTest#loadWired()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.StableElementIdTest#duplicateFileIdsAreRejected()
-	 * @see jls.StableElementIdTest#load()
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.SvgExportTest#load()
-	 * @see jls.UtilFunctionsTest#source()
-	 * @see jls.VcdExportGoldenTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#load()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
-	 * @see jls.edit.CtrlWGestureTest#oneConstant()
-	 * @see jls.edit.DragCandidateBoundTest#grid()
-	 * @see jls.edit.TriStateBundleConnectTest#load()
-	 * @see jls.edit.WireSweepSymmetryTest#withConstant()
-	 * @see jls.elem.AttributePersistenceTest#load()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
-	 * @see jls.elem.GroupOrientationTest#load()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
-	 * @see jls.elem.MemoryInitEncodingTest#load()
-	 * @see jls.elem.MuxSymbolTest#render()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.hdl.HdlCircuitBuilder#load()
-	 * @see jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
-	 * @see jls.ui.EditorGestureTest#oneGate()
-	 * @see jls.ui.UiHarnessPilotTest#load()
+	 * @jls.testedby jls.AllElementsRoundTripTest#load()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.CircuitRoundTripTest#load()
+	 * @jls.testedby jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#loadMutant()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
+	 * @jls.testedby jls.DeterministicSaveTest#load()
+	 * @jls.testedby jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
+	 * @jls.testedby jls.ElementDrawSmokeTest#load()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.FileFormatSpecTest#load()
+	 * @jls.testedby jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
+	 * @jls.testedby jls.FormatHeaderTest#load()
+	 * @jls.testedby jls.GenerativeRoundTripFuzzTest#loadClassified()
+	 * @jls.testedby jls.PrintPathSmokeTest#load()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#load()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#load()
+	 * @jls.testedby jls.SizeMeasurement#measure()
+	 * @jls.testedby jls.SpatialIndexTest#loadWired()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.StableElementIdTest#duplicateFileIdsAreRejected()
+	 * @jls.testedby jls.StableElementIdTest#load()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.SvgExportTest#load()
+	 * @jls.testedby jls.UtilFunctionsTest#source()
+	 * @jls.testedby jls.VcdExportGoldenTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#load()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#oneConstant()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#grid()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#load()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#withConstant()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#load()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.elem.GroupOrientationTest#load()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#circuitWithNamedWire()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#load()
+	 * @jls.testedby jls.elem.MuxSymbolTest#render()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.hdl.HdlCircuitBuilder#load()
+	 * @jls.testedby jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
+	 * @jls.testedby jls.ui.EditorGestureTest#oneGate()
+	 * @jls.testedby jls.ui.UiHarnessPilotTest#load()
 	 */
 	public boolean finishLoad(Graphics g) throws Exception {
 
@@ -1413,19 +1419,19 @@ public class Circuit implements Printable {
 	 * @param output
 	 *            The file to write to.
 	 *
-	 * @see jls.AllElementsRoundTripTest#save()
-	 * @see jls.CircuitChangedFlagTest#serialize()
-	 * @see jls.CircuitRoundTripTest#save()
-	 * @see jls.DeterministicSaveTest#canonicalBytesAreIdenticalWhateverThePlatformNewline()
-	 * @see jls.DeterministicSaveTest#save()
-	 * @see jls.FileFormatSpecTest#save()
-	 * @see jls.FormatHeaderTest#save()
-	 * @see jls.GenerativeRoundTripFuzzTest#save()
-	 * @see jls.SizeMeasurement#measure()
-	 * @see jls.StableElementIdTest#save()
-	 * @see jls.edit.CircuitSnapshotTest#save()
-	 * @see jls.elem.GroupOrientationTest#save()
-	 * @see jls.elem.MemoryInitEncodingTest#save()
+	 * @jls.testedby jls.AllElementsRoundTripTest#save()
+	 * @jls.testedby jls.CircuitChangedFlagTest#serialize()
+	 * @jls.testedby jls.CircuitRoundTripTest#save()
+	 * @jls.testedby jls.DeterministicSaveTest#canonicalBytesAreIdenticalWhateverThePlatformNewline()
+	 * @jls.testedby jls.DeterministicSaveTest#save()
+	 * @jls.testedby jls.FileFormatSpecTest#save()
+	 * @jls.testedby jls.FormatHeaderTest#save()
+	 * @jls.testedby jls.GenerativeRoundTripFuzzTest#save()
+	 * @jls.testedby jls.SizeMeasurement#measure()
+	 * @jls.testedby jls.StableElementIdTest#save()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#save()
+	 * @jls.testedby jls.elem.GroupOrientationTest#save()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#save()
 	 */
 	public void save(PrintWriter output) {
 
@@ -1503,7 +1509,7 @@ public class Circuit implements Printable {
 	 *
 	 * @return the SHA-256 of the canonical save text, in lowercase hex.
 	 *
-	 * @see jls.DeterministicSaveTest#stateHashIsContentDetermined()
+	 * @jls.testedby jls.DeterministicSaveTest#stateHashIsContentDetermined()
 	 */
 	public String stateHash() {
 
@@ -1558,8 +1564,10 @@ public class Circuit implements Printable {
 	 * @param ed
 	 *            The editor window doing the drawing.
 	 * @throws Exception
+	 *             if an unexpected problem stops the deferred
+	 *             finish-load or the drawing pass.
 	 *
-	 * @see jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
+	 * @jls.testedby jls.DrawCullingParityTest#tiledClippedDrawsMatchFullDraw()
 	 */
 	public void draw(Graphics g, Set<Element> second, SimpleEditor ed)
 			throws Exception {
@@ -1666,7 +1674,7 @@ public class Circuit implements Printable {
 	 * 
 	 * @return Printable.PAGE_EXISTS.
 	 *
-	 * @see jls.PrintPathSmokeTest#printingTheCircuitDirectlyRenders()
+	 * @jls.testedby jls.PrintPathSmokeTest#printingTheCircuitDirectlyRenders()
 	 */
 	@Override
 	public int print(Graphics g, PageFormat format, int pagenum) {
@@ -1733,7 +1741,7 @@ public class Circuit implements Printable {
 	 * @param format
 	 *            The page format to use.
 	 *
-	 * @see jls.PrintPathSmokeTest#everyBookedPagePrintsIntoAGraphics()
+	 * @jls.testedby jls.PrintPathSmokeTest#everyBookedPagePrintsIntoAGraphics()
 	 */
 	public void addToBook(Book book, PageFormat format) {
 
@@ -1778,11 +1786,12 @@ public class Circuit implements Printable {
 	 * @param file
 	 *            The name of the file to write to.
 	 * @throws Exception
+	 *             if the image file cannot be written.
 	 *
-	 * @see jls.ElementDrawSmokeTest#everyElementDrawsOnTheRasterExportPath()
-	 * @see jls.ElementDrawSmokeTest#everyElementDrawsOnTheSvgExportPath()
-	 * @see jls.SvgExportTest#exportingTwiceIsByteIdentical()
-	 * @see jls.SvgExportTest#theDocumentIsAnSvgImageWithDrawnContent()
+	 * @jls.testedby jls.ElementDrawSmokeTest#everyElementDrawsOnTheRasterExportPath()
+	 * @jls.testedby jls.ElementDrawSmokeTest#everyElementDrawsOnTheSvgExportPath()
+	 * @jls.testedby jls.SvgExportTest#exportingTwiceIsByteIdentical()
+	 * @jls.testedby jls.SvgExportTest#theDocumentIsAnSvgImageWithDrawnContent()
 	 */
 	public void exportImage(String file) throws Exception {
 
@@ -1948,7 +1957,7 @@ public class Circuit implements Printable {
 	 *            The SubCircuit element in the main circuit that refers to this
 	 *            subcircuit.
 	 *
-	 * @see jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
 	 */
 	public void setImported(SubCircuit sub) {
 
@@ -2103,6 +2112,8 @@ public class Circuit implements Printable {
 	/**
 	 * Get the current line number of the loaded circuit file. Used when an
 	 * error occurs so a meaningful error message can be printed.
+	 *
+	 * @return the line number the loader has reached in the circuit file.
 	 */
 	public int getLineNumber() {
 

--- a/src/jls/DefaultExceptionHandler.java
+++ b/src/jls/DefaultExceptionHandler.java
@@ -17,7 +17,14 @@ public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHa
 	private JLSStart jls = null;
 	private Circuit circuit = null;
 	private int [] extraSpace = new int[10000];
-	
+
+	/**
+	 * Create a handler with no JLS window or circuit attached yet;
+	 * setJLS and setCircuit supply them once they exist.
+	 */
+	public DefaultExceptionHandler() {
+	} // end of constructor
+
 	/**
 	 * Save reference to JLS in case circuit(s) can be saved.
 	 * 

--- a/src/jls/DefaultExceptionHandler.java
+++ b/src/jls/DefaultExceptionHandler.java
@@ -13,9 +13,13 @@ import java.util.*;
 public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHandler {
 	
 	// properties
+	/** True once an exception is being handled, so a second one just exits. */
 	private boolean recovering = false;
+	/** Reference to the main class, or null when running in batch mode. */
 	private JLSStart jls = null;
+	/** The circuit to dump with the stack trace, if any. */
 	private Circuit circuit = null;
+	/** Memory released when handling an OutOfMemoryError so recovery can proceed. */
 	private int [] extraSpace = new int[10000];
 
 	/**

--- a/src/jls/FileAbstractor.java
+++ b/src/jls/FileAbstractor.java
@@ -164,6 +164,9 @@ public final class FileAbstractor {
 	/**
 	 * Whether a probe failure means the hostile-input size cap was hit,
 	 * rather than a format mismatch.
+	 *
+	 * @param ex The exception a format probe rejected the file with.
+	 * @return true if the failure was the circuit size limit, false otherwise.
 	 */
 	private static boolean isOverLimit(IOException ex) {
 
@@ -241,6 +244,8 @@ public final class FileAbstractor {
 	/**
 	 * Read the file as XZ-compressed text.
 	 *
+	 * @param file The file to read.
+	 * @return a Scanner over the decompressed circuit text.
 	 * @throws IOException if the file is not XZ or holds no text.
 	 */
 	static Scanner readXZ(File file) throws IOException {
@@ -280,6 +285,8 @@ public final class FileAbstractor {
 	 * ZipFile closes every stream obtained from it, which used to
 	 * truncate any circuit larger than the Scanner's buffer (issue #2).
 	 *
+	 * @param file The file to read.
+	 * @return a Scanner over the extracted circuit text.
 	 * @throws IOException if the file is not a zip or has no circuit entry.
 	 *
 	 * @jls.testedby jls.FileFormatSupport#openAsZip()
@@ -308,6 +315,8 @@ public final class FileAbstractor {
 	/**
 	 * Read the file as plain circuit text.
 	 *
+	 * @param file The file to read.
+	 * @return a Scanner over the circuit text.
 	 * @throws IOException if the file cannot be read or is empty.
 	 */
 	static Scanner readText(File file) throws IOException {
@@ -339,6 +348,7 @@ public final class FileAbstractor {
 	 */
 	private static final class BoundedInputStream extends java.io.FilterInputStream {
 
+		/** The number of bytes this stream may still hand out. */
 		private long remaining = MAX_CIRCUIT_TEXT_BYTES;
 
 		/**

--- a/src/jls/FileAbstractor.java
+++ b/src/jls/FileAbstractor.java
@@ -46,7 +46,14 @@ public final class FileAbstractor {
 	 * without an XZ decoder (the 4.6-4.10 fork lineage) can open the
 	 * file. Reading needs no counterpart: openCircuit sniffs both.
 	 */
-	public enum Container { XZ, PLAIN_TEXT }
+	public enum Container {
+
+		/** The default save container: XZ-compressed UTF-8 circuit text. */
+		XZ,
+
+		/** The opt-in interchange container: bare UTF-8 circuit text. */
+		PLAIN_TEXT
+	}
 
 	/**
 	 * Upper bound on the circuit text a container may expand to. Circuit
@@ -70,23 +77,23 @@ public final class FileAbstractor {
 	 * @return a Scanner over the circuit text, or null with
 	 *         JLSInfo.loadError describing why every format probe failed.
 	 *
-	 * @see jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
-	 * @see jls.ContainerMutationFuzzTest#loadMutant()
-	 * @see jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
-	 * @see jls.FileAbstractorTest#bothContainersLoadTheSameCircuitText()
-	 * @see jls.FileAbstractorTest#emptyFileIsRejectedNotReturnedEmpty()
-	 * @see jls.FileAbstractorTest#invalidCircuitNameIsRejected()
-	 * @see jls.FileAbstractorTest#missingFileReportsWhy()
-	 * @see jls.FileAbstractorTest#plainTextWriteIsTheBareCircuitText()
-	 * @see jls.FileAbstractorTest#unreadableFileReportsPerFormatReasons()
-	 * @see jls.FileAbstractorTest#writeCircuitReplacesExistingFileAndLeavesNoTemp()
-	 * @see jls.FileAbstractorTest#writeCircuitRoundTripsThroughTheSniffer()
-	 * @see jls.FileFormatSupport#openWithFormatSniffer()
-	 * @see jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
-	 * @see jls.UntrustedFileHardeningTest#oversizedZipEntryIsRejected()
-	 * @see jls.UntrustedFileHardeningTest#sniffingCascadeDoesNotLeakFileDescriptors()
-	 * @see jls.edit.CheckpointWriterTest#awaitWritten()
-	 * @see jls.edit.CheckpointWriterTest#checkpointIsWrittenAndLoadable()
+	 * @jls.testedby jls.CliTextSaveTest#theConvertedFileHoldsTheSameCircuit()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#loadMutant()
+	 * @jls.testedby jls.ContainerMutationFuzzTest#theUnmutatedBaselinesActuallyLoad()
+	 * @jls.testedby jls.FileAbstractorTest#bothContainersLoadTheSameCircuitText()
+	 * @jls.testedby jls.FileAbstractorTest#emptyFileIsRejectedNotReturnedEmpty()
+	 * @jls.testedby jls.FileAbstractorTest#invalidCircuitNameIsRejected()
+	 * @jls.testedby jls.FileAbstractorTest#missingFileReportsWhy()
+	 * @jls.testedby jls.FileAbstractorTest#plainTextWriteIsTheBareCircuitText()
+	 * @jls.testedby jls.FileAbstractorTest#unreadableFileReportsPerFormatReasons()
+	 * @jls.testedby jls.FileAbstractorTest#writeCircuitReplacesExistingFileAndLeavesNoTemp()
+	 * @jls.testedby jls.FileAbstractorTest#writeCircuitRoundTripsThroughTheSniffer()
+	 * @jls.testedby jls.FileFormatSupport#openWithFormatSniffer()
+	 * @jls.testedby jls.FileHandleReleaseTest#assertOpenReleasesTheFile()
+	 * @jls.testedby jls.UntrustedFileHardeningTest#oversizedZipEntryIsRejected()
+	 * @jls.testedby jls.UntrustedFileHardeningTest#sniffingCascadeDoesNotLeakFileDescriptors()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#awaitWritten()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#checkpointIsWrittenAndLoadable()
 	 */
 	public static Scanner openCircuit(String filePath) {
 
@@ -173,10 +180,13 @@ public final class FileAbstractor {
 	 * @param target      The file to (re)place.
 	 * @param circuitText The complete circuit text, as produced by Circuit.save.
 	 *
-	 * @see jls.FileAbstractorTest#defaultWriteIsStillXZCompressed()
-	 * @see jls.FileAbstractorTest#plainTextWriteReplacesAnXZFileAtomically()
-	 * @see jls.FileAbstractorTest#writeCircuitReplacesExistingFileAndLeavesNoTemp()
-	 * @see jls.FileAbstractorTest#writeCircuitRoundTripsThroughTheSniffer()
+	 * @throws IOException if the temp file cannot be written or renamed
+	 *         over the target.
+	 *
+	 * @jls.testedby jls.FileAbstractorTest#defaultWriteIsStillXZCompressed()
+	 * @jls.testedby jls.FileAbstractorTest#plainTextWriteReplacesAnXZFileAtomically()
+	 * @jls.testedby jls.FileAbstractorTest#writeCircuitReplacesExistingFileAndLeavesNoTemp()
+	 * @jls.testedby jls.FileAbstractorTest#writeCircuitRoundTripsThroughTheSniffer()
 	 */
 	public static void writeCircuit(File target, String circuitText) throws IOException {
 
@@ -194,9 +204,12 @@ public final class FileAbstractor {
 	 * @param circuitText The complete circuit text, as produced by Circuit.save.
 	 * @param container   The on-disk container to wrap the text in.
 	 *
-	 * @see jls.FileAbstractorTest#bothContainersLoadTheSameCircuitText()
-	 * @see jls.FileAbstractorTest#plainTextWriteIsTheBareCircuitText()
-	 * @see jls.FileAbstractorTest#plainTextWriteReplacesAnXZFileAtomically()
+	 * @throws IOException if the temp file cannot be written or renamed
+	 *         over the target.
+	 *
+	 * @jls.testedby jls.FileAbstractorTest#bothContainersLoadTheSameCircuitText()
+	 * @jls.testedby jls.FileAbstractorTest#plainTextWriteIsTheBareCircuitText()
+	 * @jls.testedby jls.FileAbstractorTest#plainTextWriteReplacesAnXZFileAtomically()
 	 */
 	public static void writeCircuit(File target, String circuitText,
 			Container container) throws IOException {
@@ -269,7 +282,7 @@ public final class FileAbstractor {
 	 *
 	 * @throws IOException if the file is not a zip or has no circuit entry.
 	 *
-	 * @see jls.FileFormatSupport#openAsZip()
+	 * @jls.testedby jls.FileFormatSupport#openAsZip()
 	 */
 	static Scanner readZip(File file) throws IOException {
 

--- a/src/jls/Help.java
+++ b/src/jls/Help.java
@@ -35,10 +35,15 @@ import javax.swing.tree.TreeSelectionModel;
  */
 public final class Help {
 
+	/** Topic id to help page name, parsed from help/Map.jhm on first use. */
 	private static Map<String,String> topicToUrl = null;
+	/** The single help window, built lazily on first use. */
 	private static JFrame window = null;
+	/** The HTML viewer pane showing the current help page. */
 	private static JEditorPane page = null;
+	/** The table-of-contents tree shown beside the page viewer. */
 	private static JTree toc = null;
+	/** Topic id to its path in the contents tree, for selection sync. */
 	private static Map<String,TreePath> topicToTocPath = null;
 
 	/** No instances: this is a static utility. */
@@ -129,6 +134,8 @@ public final class Help {
 	/**
 	 * Parse help/JLSHelpTOC.xml into a tree. The format is nested
 	 * {@code <tocitem text="..." [target="..."]>} elements.
+	 *
+	 * @return The root node of the contents tree.
 	 */
 	private static DefaultMutableTreeNode loadToc() {
 
@@ -175,10 +182,14 @@ public final class Help {
 	/** A TOC tree node: display text plus optional topic id. */
 	private static final class TocEntry {
 
+		/** The label shown in the contents tree. */
 		final String text;
+		/** The topic id to open when this entry is selected, or null. */
 		final String topic;
 
 		/**
+		 * Create a contents-tree entry.
+		 *
 		 * @param text  The label shown in the contents tree.
 		 * @param topic The topic id to open when selected, or null.
 		 */

--- a/src/jls/JLS.java
+++ b/src/jls/JLS.java
@@ -16,6 +16,13 @@ package jls;
 public final class JLS  {
 
 	/**
+	 * Create a JLS instance. The class is stateless: all work happens
+	 * in the static {@link #main} entry point.
+	 */
+	public JLS() {
+	} // end of constructor
+
+	/**
 	 * Set up exception handler, then start up JLS.
 	 *
 	 * @param args Command line arguments.

--- a/src/jls/JLSInfo.java
+++ b/src/jls/JLSInfo.java
@@ -13,8 +13,10 @@ public final class JLSInfo {
 	// version identity, single-sourced from the pom: the build filters
 	// the project version into jls/version.properties (issue #36); the
 	// "dev" fallback covers IDE/exploded runs without the resource
+	/** The project version, single-sourced from the pom (or "dev" when unavailable). */
 	public static final String versionString = loadVersion();
 
+	/** The program name and version ("JLS " followed by the version string). */
 	public static final String version = "JLS " + versionString;
 
 	/**
@@ -44,50 +46,84 @@ public final class JLSInfo {
 	} // end of loadVersion method
 	
 	// miscellaneous parameters
+	/** Initial width and height of the main window, in pixels. */
 	public static final int windowsize = 600;
+	/** Width and height of the (square) circuit drawing area, in pixels. */
 	public static final int circuitsize = 1000;			// square circuit (can be increased)
+	/** Grid spacing used for snap-to positioning, in pixels. */
 	public static final int spacing = 12;					// for snap-to
+	/** Diameter of input and output connection points, in pixels. */
 	public static final int pointDiameter = 6;			// for inputs and outputs
+	/** Diameter of state machine states, in pixels. */
 	public static final int stateDiameter = 40;			// state machine states
+	/** Size of state machine transition arrowheads, in pixels. */
 	public static final int arrowSize = 6;				// state machine arrows
 	// semantic colors; set from the active Theme (issue #76), so they
 	// are mutable statics like gridColor below. Theme.apply() is the
 	// only intended writer.
+	/** Color used when connections line up (touch). */
 	public static Color touchColor =
 		Theme.DEFAULT.touch();							// when connections line up
+	/** Color used for highlighted elements. */
 	public static Color highlightColor =
 		Theme.DEFAULT.highlight();						// when elements are highlighted
+	/** Color used for selected elements. */
 	public static Color selectionColor =
 		Theme.DEFAULT.selection();						// when elements are selected
+	/** Color used for watched elements. */
 	public static Color watchColor =
 		Theme.DEFAULT.watch();							// watched elements
+	/** Color used for wires carrying a non-zero value. */
 	public static Color nonZeroColor =
 		Theme.DEFAULT.nonZero();							// wires with non-zero values
+	/** Color used for the initial state of a state machine. */
 	public static Color initialStateColor =
 		Theme.DEFAULT.initialState();					// initial states of state machines
+	/** Color used for wires with no value (HiZ). */
 	public static Color wireOffColor =
 		Theme.DEFAULT.wireOff();							// wires with no value (HiZ)
+	/** Color used for wires with an all-zero value. */
 	public static Color wireZeroColor =
 		Theme.DEFAULT.wireZero();						// wires with an all-zero value
+	/** Number of circuit changes between checkpoint file writes. */
 	public static final int checkPointFreq = 10;			// how many changes between checkpoint file writes
+	/** Maximum number of undos remembered. */
 	public static final int undoStackDepth = 10;			// maximum number of undos
+	/** Default simulation time limit. */
 	public static final long defaultTimeLimit = 100000000;		// default simulation time
+	/** The main window frame, used as the parent of dialog boxes. */
 	public static Frame frame = null;					// for dialog boxes
+	/** The simulator, referenced by undo/redo. */
 	public static Simulator sim = null;					// for undo/redo
+	/** True when JLS is running in batch mode. */
 	public static boolean batch = false;				// batch mode
+	/** True when a signal trace should be printed. */
 	public static boolean printTrace = false;			// print signal trace
+	/** True when exporting an image from the command line. */
 	public static boolean imgexport = false;			// export image from command line
+	/** True when exporting HDL from the command line (issue #60). */
 	public static boolean hdlexport = false;			// export HDL from command line (#60)
+	/** True when re-saving a circuit as plain text from the command line (issue #129). */
 	public static boolean textsave = false;				// re-save as plain text from command line (#129)
 	/**
 	 * The four cardinal directions an element can face in the editor,
 	 * used to drive drawing and to rotate or flip elements.
 	 */
-	public enum Orientation { UP, DOWN, LEFT, RIGHT;
+	public enum Orientation {
+		/** Facing up. */
+		UP,
+		/** Facing down. */
+		DOWN,
+		/** Facing left. */
+		LEFT,
+		/** Facing right. */
+		RIGHT;
 
 		/**
 		 * The orientation after a quarter-turn counterclockwise (what
 		 * rotating an element "left" does to each of its orientations).
+		 *
+		 * @return the orientation one quarter-turn counterclockwise from this one.
 		 */
 		public Orientation ccw() {
 			switch (this) {
@@ -101,6 +137,8 @@ public final class JLSInfo {
 		/**
 		 * The orientation after a quarter-turn clockwise (rotating an
 		 * element "right").
+		 *
+		 * @return the orientation one quarter-turn clockwise from this one.
 		 */
 		public Orientation cw() {
 			switch (this) {
@@ -113,6 +151,8 @@ public final class JLSInfo {
 
 		/**
 		 * The opposite orientation (what flipping an element does).
+		 *
+		 * @return the opposite orientation.
 		 */
 		public Orientation flipped() {
 			switch (this) {
@@ -127,6 +167,10 @@ public final class JLSInfo {
 		 * The orientation named by a saved-file string, or the given
 		 * current value if the string names none (the handwritten
 		 * loaders always ignored unknown strings).
+		 *
+		 * @param value The orientation name read from a saved file.
+		 * @param current The orientation to fall back on if value names none.
+		 * @return the orientation named by value, or current if there is no match.
 		 */
 		public static Orientation parse(String value, Orientation current) {
 			for (Orientation o : values()) {
@@ -137,11 +181,15 @@ public final class JLSInfo {
 			return current;
 		} // end of parse method
 	}
+	/** Color of the editor window grid. */
 	public static Color gridColor =
 		Theme.DEFAULT.grid();							// editor window grid
+	/** Color of the editor window background. */
 	public static Color backgroundColor =
 		Theme.DEFAULT.background();						// editor window background
+	/** Error message from the most recent circuit load failure, or "" if none. */
 	public static String loadError = "";				// error message when loading a circuit
+	/** Structured detail behind loadError, or null if none (issue #58). */
 	public static LoadError lastLoadError = null;		// structured detail behind loadError (#58)
 
 	/**

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -83,19 +83,31 @@ import jls.sim.InteractiveSimulator;
 public class JLSStart extends JFrame implements ChangeListener {
 
 	// properties
+	/** Simulation time limit (-d flag), defaulting to JLSInfo.defaultTimeLimit. */
 	private static long timeLimit = JLSInfo.defaultTimeLimit;
+	/** Startup parameter file name (-s flag), or null if none given. */
 	private static String paramFile = null;
+	/** Test input file name (-t flag), or null if none given. */
 	private static String testFile = null;
+	/** Circuit (.jls) file named on the command line, or null if none given. */
 	private static String startFile = null;
+	/** Image export output file name (-i flag operand), or null to derive it from the circuit name. */
 	private static String imageFile = null;
+	/** VCD waveform output file name (-vcd flag), or null if none given. */
 	private static String vcdFile = null;
+	/** HDL export output file name (-export flag), or null if none given. */
 	private static String exportFile = null;
+	/** Plain-text re-save output file name (-savetext flag), or null if none given. */
 	private static String textSaveFile = null;
+	/** True if -p or -v asked for the circuit to be printed. */
 	private static boolean printCircuit = false;
+	/** True to print only the top level (-v) rather than all subcircuits (-p). */
 	private static boolean printCircuitTop;
+	/** Printer name from -p, -v or -r, or null if none given. */
 	private static String printer = null;
 	/** The interactive simulator, shared by all open circuit editors. */
 	private InteractiveSimulator interSim;
+	/** The default exception handler, saved by start() and kept aware of the current circuit. */
 	private static DefaultExceptionHandler exHandler = null;
 
 	/** The frame's content pane. */
@@ -558,7 +570,14 @@ public class JLSStart extends JFrame implements ChangeListener {
 	/**
 	 * Operand arity of a command-line flag (issue #71).
 	 */
-	private enum Arity { NONE, REQUIRED, OPTIONAL }
+	private enum Arity {
+		/** The flag takes no operand. */
+		NONE,
+		/** The flag requires an operand. */
+		REQUIRED,
+		/** The flag may take an operand but need not. */
+		OPTIONAL
+	}
 
 	/**
 	 * One row of the command-line flag table: the flag name (one or
@@ -568,10 +587,15 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 */
 	private static final class FlagSpec {
 
+		/** The flag name, without the leading '-'. */
 		final String flag;
+		/** Whether the flag takes no, a required, or an optional operand. */
 		final Arity arity;
+		/** The operand's name in the usage text, or null if the flag takes none. */
 		final String operandName;
+		/** The operand phrase for "requires ..." errors, or null if the flag takes none. */
 		final String operandWhat;
+		/** The usage description for this flag. */
 		final String description;
 
 		/**

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -94,13 +94,19 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private static boolean printCircuit = false;
 	private static boolean printCircuitTop;
 	private static String printer = null;
+	/** The interactive simulator, shared by all open circuit editors. */
 	private InteractiveSimulator interSim;
 	private static DefaultExceptionHandler exHandler = null;
 
+	/** The frame's content pane. */
 	private Container window;
+	/** Splits the editor tabs (top) from the simulator (bottom). */
 	private JSplitPane both;
+	/** The tabbed pane holding one editor per open circuit. */
 	private JTabbedPane edits;
+	/** Pseudo-circuit holding the elements most recently cut or copied. */
 	private Circuit clipboard = new Circuit("clipboard");		// for cut and paste
+	/** Persistent user preferences, opened at startup. */
 	private final UserPrefs prefs = UserPrefs.open();	// persistent user preferences (#76)
 
 	/**
@@ -511,7 +517,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 * @param circ The circuit to find watched elements in.
 	 * @param qual Qualified name of subcircuit.
 	 *
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
 	 */
 	public static void displayResults(Circuit circ, String qual) {
 
@@ -628,7 +634,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 *
 	 * @return a fresh array of the accepted flag names.
 	 *
-	 * @see jls.CliFlagTableTest#tableFlags()
+	 * @jls.testedby jls.CliFlagTableTest#tableFlags()
 	 */
 	static String[] commandLineFlags() {
 
@@ -769,7 +775,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 *
 	 * @return the class name of the selected look-and-feel.
 	 *
-	 * @see jls.LookAndFeelPolicyTest
+	 * @jls.testedby jls.LookAndFeelPolicyTest
 	 */
 	static String lookAndFeelClassName() {
 
@@ -796,7 +802,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 *
 	 * @return true if a look-and-feel was installed.
 	 *
-	 * @see jls.LookAndFeelPolicyTest
+	 * @jls.testedby jls.LookAndFeelPolicyTest
 	 */
 	static boolean installLookAndFeel() {
 
@@ -974,9 +980,9 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 *
 	 * @return the complete usage message.
 	 *
-	 * @see jls.CliFlagTableTest#helpPrintsTheGeneratedUsageAndExitsZero()
-	 * @see jls.CliFlagTableTest#usageDocumentsExactlyTheParserFlags()
-	 * @see jls.WaylandStartupCliTest#helpIsUnaffectedAndDocumentsTheEscapeHatch()
+	 * @jls.testedby jls.CliFlagTableTest#helpPrintsTheGeneratedUsageAndExitsZero()
+	 * @jls.testedby jls.CliFlagTableTest#usageDocumentsExactlyTheParserFlags()
+	 * @jls.testedby jls.WaylandStartupCliTest#helpIsUnaffectedAndDocumentsTheEscapeHatch()
 	 */
 	static String usageText() {
 
@@ -1785,6 +1791,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 		setupEditor(circ,name);
 	} // end of newCircuit method
 
+	/** The directory of the previous file opened. */
 	private String prevOpenDir = "";  // the directory of the previous file opened
 
 	/**
@@ -2016,7 +2023,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 	
 	/**
 	 * Import a circuit from a file into this circuit.
-	 * @throws Exception 
+	 * @throws Exception if an unexpected problem stops the import.
 	 */
 	public void fileImport() throws Exception {
 
@@ -2517,7 +2524,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 	/**
 	 * Write an image of the circuit to a file.
-	 * @throws Exception 
+	 * @throws Exception if the image file cannot be written.
 	 */
 	public void exportImage() throws Exception {
 

--- a/src/jls/KeyPad.java
+++ b/src/jls/KeyPad.java
@@ -15,16 +15,27 @@ import java.net.*;
 public final class KeyPad extends JButton implements ActionListener {
 	
 	// properties
+	/** The digit buttons, 0-9 (and a-f when the base is 16). */
 	private JButton [] digits = new JButton[16];
+	/** The button that resets the text field to the default value. */
 	private JButton reset = new JButton("C");
+	/** The button that hides the keypad window. */
 	private JButton hide = new JButton(); 
+	/** The text field the keypad fills. */
 	private JTextField target;
+	/** The number base (10 or 16), hence how many digit buttons work. */
 	private int base;
+	/** The value the reset button puts back into the text field. */
 	private long defaultValue;
+	/** True if the next digit replaces the text instead of appending. */
 	private boolean firstChange = true;
+	/** The undecorated window containing the keypad buttons. */
 	private JDialog win;
+	/** True when the keypad window is showing. */
 	private boolean winVisible = false;
+	/** When the keypad was last auto-hidden by focus loss, in milliseconds. */
 	private long autoHidden = 0;
+	/** The document filter restricting the text field to digits in the base. */
 	TextFilter filter;
 	
 	/**

--- a/src/jls/LoadError.java
+++ b/src/jls/LoadError.java
@@ -49,6 +49,7 @@ public final class LoadError {
 		/** The file blows past a hostile-input cap (issue #38). */
 		LIMIT_EXCEEDED("expansion limit exceeded");
 
+		/** The user-visible label for this category. */
 		private final String label;
 
 		/**
@@ -72,10 +73,15 @@ public final class LoadError {
 		}
 	} // end of Category enum
 
+	/** Which kind of failure this is. */
 	private final Category category;
+	/** What went wrong, in words a student can read. */
 	private final String detail;
+	/** The 1-based line the loader had reached, or 0 if unknown. */
 	private final int line;
+	/** The element being read, or null if no element is in play. */
 	private final String element;
+	/** One actionable next-step sentence, or null. */
 	private final String hint;
 
 	/**

--- a/src/jls/LoadError.java
+++ b/src/jls/LoadError.java
@@ -65,7 +65,7 @@ public final class LoadError {
 		 *
 		 * @return the label, e.g. "malformed file".
 		 *
-		 * @see jls.elem.OrientationGeometryTest#errorCategory()
+		 * @jls.testedby jls.elem.OrientationGeometryTest#errorCategory()
 		 */
 		public String label() {
 			return label;
@@ -114,18 +114,20 @@ public final class LoadError {
 	} // end of of method
 
 	/**
+	 * Get which kind of failure this is.
+	 *
 	 * @return the failure category.
 	 *
-	 * @see jls.FormatHeaderTest#malformedFormatVersionFailsAsMalformed()
-	 * @see jls.FormatHeaderTest#newerFormatVersionFailsAsNeedsNewerJls()
-	 * @see jls.FormatHeaderTest#truncatedFormatHeaderFailsAsMalformed()
-	 * @see jls.LoadErrorReportingTest#badElementParameterNamesElementLineAndConstraint()
-	 * @see jls.LoadErrorReportingTest#garbageBytesAreReportedAsNotACircuitFile()
-	 * @see jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
-	 * @see jls.LoadErrorReportingTest#nonIntegerAttributeValueReportsAttributeAndLine()
-	 * @see jls.LoadErrorReportingTest#truncatedFileNamesCategoryLineElementAndNextStep()
-	 * @see jls.LoadErrorReportingTest#unknownElementTagNamesTagCategoryAndUpgradeHint()
-	 * @see jls.elem.OrientationGeometryTest#errorCategory()
+	 * @jls.testedby jls.FormatHeaderTest#malformedFormatVersionFailsAsMalformed()
+	 * @jls.testedby jls.FormatHeaderTest#newerFormatVersionFailsAsNeedsNewerJls()
+	 * @jls.testedby jls.FormatHeaderTest#truncatedFormatHeaderFailsAsMalformed()
+	 * @jls.testedby jls.LoadErrorReportingTest#badElementParameterNamesElementLineAndConstraint()
+	 * @jls.testedby jls.LoadErrorReportingTest#garbageBytesAreReportedAsNotACircuitFile()
+	 * @jls.testedby jls.LoadErrorReportingTest#midStreamIOExceptionIsReportedAsIOError()
+	 * @jls.testedby jls.LoadErrorReportingTest#nonIntegerAttributeValueReportsAttributeAndLine()
+	 * @jls.testedby jls.LoadErrorReportingTest#truncatedFileNamesCategoryLineElementAndNextStep()
+	 * @jls.testedby jls.LoadErrorReportingTest#unknownElementTagNamesTagCategoryAndUpgradeHint()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#errorCategory()
 	 */
 	public Category getCategory() {
 
@@ -133,6 +135,8 @@ public final class LoadError {
 	} // end of getCategory method
 
 	/**
+	 * Get the human-readable detail of the failure.
+	 *
 	 * @return what went wrong, in words.
 	 */
 	public String getDetail() {
@@ -141,9 +145,11 @@ public final class LoadError {
 	} // end of getDetail method
 
 	/**
+	 * Get the line number where the failure hit.
+	 *
 	 * @return the 1-based line the loader had reached, or 0 if unknown.
 	 *
-	 * @see jls.LoadErrorReportingTest#truncatedFileNamesCategoryLineElementAndNextStep()
+	 * @jls.testedby jls.LoadErrorReportingTest#truncatedFileNamesCategoryLineElementAndNextStep()
 	 */
 	public int getLine() {
 
@@ -151,6 +157,8 @@ public final class LoadError {
 	} // end of getLine method
 
 	/**
+	 * Get the element the loader was reading, if any.
+	 *
 	 * @return the element being read when the failure hit, or null.
 	 */
 	public String getElement() {
@@ -159,6 +167,8 @@ public final class LoadError {
 	} // end of getElement method
 
 	/**
+	 * Get the actionable next step, if any.
+	 *
 	 * @return the next-step sentence, or null.
 	 */
 	public String getHint() {
@@ -174,9 +184,9 @@ public final class LoadError {
 	 *
 	 * @return the full user-visible message.
 	 *
-	 * @see jls.FormatHeaderTest#malformedFormatVersionFailsAsMalformed()
-	 * @see jls.FormatHeaderTest#newerFormatVersionFailsAsNeedsNewerJls()
-	 * @see jls.StableElementIdTest#duplicateFileIdsAreRejected()
+	 * @jls.testedby jls.FormatHeaderTest#malformedFormatVersionFailsAsMalformed()
+	 * @jls.testedby jls.FormatHeaderTest#newerFormatVersionFailsAsNeedsNewerJls()
+	 * @jls.testedby jls.StableElementIdTest#duplicateFileIdsAreRejected()
 	 */
 	public String render() {
 

--- a/src/jls/MenuAcceleratorPolicy.java
+++ b/src/jls/MenuAcceleratorPolicy.java
@@ -41,7 +41,7 @@ import javax.swing.KeyStroke;
  * {@code Toolkit.getMenuShortcutKeyMaskEx()} reports on those
  * platforms at runtime.
  *
- * @see jls.MenuAcceleratorPolicyTest
+ * @jls.testedby jls.MenuAcceleratorPolicyTest
  */
 public final class MenuAcceleratorPolicy {
 
@@ -61,7 +61,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return true for macOS.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#isMacRecognizesAppleOsNames()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#isMacRecognizesAppleOsNames()
 	 */
 	public static boolean isMac(String osName) {
 
@@ -80,7 +80,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the extended modifier mask for menu accelerators.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#macUsesCommandOthersUseControl()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#macUsesCommandOthersUseControl()
 	 */
 	public static int menuMask(String osName) {
 
@@ -95,7 +95,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
 	 */
 	public static KeyStroke newCircuit(String osName) {
 
@@ -109,7 +109,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
 	 */
 	public static KeyStroke open(String osName) {
 
@@ -123,7 +123,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
 	 */
 	public static KeyStroke save(String osName) {
 
@@ -138,7 +138,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#saveAsIsShiftedSave()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#saveAsIsShiftedSave()
 	 */
 	public static KeyStroke saveAs(String osName) {
 
@@ -155,7 +155,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#fileAcceleratorsUseThePlatformMask()
 	 */
 	public static KeyStroke exit(String osName) {
 
@@ -171,8 +171,8 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the accelerator to display.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#macRedoIsShiftCommandZ()
-	 * @see jls.MenuAcceleratorPolicyTest#otherPlatformsRedoStaysControlY()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#macRedoIsShiftCommandZ()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#otherPlatformsRedoStaysControlY()
 	 */
 	public static KeyStroke redoDisplayed(String osName) {
 
@@ -195,8 +195,8 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the redo bindings, displayed accelerator first.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#macRedoKeepsTheOldBindingAsAnAlias()
-	 * @see jls.MenuAcceleratorPolicyTest#otherPlatformsRedoStaysControlY()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#macRedoKeepsTheOldBindingAsAnAlias()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#otherPlatformsRedoStaysControlY()
 	 */
 	public static List<KeyStroke> redoBindings(String osName) {
 
@@ -214,7 +214,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the rotate-clockwise keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
 	 */
 	public static KeyStroke rotateCwStroke() {
 
@@ -227,7 +227,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the rotate-counter-clockwise keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
 	 */
 	public static KeyStroke rotateCcwStroke() {
 
@@ -241,7 +241,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the flip keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#rotateAndFlipArePlainKeys()
 	 */
 	public static KeyStroke flipStroke() {
 
@@ -259,7 +259,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the view-value keystroke.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#viewValueIsPlainVNotMaskedS()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#viewValueIsPlainVNotMaskedS()
 	 */
 	public static KeyStroke viewValueStroke() {
 
@@ -272,7 +272,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the File menu mnemonic key code.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
 	 */
 	public static int fileMenuMnemonic() {
 
@@ -284,7 +284,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the Simulator menu mnemonic key code.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
 	 */
 	public static int simulatorMenuMnemonic() {
 
@@ -296,7 +296,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the Global menu mnemonic key code.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
 	 */
 	public static int globalMenuMnemonic() {
 
@@ -308,7 +308,7 @@ public final class MenuAcceleratorPolicy {
 	 *
 	 * @return the Help menu mnemonic key code.
 	 *
-	 * @see jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
 	 */
 	public static int helpMenuMnemonic() {
 

--- a/src/jls/NumericField.java
+++ b/src/jls/NumericField.java
@@ -46,12 +46,12 @@ public final class NumericField {
 	 * @return the parsed-and-clamped value, or previous if the text was
 	 *         not a parsable int.
 	 *
-	 * @see jls.NumericFieldTest#emptyTextMeansTheMinimum()
-	 * @see jls.NumericFieldTest#lonelyMinusSignKeepsThePreviousValueAndReports()
-	 * @see jls.NumericFieldTest#negativeValuesClampToTheMinimumWithoutError()
-	 * @see jls.NumericFieldTest#unparsableTextKeepsThePreviousValueAndReports()
-	 * @see jls.NumericFieldTest#validTextParsesAndNormalizesTheField()
-	 * @see jls.NumericFieldTest#valuesBelowTheMinimumClampSilently()
+	 * @jls.testedby jls.NumericFieldTest#emptyTextMeansTheMinimum()
+	 * @jls.testedby jls.NumericFieldTest#lonelyMinusSignKeepsThePreviousValueAndReports()
+	 * @jls.testedby jls.NumericFieldTest#negativeValuesClampToTheMinimumWithoutError()
+	 * @jls.testedby jls.NumericFieldTest#unparsableTextKeepsThePreviousValueAndReports()
+	 * @jls.testedby jls.NumericFieldTest#validTextParsesAndNormalizesTheField()
+	 * @jls.testedby jls.NumericFieldTest#valuesBelowTheMinimumClampSilently()
 	 */
 	public static int parse(Component parent, JTextField field, int minimum,
 			int previous, String description) {

--- a/src/jls/SpatialIndex.java
+++ b/src/jls/SpatialIndex.java
@@ -49,6 +49,13 @@ public final class SpatialIndex {
 	private final Map<Element, Rectangle> indexed = new HashMap<Element, Rectangle>();
 	private boolean dirty = true;
 
+	/**
+	 * Create an empty index. It starts dirty, so the first query pays
+	 * one rebuild pass over the authoritative element set.
+	 */
+	public SpatialIndex() {
+	} // end of constructor
+
 	/** Pack a cell coordinate pair into a map key. */
 	private static long key(int cx, int cy) {
 
@@ -57,6 +64,9 @@ public final class SpatialIndex {
 
 	/**
 	 * Whether the index needs a rebuild before it can answer queries.
+	 *
+	 * @return true if the index is stale and must be rebuilt, false if
+	 *         it is current.
 	 */
 	public boolean isDirty() {
 

--- a/src/jls/SpatialIndex.java
+++ b/src/jls/SpatialIndex.java
@@ -45,8 +45,11 @@ public final class SpatialIndex {
 	 */
 	private static final int CELL = 4 * JLSInfo.spacing;
 
+	/** Grid cells, keyed by packed cell coordinates, holding the elements that overlap them. */
 	private final Map<Long, List<Element>> cells = new HashMap<Long, List<Element>>();
+	/** The bounds each tracked element was indexed under. */
 	private final Map<Element, Rectangle> indexed = new HashMap<Element, Rectangle>();
+	/** True when the index is stale and must be rebuilt before answering queries. */
 	private boolean dirty = true;
 
 	/**
@@ -56,7 +59,14 @@ public final class SpatialIndex {
 	public SpatialIndex() {
 	} // end of constructor
 
-	/** Pack a cell coordinate pair into a map key. */
+	/**
+	 * Pack a cell coordinate pair into a map key.
+	 *
+	 * @param cx The cell x-coordinate.
+	 * @param cy The cell y-coordinate.
+	 *
+	 * @return a single long combining both coordinates.
+	 */
 	private static long key(int cx, int cy) {
 
 		return ((long) cx << 32) ^ (cy & 0xffffffffL);
@@ -215,6 +225,11 @@ public final class SpatialIndex {
 	 * Rectangle intersection that, unlike Rectangle.intersects, also counts
 	 * zero-area contact (shared edges, zero-width wires): put-alignment
 	 * checks depend on edge-touching elements being candidates.
+	 *
+	 * @param a The first rectangle.
+	 * @param b The second rectangle.
+	 *
+	 * @return true if the rectangles overlap or touch, false otherwise.
 	 */
 	private static boolean boundsTouch(Rectangle a, Rectangle b) {
 

--- a/src/jls/TellUser.java
+++ b/src/jls/TellUser.java
@@ -60,6 +60,8 @@ public class TellUser {
 	 * Whether a dialog can and should actually be shown. In batch mode
 	 * (-b) dialogs are forbidden by the CLI contract even if a display
 	 * exists; in headless mode they would throw HeadlessException.
+	 *
+	 * @return true if a dialog may be shown.
 	 */
 	static private boolean interactive() {
 		return !JLSInfo.batch && !GraphicsEnvironment.isHeadless();
@@ -69,6 +71,10 @@ public class TellUser {
 	 * The component to parent a dialog on: the caller's component if it
 	 * gave one, else the application frame (never a bare null, which
 	 * can center the dialog on the wrong monitor).
+	 *
+	 * @param parent The caller's component, or null for the application frame.
+	 *
+	 * @return the component to parent the dialog on.
 	 */
 	static private Component parentFor(Component parent) {
 		return parent != null ? parent : JLSInfo.frame;

--- a/src/jls/TellUser.java
+++ b/src/jls/TellUser.java
@@ -9,6 +9,8 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.JOptionPane;
 
 /**
+ * All communication from JLS to the user funnels through this class.
+ *
  * @author Josh Marshall
  *
  * The single seam through which JLS talks to the user (issue #81):
@@ -35,11 +37,24 @@ import javax.swing.JOptionPane;
 public class TellUser {
 
 	/**
+	 * Create a TellUser. Never needed: every method is static.
+	 */
+	public TellUser() {
+	}
+
+	/**
 	 * The answer to a three-way (yes/no/cancel) question. Closing the
 	 * dialog counts as CANCEL: an unanswered question must never take
 	 * the destructive branch.
 	 */
-	public enum Answer { YES, NO, CANCEL }
+	public enum Answer {
+		/** The user said yes. */
+		YES,
+		/** The user said no. */
+		NO,
+		/** The user cancelled or closed the dialog, or the run is batch/headless. */
+		CANCEL
+	}
 
 	/**
 	 * Whether a dialog can and should actually be shown. In batch mode

--- a/src/jls/TextFilter.java
+++ b/src/jls/TextFilter.java
@@ -14,8 +14,11 @@ import javax.swing.text.DocumentFilter;
 public final class TextFilter extends DocumentFilter {
 
 	// properties
+	/** The text field being filtered, read to build an edit's resulting content. */
 	private JTextField target;
+	/** The base (radix) numbers in the field are parsed in. */
 	private int base = 10;
+	/** The largest value the field may hold. */
 	private BigInteger max = null; // null means no maximum
 
 	/**

--- a/src/jls/ToolkitPolicy.java
+++ b/src/jls/ToolkitPolicy.java
@@ -118,7 +118,7 @@ final class ToolkitPolicy {
 	 *
 	 * @return the decision.
 	 *
-	 * @see jls.ToolkitPolicyTest#decide()
+	 * @jls.testedby jls.ToolkitPolicyTest#decide()
 	 */
 	static Decision decide(String osName, String waylandDisplay,
 			String display, String override, boolean headlessRun,
@@ -187,8 +187,8 @@ final class ToolkitPolicy {
 	 *
 	 * @return true if the WLToolkit class exists in this runtime.
 	 *
-	 * @see jls.ToolkitPolicyTest#wlToolkitProbeNeverInitializesAwtAndAnswersFalseOnStockJdk()
-	 * @see jls.WaylandStartupCliTest#assumeStockJdk()
+	 * @jls.testedby jls.ToolkitPolicyTest#wlToolkitProbeNeverInitializesAwtAndAnswersFalseOnStockJdk()
+	 * @jls.testedby jls.WaylandStartupCliTest#assumeStockJdk()
 	 */
 	static boolean runtimeHasWlToolkit() {
 

--- a/src/jls/UserPrefs.java
+++ b/src/jls/UserPrefs.java
@@ -25,14 +25,19 @@ import java.util.prefs.Preferences;
 public final class UserPrefs {
 
 	// preference keys
+	/** The key the color theme name is stored under. */
 	private static final String THEME_KEY = "theme";
+	/** The key the grid color override is stored under. */
 	private static final String GRID_KEY = "gridColor";
+	/** The key the background color override is stored under. */
 	private static final String BACKGROUND_KEY = "backgroundColor";
 
 	// the backing node, or null when only the in-memory map is used
+	/** The backing preferences node, or null when only the in-memory map is used. */
 	private final Preferences node;
 
 	// in-memory fallback (and write-through cache) for sandboxed runs
+	/** In-memory fallback (and write-through cache) for sandboxed runs. */
 	private final Map<String, String> memory = new HashMap<String, String>();
 
 	/**

--- a/src/jls/Util.java
+++ b/src/jls/Util.java
@@ -27,9 +27,9 @@ public final class Util {
 	 * 
 	 * @return the point of minimum x,y coordinates of all elements.
 	 *
-	 * @see jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
-	 * @see jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
-	 * @see jls.UtilFunctionsTest#partitionRebuildsWireNets()
+	 * @jls.testedby jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
+	 * @jls.testedby jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
+	 * @jls.testedby jls.UtilFunctionsTest#partitionRebuildsWireNets()
 	 */
 	public static Point copy(Set<Element> from, Circuit to) {
 
@@ -136,7 +136,7 @@ public final class Util {
 	 * 
 	 * @param circ The circuit to partition.
 	 *
-	 * @see jls.UtilFunctionsTest#partitionRebuildsWireNets()
+	 * @jls.testedby jls.UtilFunctionsTest#partitionRebuildsWireNets()
 	 */
 	public static void partition(Circuit circ) {
 		
@@ -211,7 +211,7 @@ public final class Util {
 	 * 
 	 * @return true if the name is valid, false if not.
 	 *
-	 * @see jls.UtilFunctionsTest#nameValidationAcceptsIdentifiersOnly()
+	 * @jls.testedby jls.UtilFunctionsTest#nameValidationAcceptsIdentifiersOnly()
 	 */
 	public static boolean isValidName(String str) {
 		
@@ -240,7 +240,7 @@ public final class Util {
 	 * 
 	 * @return the base name (minus directory prefix) if valid, or null if not valid.
 	 *
-	 * @see jls.UtilFunctionsTest#fileNameValidationStripsDirectoriesOnBothSeparators()
+	 * @jls.testedby jls.UtilFunctionsTest#fileNameValidationStripsDirectoriesOnBothSeparators()
 	 */
 	public static String isValidFileName(String str) {
 
@@ -272,9 +272,9 @@ public final class Util {
 	 *
 	 * @return the user's home directory.
 	 *
-	 * @see jls.SeedDirectoryTest#defaultDirectoryIsUserHome()
-	 * @see jls.SeedDirectoryTest#emptyRememberedFallsBackToDefault()
-	 * @see jls.SeedDirectoryTest#nullRememberedFallsBackToDefault()
+	 * @jls.testedby jls.SeedDirectoryTest#defaultDirectoryIsUserHome()
+	 * @jls.testedby jls.SeedDirectoryTest#emptyRememberedFallsBackToDefault()
+	 * @jls.testedby jls.SeedDirectoryTest#nullRememberedFallsBackToDefault()
 	 */
 	public static String defaultDirectory() {
 
@@ -292,9 +292,9 @@ public final class Util {
 	 * @return remembered if non-null and non-empty, otherwise
 	 * defaultDirectory().
 	 *
-	 * @see jls.SeedDirectoryTest#emptyRememberedFallsBackToDefault()
-	 * @see jls.SeedDirectoryTest#nullRememberedFallsBackToDefault()
-	 * @see jls.SeedDirectoryTest#rememberedDirectoryWins()
+	 * @jls.testedby jls.SeedDirectoryTest#emptyRememberedFallsBackToDefault()
+	 * @jls.testedby jls.SeedDirectoryTest#nullRememberedFallsBackToDefault()
+	 * @jls.testedby jls.SeedDirectoryTest#rememberedDirectoryWins()
 	 */
 	public static String seedDirectory(String remembered) {
 
@@ -312,7 +312,7 @@ public final class Util {
 	 * 
 	 * @return the string.
 	 *
-	 * @see jls.UtilFunctionsTest#baseConversionMatchesItsDisplayContract()
+	 * @jls.testedby jls.UtilFunctionsTest#baseConversionMatchesItsDisplayContract()
 	 */
 	public static String convert(BigInteger value, int base, boolean extra) {
 		

--- a/src/jls/collab/crdt/CausalBuffer.java
+++ b/src/jls/collab/crdt/CausalBuffer.java
@@ -46,6 +46,12 @@ public final class CausalBuffer {
 	private long duplicatesDropped;
 
 	/**
+	 * Create an empty buffer: nothing delivered yet, nothing pending.
+	 */
+	public CausalBuffer() {
+	}
+
+	/**
 	 * Present one arriving envelope and collect everything that is now
 	 * deliverable: possibly nothing (the envelope was early, or a
 	 * duplicate), possibly the envelope alone, possibly a cascade of

--- a/src/jls/collab/net/Crypto.java
+++ b/src/jls/collab/net/Crypto.java
@@ -42,6 +42,7 @@ final class Crypto {
 	/** The GCM authentication-tag length in bits, from TAG_BYTES. */
 	private static final int TAG_BITS = TAG_BYTES * 8;
 
+	/** No instances: this is a static utility. */
 	private Crypto() {
 
 	} // end of constructor

--- a/src/jls/collab/op/CircuitOpReader.java
+++ b/src/jls/collab/op/CircuitOpReader.java
@@ -26,10 +26,16 @@ public final class CircuitOpReader {
 
 	/** Hostile-input caps (issue #38 discipline). */
 	private static final int MAX_IDS = 10_000;
+	/** Longest escaped string value accepted for ordinary fields, in characters. */
 	private static final int MAX_STRING = 10_000;
+	/** Most element blocks accepted in one op block. */
 	private static final int MAX_BLOCKS = 1_000;
+	/** Most lines accepted in one op block before its END line. */
 	private static final int MAX_LINES = MAX_IDS + 16;
 
+	/**
+	 * Prevent instantiation: this class is all static methods.
+	 */
 	private CircuitOpReader() {
 
 	} // end of constructor

--- a/src/jls/collab/op/ElementBlocks.java
+++ b/src/jls/collab/op/ElementBlocks.java
@@ -27,6 +27,9 @@ final class ElementBlocks {
 	 */
 	static final int MAX_BLOCK = 100_000;
 
+	/**
+	 * Prevents instantiation; this class holds only static helpers.
+	 */
 	private ElementBlocks() {
 
 	} // end of constructor

--- a/src/jls/collab/op/ElementVocabulary.java
+++ b/src/jls/collab/op/ElementVocabulary.java
@@ -45,6 +45,9 @@ public final class ElementVocabulary {
 			"StateMachine", "Stop", "SubCircuit", "Text", "TriState",
 			"TruthTable", "WireEnd", "XorGate");
 
+	/**
+	 * Not instantiable - this class is only a vocabulary of static members.
+	 */
 	private ElementVocabulary() {
 
 	} // end of constructor

--- a/src/jls/collab/op/OpRejected.java
+++ b/src/jls/collab/op/OpRejected.java
@@ -8,6 +8,7 @@ package jls.collab.op;
  */
 public class OpRejected extends Exception {
 
+	/** Serialization version identifier. */
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/src/jls/collab/op/Ops.java
+++ b/src/jls/collab/op/Ops.java
@@ -13,6 +13,9 @@ import jls.elem.ElementId;
  */
 final class Ops {
 
+	/**
+	 * Prevent instantiation; this class only has static helpers.
+	 */
 	private Ops() {
 
 	} // end of constructor

--- a/src/jls/edit/CircuitSnapshot.java
+++ b/src/jls/edit/CircuitSnapshot.java
@@ -47,13 +47,13 @@ public final class CircuitSnapshot {
 	 *
 	 * @return the snapshot.
 	 *
-	 * @see jls.StableElementIdTest#undoRestorePreservesIds()
-	 * @see jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
-	 * @see jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
-	 * @see jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
-	 * @see jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
-	 * @see jls.edit.CircuitSnapshotTest#unchangedCircuitSnapshotsIdentically()
+	 * @jls.testedby jls.StableElementIdTest#undoRestorePreservesIds()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#capturePreservesTheChangedFlag()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#unchangedCircuitSnapshotsIdentically()
 	 */
 	public static CircuitSnapshot capture(Circuit circuit) {
 
@@ -75,10 +75,10 @@ public final class CircuitSnapshot {
 	 * @return the restored circuit, or null if the snapshot did not load
 	 *         (JLSInfo.loadError says why).
 	 *
-	 * @see jls.StableElementIdTest#undoRestorePreservesIds()
-	 * @see jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
-	 * @see jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.StableElementIdTest#undoRestorePreservesIds()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#captureRestoreReproducesTheCircuit()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
 	 */
 	public Circuit restore(String name, Graphics g) {
 
@@ -109,9 +109,9 @@ public final class CircuitSnapshot {
 	 *
 	 * @return true if the serialized content is identical.
 	 *
-	 * @see jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
-	 * @see jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
-	 * @see jls.edit.CircuitSnapshotTest#unchangedCircuitSnapshotsIdentically()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#restoreDoesNotPerturbSnapshotIdentity()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#unchangedCircuitSnapshotsIdentically()
 	 */
 	public boolean sameAs(CircuitSnapshot other) {
 
@@ -123,7 +123,7 @@ public final class CircuitSnapshot {
 	 *
 	 * @return the deflated byte count.
 	 *
-	 * @see jls.edit.CircuitSnapshotTest#snapshotIsCompact()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#snapshotIsCompact()
 	 */
 	public int retainedBytes() {
 

--- a/src/jls/edit/DeleteKeyPolicy.java
+++ b/src/jls/edit/DeleteKeyPolicy.java
@@ -49,9 +49,9 @@ final class DeleteKeyPolicy {
 	 *
 	 * @return the canvas delete bindings.
 	 *
-	 * @see jls.edit.DeleteKeyPolicyTest#canvasBindingsAreExactlyTheTwoUnmodifiedKeys()
-	 * @see jls.edit.DeleteKeyPolicyTest#canvasBindsPlainBackspace()
-	 * @see jls.edit.DeleteKeyPolicyTest#canvasBindsPlainDelete()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#canvasBindingsAreExactlyTheTwoUnmodifiedKeys()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#canvasBindsPlainBackspace()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#canvasBindsPlainDelete()
 	 */
 	static List<KeyStroke> canvasBindings() {
 
@@ -69,8 +69,8 @@ final class DeleteKeyPolicy {
 	 *
 	 * @return the accelerator to display.
 	 *
-	 * @see jls.edit.DeleteKeyPolicyTest#macMenuShowsBackspace()
-	 * @see jls.edit.DeleteKeyPolicyTest#otherPlatformsMenuShowsDelete()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#macMenuShowsBackspace()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#otherPlatformsMenuShowsDelete()
 	 */
 	static KeyStroke menuAccelerator(String osName) {
 
@@ -87,7 +87,7 @@ final class DeleteKeyPolicy {
 	 *
 	 * @return true for macOS.
 	 *
-	 * @see jls.edit.DeleteKeyPolicyTest#isMacRecognizesAppleOsNames()
+	 * @jls.testedby jls.edit.DeleteKeyPolicyTest#isMacRecognizesAppleOsNames()
 	 */
 	static boolean isMac(String osName) {
 

--- a/src/jls/edit/Editor.java
+++ b/src/jls/edit/Editor.java
@@ -36,7 +36,7 @@ public final class Editor extends SimpleEditor {
 	 * @param name The name of the circuit.
 	 * @param clipboard The clipboard.
 	 *
-	 * @see jls.ui.EditorGestureSupport#EditorGestureSupport()
+	 * @jls.testedby jls.ui.EditorGestureSupport#EditorGestureSupport()
 	 */
 	public Editor(JTabbedPane pane, Circuit circuit, String name, Circuit clipboard) {
 
@@ -224,11 +224,11 @@ public final class Editor extends SimpleEditor {
 	 *
 	 * @return true if another editor's circuit already has the name.
 	 *
-	 * @see jls.edit.SaveAsNameCheckTest#distinctSiblingWithSameNameIsStillACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
-	 * @see jls.edit.SaveAsNameCheckTest#savingUnderAnotherEditorsNameIsACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#savingUnderOwnCurrentNameIsNotACollision()
-	 * @see jls.edit.SaveAsNameCheckTest#unusedNameIsNotACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#distinctSiblingWithSameNameIsStillACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#savingUnderAnotherEditorsNameIsACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#savingUnderOwnCurrentNameIsNotACollision()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#unusedNameIsNotACollision()
 	 */
 	static boolean nameUsedByAnotherEditor(String name, Circuit self,
 			Iterable<Circuit> edited) {

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -197,10 +197,10 @@ public abstract class SimpleEditor extends JPanel {
 	 *
 	 * @param fileName Absolute path of the .jls~ checkpoint file.
 	 * @param circuitText The serialized circuit.
-	 * @see jls.edit.CheckpointWriterTest#cancelSupersedesQueuedCheckpointAndDeletesFile()
-	 * @see jls.edit.CheckpointWriterTest#checkpointAfterCancelIsStillWritten()
-	 * @see jls.edit.CheckpointWriterTest#checkpointIsWrittenAndLoadable()
-	 * @see jls.edit.CheckpointWriterTest#newerCheckpointSupersedesQueuedOne()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#cancelSupersedesQueuedCheckpointAndDeletesFile()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#checkpointAfterCancelIsStillWritten()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#checkpointIsWrittenAndLoadable()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#newerCheckpointSupersedesQueuedOne()
 	 */
 	static void writeCheckpointInBackground(final String fileName, String circuitText) {
 
@@ -233,8 +233,8 @@ public abstract class SimpleEditor extends JPanel {
 	 * so quitting right after a save cannot leave a stale checkpoint behind.
 	 *
 	 * @param fileName Absolute path of the .jls~ checkpoint file.
-	 * @see jls.edit.CheckpointWriterTest#cancelSupersedesQueuedCheckpointAndDeletesFile()
-	 * @see jls.edit.CheckpointWriterTest#checkpointAfterCancelIsStillWritten()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#cancelSupersedesQueuedCheckpointAndDeletesFile()
+	 * @jls.testedby jls.edit.CheckpointWriterTest#checkpointAfterCancelIsStillWritten()
 	 */
 	static void cancelCheckpoint(final String fileName) {
 
@@ -276,13 +276,13 @@ public abstract class SimpleEditor extends JPanel {
 	 *
 	 * @return true if put belongs to a bundle and the attach would mix
 	 *         tri-state and normal wires, false otherwise.
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToNormalBundle()
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
-	 * @see jls.edit.TriStateBundleConnectTest#nonGroupPutsNeverMix()
-	 * @see jls.edit.TriStateBundleConnectTest#normalDrivenWireIsStillRefusedOnTriStateBundle()
-	 * @see jls.edit.TriStateBundleConnectTest#normalWireMayAttachToNormalBundle()
-	 * @see jls.edit.TriStateBundleConnectTest#triStateWireIsStillRefusedOnNormalBundle()
-	 * @see jls.edit.TriStateBundleConnectTest#triStateWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToNormalBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#nonGroupPutsNeverMix()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#normalDrivenWireIsStillRefusedOnTriStateBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#normalWireMayAttachToNormalBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#triStateWireIsStillRefusedOnNormalBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#triStateWireMayAttachToTriStateBundle()
 	 */
 	static boolean mixesTriStateAndNormal(WireEnd end, Put put) {
 
@@ -349,12 +349,12 @@ public abstract class SimpleEditor extends JPanel {
 	 * @param wire The wire to check.
 	 *
 	 * @return true if the wire collides along its span.
-	 * @see jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
-	 * @see jls.edit.WireSweepSymmetryTest#elementsMovingWithTheSelectionAreSkipped()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
-	 * @see jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
-	 * @see jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#elementsMovingWithTheSelectionAreSkipped()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
 	 */
 	static boolean wireCollidesAlongSpan(Circuit circuit,
 			Set<Element> selected, Element sel, Wire wire) {
@@ -470,7 +470,7 @@ public abstract class SimpleEditor extends JPanel {
 	 * Get the circuit being editted by this editor.
 	 * 
 	 * @return the circuit.
-	 * @see jls.ui.EditorGestureSupport#currentCircuit()
+	 * @jls.testedby jls.ui.EditorGestureSupport#currentCircuit()
 	 */
 	public Circuit getCircuit() {
 
@@ -747,11 +747,11 @@ public abstract class SimpleEditor extends JPanel {
 	 * @param state The current editor state.
 	 * @param selectionSize The number of currently selected elements.
 	 * @return the gesture to perform.
-	 * @see jls.edit.CtrlWGestureTest#idleStartsWireDespiteMultiSelection()
-	 * @see jls.edit.CtrlWGestureTest#idleStartsWireDespiteSingleSelection()
-	 * @see jls.edit.CtrlWGestureTest#idleStartsWireWithEmptySelection()
-	 * @see jls.edit.CtrlWGestureTest#otherStatesDoNothing()
-	 * @see jls.edit.CtrlWGestureTest#watchToggleStillReachableFromSelectedState()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireDespiteMultiSelection()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireDespiteSingleSelection()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireWithEmptySelection()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#otherStatesDoNothing()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#watchToggleStillReachableFromSelectedState()
 	 */
 	static CtrlW ctrlWGesture(State state, int selectionSize) {
 
@@ -787,9 +787,9 @@ public abstract class SimpleEditor extends JPanel {
 	 * @param x The x-coordinate for the wire end.
 	 * @param y The y-coordinate for the wire end.
 	 * @return the new wire end and the pre-clear selection state.
-	 * @see jls.edit.CtrlWGestureTest#overlapFeedbackKeyedOffPreClearSelection()
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
-	 * @see jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#overlapFeedbackKeyedOffPreClearSelection()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
 	 */
 	static WireStart startWireGesture(Circuit circuit, Set<Element> selected,
 			int x, int y) {

--- a/src/jls/edit/UndoManager.java
+++ b/src/jls/edit/UndoManager.java
@@ -78,7 +78,7 @@ final class UndoManager {
 	 *              exactly from the pre-extraction code so undo capacity
 	 *              does not change).
 	 *
-	 * @see jls.edit.UndoManagerTest#pushClampsToTheConfiguredDepth()
+	 * @jls.testedby jls.edit.UndoManagerTest#pushClampsToTheConfiguredDepth()
 	 */
 	UndoManager(IntSupplier depth) {
 
@@ -94,8 +94,8 @@ final class UndoManager {
 	 *
 	 * @param snap The snapshot to push.
 	 *
-	 * @see jls.edit.UndoManagerTest#pushDropsNoOpSnapshots()
-	 * @see jls.edit.UndoManagerTest#pushClampsToTheConfiguredDepth()
+	 * @jls.testedby jls.edit.UndoManagerTest#pushDropsNoOpSnapshots()
+	 * @jls.testedby jls.edit.UndoManagerTest#pushClampsToTheConfiguredDepth()
 	 */
 	public void push(CircuitSnapshot snap) {
 
@@ -120,7 +120,7 @@ final class UndoManager {
 	 * Discard all redo states. Called when a new edit is made: the
 	 * undone future it invalidates can no longer be redone.
 	 *
-	 * @see jls.edit.UndoManagerTest#clearRedosEmptiesTheRedoStack()
+	 * @jls.testedby jls.edit.UndoManagerTest#clearRedosEmptiesTheRedoStack()
 	 */
 	public void clearRedos() {
 
@@ -133,7 +133,7 @@ final class UndoManager {
 	 *
 	 * @return true if a call to {@link #undo} can restore a prior state.
 	 *
-	 * @see jls.edit.UndoManagerTest#undoRequiresMoreThanTheBaseSnapshot()
+	 * @jls.testedby jls.edit.UndoManagerTest#undoRequiresMoreThanTheBaseSnapshot()
 	 */
 	public boolean canUndo() {
 
@@ -145,7 +145,7 @@ final class UndoManager {
 	 *
 	 * @return true if a call to {@link #redo} can reapply an undone state.
 	 *
-	 * @see jls.edit.UndoManagerTest#undoRestoresThePreviousSnapshotAndEnablesRedo()
+	 * @jls.testedby jls.edit.UndoManagerTest#undoRestoresThePreviousSnapshotAndEnablesRedo()
 	 */
 	public boolean canRedo() {
 
@@ -162,8 +162,8 @@ final class UndoManager {
 	 * @return true if a state was restored, false if there was nothing
 	 *         to undo or the restore failed.
 	 *
-	 * @see jls.edit.UndoManagerTest#undoRestoresThePreviousSnapshotAndEnablesRedo()
-	 * @see jls.edit.UndoManagerTest#failedRestoreLeavesTheStacksUntouched()
+	 * @jls.testedby jls.edit.UndoManagerTest#undoRestoresThePreviousSnapshotAndEnablesRedo()
+	 * @jls.testedby jls.edit.UndoManagerTest#failedRestoreLeavesTheStacksUntouched()
 	 */
 	public boolean undo(Restorer restorer) {
 
@@ -193,8 +193,8 @@ final class UndoManager {
 	 * @return true if a state was restored, false if there was nothing
 	 *         to redo or the restore failed.
 	 *
-	 * @see jls.edit.UndoManagerTest#redoReappliesTheUndoneSnapshot()
-	 * @see jls.edit.UndoManagerTest#redoWithNothingUndoneDoesNothing()
+	 * @jls.testedby jls.edit.UndoManagerTest#redoReappliesTheUndoneSnapshot()
+	 * @jls.testedby jls.edit.UndoManagerTest#redoWithNothingUndoneDoesNothing()
 	 */
 	public boolean redo(Restorer restorer) {
 

--- a/src/jls/edit/Viewport.java
+++ b/src/jls/edit/Viewport.java
@@ -47,7 +47,7 @@ import java.awt.geom.Point2D;
  * object; device-scale (HiDPI) factors compose here as well when that
  * work lands.
  *
- * @see jls.edit.ViewportTest
+ * @jls.testedby jls.edit.ViewportTest
  */
 final class Viewport {
 

--- a/src/jls/elem/Adder.java
+++ b/src/jls/elem/Adder.java
@@ -22,15 +22,21 @@ import java.util.*;
 public final class Adder extends LogicElement {
 	
 	// default values
+	/** The default number of bits. */
 	private static final int defaultBits = 1;
-	private static final int defaultPropDelay = 30; 
-	
+	/** The default propagation delay per bit. */
+	private static final int defaultPropDelay = 30;
+
 	// saved properties
+	/** The number of bits in each addend and the sum. */
 	private int bits = defaultBits;
+	/** The propagation delay, in simulated time units. */
 	private int propDelay = defaultPropDelay;
+	/** Which way the adder faces. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
-	
+
 	// running properties
+	/** Whether the user cancelled the creation dialog. */
 	private boolean cancelled;
 
 	/**
@@ -105,6 +111,8 @@ public final class Adder extends LogicElement {
 	/**
 	 * The transform from canonical geometry (RIGHT) to the current
 	 * orientation.
+	 *
+	 * @return the transform chain for the current orientation.
 	 */
 	private GridTransform.Chain placement() {
 
@@ -263,6 +271,7 @@ public final class Adder extends LogicElement {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes: bits, delay, orient (#23). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("bits") {
@@ -325,6 +334,7 @@ public final class Adder extends LogicElement {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order (#23). */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -487,11 +497,17 @@ public final class Adder extends LogicElement {
 	private class AdderCreate extends ElementDialog {
 		
 		// properties
+		/** Field to enter the number of bits. */
 		private JTextField bitsField = new JTextField(defaultBits+"",10);
+		/** Keypad for the bits field. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Button selecting the left orientation. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Button selecting the right orientation (the default). */
 		private JRadioButton right = new JRadioButton("Right", true);
+		/** Button selecting the up orientation. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Button selecting the down orientation. */
 		private JRadioButton down = new JRadioButton("Down");
 		
 		/**
@@ -599,6 +615,7 @@ public final class Adder extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The sum-and-carry value currently propagating through the adder. */
 	private BitSet toBeValue;
 	
 	/**

--- a/src/jls/elem/AndGate.java
+++ b/src/jls/elem/AndGate.java
@@ -17,6 +17,7 @@ import javax.swing.*;
 public final class AndGate extends Gate {
 	
 	// identity and shared previous-settings state (#22)
+	/** The kind descriptor and shared previous-settings state for AND gates. */
 	private static final Kind KIND =
 			new Kind("AND","AndGate",-1,10);
 	

--- a/src/jls/elem/Attribute.java
+++ b/src/jls/elem/Attribute.java
@@ -25,6 +25,8 @@ public abstract class Attribute {
 	protected final String name;
 
 	/**
+	 * Create a new attribute declaration.
+	 *
 	 * @param name The attribute name as it appears in saved files.
 	 */
 	protected Attribute(String name) {
@@ -53,6 +55,9 @@ public abstract class Attribute {
 	/**
 	 * Offer an int value from the loader.
 	 *
+	 * @param el The element to write to.
+	 * @param name The attribute name read from the file.
+	 * @param value The loaded value.
 	 * @return true if this attribute consumed it.
 	 */
 	public boolean setInt(Element el, String name, int value) {
@@ -60,19 +65,40 @@ public abstract class Attribute {
 		return false;
 	} // end of setInt method
 
-	/** Offer a long value from the loader. */
+	/**
+	 * Offer a long value from the loader.
+	 *
+	 * @param el The element to write to.
+	 * @param name The attribute name read from the file.
+	 * @param value The loaded value.
+	 * @return true if this attribute consumed it.
+	 */
 	public boolean setLong(Element el, String name, long value) {
 
 		return false;
 	} // end of setLong method
 
-	/** Offer a BigInteger value from the loader. */
+	/**
+	 * Offer a BigInteger value from the loader.
+	 *
+	 * @param el The element to write to.
+	 * @param name The attribute name read from the file.
+	 * @param value The loaded value.
+	 * @return true if this attribute consumed it.
+	 */
 	public boolean setBigInt(Element el, String name, BigInteger value) {
 
 		return false;
 	} // end of setBigInt method
 
-	/** Offer a String value from the loader. */
+	/**
+	 * Offer a String value from the loader.
+	 *
+	 * @param el The element to write to.
+	 * @param name The attribute name read from the file.
+	 * @param value The loaded value.
+	 * @return true if this attribute consumed it.
+	 */
 	public boolean setString(Element el, String name, String value) {
 
 		return false;
@@ -84,6 +110,8 @@ public abstract class Attribute {
 	public abstract static class IntAttribute extends Attribute {
 
 		/**
+		 * Create a new int-typed attribute declaration.
+		 *
 		 * @param name The attribute name as it appears in saved files.
 		 */
 		protected IntAttribute(String name) {
@@ -107,7 +135,12 @@ public abstract class Attribute {
 		 */
 		protected abstract void set(Element el, int value);
 
-		/** Override to skip the save line (defaults, recomputed values). */
+		/**
+		 * Override to skip the save line (defaults, recomputed values).
+		 *
+		 * @param el The element to read from.
+		 * @return true if the save line should be omitted.
+		 */
 		protected boolean omitted(Element el) {
 
 			return false;
@@ -156,6 +189,8 @@ public abstract class Attribute {
 	public abstract static class BigIntAttribute extends Attribute {
 
 		/**
+		 * Create a new BigInteger-typed attribute declaration.
+		 *
 		 * @param name The attribute name as it appears in saved files.
 		 */
 		protected BigIntAttribute(String name) {
@@ -232,6 +267,8 @@ public abstract class Attribute {
 	public abstract static class StringAttribute extends Attribute {
 
 		/**
+		 * Create a new String-typed attribute declaration.
+		 *
 		 * @param name The attribute name as it appears in saved files.
 		 */
 		protected StringAttribute(String name) {
@@ -255,7 +292,12 @@ public abstract class Attribute {
 		 */
 		protected abstract void set(Element el, String value);
 
-		/** Override to skip the save line. */
+		/**
+		 * Override to skip the save line.
+		 *
+		 * @param el The element to read from.
+		 * @return true if the save line should be omitted.
+		 */
 		protected boolean omitted(Element el) {
 
 			return false;
@@ -309,6 +351,8 @@ public abstract class Attribute {
 	public abstract static class OrientationAttribute extends StringAttribute {
 
 		/**
+		 * Create a new orientation attribute declaration.
+		 *
 		 * @param name The attribute name as it appears in saved files.
 		 */
 		protected OrientationAttribute(String name) {

--- a/src/jls/elem/Clock.java
+++ b/src/jls/elem/Clock.java
@@ -19,13 +19,17 @@ import javax.swing.*;
 public final class Clock extends LogicElement {
 	
 	// default values
+	/** The cycle time offered by the creation dialog's keypad. */
 	private static int defaultCycleTime = 2;
+	/** The one time offered by the creation dialog's keypad. */
 	private static int defaultOneTime = defaultCycleTime/2;
-	
+
 	// one constraint string, two surfaces: dialog and loader (issue #52);
 	// non-positive times cause a zero-delay repost livelock at t=0
+	/** Constraint message for a non-positive cycle time. */
 	static final String CYCLE_CONSTRAINT =
 			"Cycle time must be a positive number of time units";
+	/** Constraint message for an invalid one time. */
 	static final String ONE_CONSTRAINT =
 			"One time must be positive and less than the cycle time";
 
@@ -61,9 +65,13 @@ public final class Clock extends LogicElement {
 	} // end of checkOneTime method
 
 	// properties
+	/** The clock period, in simulated time units. */
 	private int cycleTime = defaultCycleTime;
+	/** The number of time units per cycle the output is 1. */
 	private int oneTime = defaultOneTime;
+	/** Which way the output pin faces. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
+	/** Whether the user cancelled the creation or change dialog. */
 	private boolean cancelled;
 	
 	/**
@@ -213,6 +221,7 @@ public final class Clock extends LogicElement {
 
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes: cycle, one, orient (#23). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("cycle") {
@@ -293,6 +302,7 @@ public final class Clock extends LogicElement {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order (#23). */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -424,13 +434,21 @@ public final class Clock extends LogicElement {
 	private class ClockCreate extends ElementDialog {
 
 		// properties
+		/** Field to enter the cycle time. */
 		private JTextField cycleTimeField = new JTextField(cycleTime+"",10);
+		/** Field to enter the one time. */
 		private JTextField oneTimeField = new JTextField(oneTime+"",10);
+		/** Keypad for the cycle time field. */
 		private KeyPad cycleTimePad = new KeyPad(cycleTimeField,10,defaultCycleTime,this);
+		/** Keypad for the one time field. */
 		private KeyPad oneTimePad = new KeyPad(oneTimeField,10,defaultOneTime,this);
+		/** Button selecting the left orientation. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Button selecting the right orientation (the default). */
 		private JRadioButton right = new JRadioButton("Right", true);
+		/** Button selecting the up orientation. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Button selecting the down orientation. */
 		private JRadioButton down = new JRadioButton("Down");
 		
 		/**

--- a/src/jls/elem/Clock.java
+++ b/src/jls/elem/Clock.java
@@ -36,7 +36,7 @@ public final class Clock extends LogicElement {
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#clockCycleTimeRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#clockCycleTimeRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkCycleTime(int cycleTime) {
 
@@ -53,7 +53,7 @@ public final class Clock extends LogicElement {
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#clockOneTimeRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#clockOneTimeRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkOneTime(int cycleTime, int oneTime) {
 

--- a/src/jls/elem/Constant.java
+++ b/src/jls/elem/Constant.java
@@ -23,19 +23,29 @@ import java.util.*;
 public final class Constant extends LogicElement implements ActionListener {
 	
 	// named constants
+	/** Default constant value. */
 	private static final BigInteger defaultValue = BigInteger.ZERO;
+	/** Default display radix. */
 	private static final int defaultBase = 10;
 	
 	// saved properties
+	/** The value this constant outputs. */
 	private BigInteger value = defaultValue;
+	/** The radix the value is displayed in (2, 10 or 16). */
 	private int base = defaultBase;
+	/** Which way this constant faces. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
 	
 	// running properties
+	/** Value of the previously created constant. */
 	private static BigInteger previousValue = defaultValue;
+	/** Display radix of the previously created constant. */
 	private static int previousBase = defaultBase;
+	/** Orientation of the previously created constant. */
 	private static JLSInfo.Orientation previousOrientation = JLSInfo.Orientation.RIGHT;
+	/** True if the creation or change dialog was cancelled. */
 	private boolean cancelled;
+	/** True if a changed value no longer fits, so the element must resize. */
 	private boolean changed;
 	
 	/**
@@ -173,6 +183,7 @@ public final class Constant extends LogicElement implements ActionListener {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** The persistence attributes specific to constants. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.BigIntAttribute("value") {
@@ -242,6 +253,7 @@ public final class Constant extends LogicElement implements ActionListener {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -392,15 +404,25 @@ public final class Constant extends LogicElement implements ActionListener {
 	private class ConstantCreate extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Button to repeat the previously created constant's settings. */
 		private JButton repeat;
+		/** Text field for the constant's value. */
 		private JTextField valueField = new JTextField(defaultValue+"",defaultBase);
+		/** Keypad for the value field. */
 		private KeyPad valuePad = new KeyPad(valueField,16,defaultValue.longValue(),this);
+		/** Binary radix choice. */
 		private JRadioButton base2 = new JRadioButton("2");
+		/** Decimal radix choice. */
 		private JRadioButton base10 = new JRadioButton("10");
+		/** Hexadecimal radix choice. */
 		private JRadioButton base16 = new JRadioButton("16");
+		/** Left orientation choice. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Right orientation choice. */
 		private JRadioButton right = new JRadioButton("Right", true);
+		/** Up orientation choice. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Down orientation choice. */
 		private JRadioButton down = new JRadioButton("Down");
 		
 		/**
@@ -644,6 +666,7 @@ public final class Constant extends LogicElement implements ActionListener {
 	
 	} // end of change method
 	
+	/** Graphics object saved by the change method for use by valueFits. */
 	private Graphics saveg;	// saved by change method, used by valueFits method
 	
 	/**
@@ -671,10 +694,15 @@ public final class Constant extends LogicElement implements ActionListener {
 	private class ConstantChange extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Text field for the constant's new value. */
 		private JTextField valueField = new JTextField(Util.convert(value,base,false),10);
+		/** Keypad for the value field. */
 		private KeyPad valuePad = new KeyPad(valueField,16,defaultValue.longValue(),this);
+		/** Binary radix choice. */
 		private JRadioButton base2 = new JRadioButton("2");
+		/** Decimal radix choice. */
 		private JRadioButton base10 = new JRadioButton("10");
+		/** Hexadecimal radix choice. */
 		private JRadioButton base16 = new JRadioButton("16");
 		
 		/**
@@ -831,12 +859,19 @@ public final class Constant extends LogicElement implements ActionListener {
 		return true;
 	} // end of quickChange method
 	
+	/** The editor to reset after a quick change. */
 	private SimpleEditor sed;
+	/** Quick-change shortcut menu. */
 	private JMenu quick = new JMenu("shortcuts");
+	/** Menu item to set the value to 0. */
 	private JMenuItem zero = new JMenuItem("0");
+	/** Menu item to set the value to 1. */
 	private JMenuItem one = new JMenuItem("1");
+	/** Menu item to add 1 to the value. */
 	private JMenuItem plus = new JMenuItem("add 1");
+	/** Menu item to subtract 1 from the value (but not below 0). */
 	private JMenuItem minus = new JMenuItem("subtract 1");
+	/** True once the quick-change menu has been built. */
 	private boolean menuMade = false;
 	
 	/**

--- a/src/jls/elem/Decoder.java
+++ b/src/jls/elem/Decoder.java
@@ -46,18 +46,26 @@ import jls.util.Placement;
 public final class Decoder extends LogicElement {
 	
 	// default values
+	/** Default number of input bits. */
 	private static final int defaultBits = 1;
+	/** Default propagation delay. */
 	private static final int defaultPropDelay = 15; 
 	
 	// saved properties
+	/** Number of input bits (the decoder has 2^bits outputs). */
 	private int bits = defaultBits;
+	/** Propagation delay of this decoder. */
 	private int propDelay = defaultPropDelay;
 	//Orientation is based off of where the inputs are
+	/** Which side the input is on. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.LEFT;
 	
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
+	/** The "decoder" label drawn on the element, abbreviated to "dec" if it doesn't fit. */
 	private String dec;
+	/** The input/output width label drawn on the element (e.g. "1-n"), oriented to match the element. */
 	private String inout;
 	
 	/**
@@ -242,6 +250,7 @@ public final class Decoder extends LogicElement {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes: bits, delay and orientation. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("bits") {
@@ -304,6 +313,7 @@ public final class Decoder extends LogicElement {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -464,11 +474,17 @@ public final class Decoder extends LogicElement {
 	private class DecoderCreate extends ElementDialog {
 
 		// properties
+		/** Text field for the number of input bits. */
 		private JTextField bitsField = new JTextField(defaultBits+"",10);
+		/** Pop-up numeric keypad attached to the bits field. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Selects input-on-the-left orientation (the default). */
 		private JRadioButton left = new JRadioButton("Left", true);
+		/** Selects input-on-the-right orientation. */
 		private JRadioButton right = new JRadioButton("Right");
+		/** Selects input-on-top orientation. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Selects input-on-the-bottom orientation. */
 		private JRadioButton down = new JRadioButton("Down");
 		
 		/**
@@ -573,6 +589,7 @@ public final class Decoder extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The output value this decoder will take on once its propagation delay elapses. */
 	private BitSet toBeValue;
 	
 	/**

--- a/src/jls/elem/DelayGate.java
+++ b/src/jls/elem/DelayGate.java
@@ -23,6 +23,7 @@ import java.util.*;
 public final class DelayGate extends Gate {
 	
 	// identity (#22); previous-settings unused: DELAY has its own dialog
+	/** The kind descriptor (names and pin counts) for DELAY gates. */
 	private static final Kind KIND =
 			new Kind("DELAY","DelayGate",1,0);
 	
@@ -36,6 +37,7 @@ public final class DelayGate extends Gate {
 	} // end of kind method
 	
 	// default values
+	/** Default propagation delay shown in the creation dialog. */
 	private static final int defaultPropDelay = 1;
 	
 	/**
@@ -121,13 +123,21 @@ public final class DelayGate extends Gate {
 	private class DelayCreate extends ElementDialog {
 
 			// properties
+			/** Text field for the propagation delay. */
 			private JTextField delayField = new JTextField(defaultPropDelay+"",5);
+			/** Text field for the number of gates (bits). */
 			private JTextField gatesField = new JTextField(defaultBits+"",5);
+			/** Pop-up keypad for the delay field. */
 			private KeyPad delayPad = new KeyPad(delayField,10,defaultPropDelay,this);
+			/** Pop-up keypad for the gates field. */
 			private KeyPad gatesPad = new KeyPad(gatesField,10,defaultBits,this);
+			/** Button selecting leftward orientation. */
 			private JRadioButton left = new JRadioButton("left");
+			/** Button selecting upward orientation. */
 			private JRadioButton up = new JRadioButton("up");
+			/** Button selecting downward orientation. */
 			private JRadioButton down = new JRadioButton("down");
+			/** Button selecting rightward orientation. */
 			private JRadioButton right = new JRadioButton("right");
 
 			/**

--- a/src/jls/elem/Display.java
+++ b/src/jls/elem/Display.java
@@ -388,10 +388,15 @@ public final class Display extends LogicElement {
 	protected class DispCreate extends ElementDialog {
 
 		// properties
+		/** Text field for entering the number of input bits. */
 		private JTextField bitsField = new JTextField(defaultBits+"",5);
+		/** Pop-up keypad for the bits field. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Radio button selecting base 2 (binary) display. */
 		private JRadioButton b2 = new JRadioButton("2");
+		/** Radio button selecting base 10 (decimal) display. */
 		private JRadioButton b10 = new JRadioButton("10");
+		/** Radio button selecting base 16 (hexadecimal) display. */
 		private JRadioButton b16 = new JRadioButton("16");
 		
 		/**

--- a/src/jls/elem/Display.java
+++ b/src/jls/elem/Display.java
@@ -46,16 +46,21 @@ import jls.util.Placement;
 public final class Display extends LogicElement {
 	
 	// constants
+	/** The input width a new display starts with. */
 	private final int defaultBits = 1;
 	
 	// properties
+	/** The width of the displayed input, in bits. */
 	private int bits = defaultBits;
+	/** The radix (2, 10 or 16) the value is displayed in. */
 	private int base = 10;
 	
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled = false;
 	
 	// legacy
+	/** Legacy single-input orientation marker; -1 means "new save format". */
 	int orient = -1;
 	
 	/**
@@ -239,6 +244,7 @@ public final class Display extends LogicElement {
 
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own persisted attributes, in save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("bits") {
@@ -298,6 +304,7 @@ public final class Display extends LogicElement {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -487,6 +494,7 @@ public final class Display extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The value being displayed; null shows as HiZ. */
 	private BitSet currentValue = new BitSet();
 	
 	/**

--- a/src/jls/elem/DisplayBool.java
+++ b/src/jls/elem/DisplayBool.java
@@ -15,9 +15,13 @@ import java.util.*;
 public final class DisplayBool extends JPanel implements MouseListener {
 
 	// properties
+	/** The truth table element this display is a part of. */
 	private TruthTable ttelem;
+	/** The displayed entries, indexed by row and column. */
 	private Entry [][] dtable;
+	/** Number of rows in the displayed table. */
 	private int rows;
+	/** Number of columns in the displayed table. */
 	private int cols;
 	
 	/**

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -22,8 +22,11 @@ public abstract sealed class Element
 		permits DisplayElement, LogicElement, Wire {
 
 	// saved properties
+	/** The file-local reference index, reassigned on every save. */
 	private int id; 						// file-local reference index, reassigned on every save
+	/** The permanent identity of this element (#165). */
 	private ElementId stableId = ElementId.mintFresh(); // permanent identity (#165)
+	/** Whether stableId was declared by the loaded file. */
 	private boolean stableIdFromFile = false; // whether stableId was declared by the loaded file
 	/** The x-coordinate of the upper left corner of this element. */
 	protected int x; 						// upper left corner of element
@@ -33,13 +36,17 @@ public abstract sealed class Element
 	protected int width = 0; 				// size of element
 	/** The height of this element in pixels. */
 	protected int height = 0;
+	/** Whether editing of this element is disallowed. */
 	private boolean uneditable = false;		// to keep others from editing this element
+	/** The position of this element in the signal trace (-1 if none). */
 	private int tracePosition = -1;			// position in signal trace (-1 if none)
 
 	// running properties
 	/** Whether this element should be drawn highlighted. */
 	protected boolean highlight = false;	// whether the elements should be drawn highlighted
+	/** The saved x-coordinate, restored after an aborted move. */
 	private int savex;						// so it can be put back after an aborted move
+	/** The saved y-coordinate, restored after an aborted move. */
 	private int savey;
 	/** The circuit this element is part of. */
 	protected Circuit circuit;				// the circuit this element is part of
@@ -183,6 +190,7 @@ public abstract sealed class Element
 
 	// The attributes every element saves, in their historical save order
 	// (#23). One declaration drives save, copy, and load dispatch.
+	/** The attributes every element saves, in historical save order (#23). */
 	private static final java.util.List<Attribute> BASE_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("id") {
@@ -945,7 +953,9 @@ public abstract sealed class Element
 	private class DelayChange extends ElementDialog {
 
 		// properties
+		/** Field to enter the delay or access time. */
 		private JTextField delayField = new JTextField(10);
+		/** Keypad for the delay field. */
 		private KeyPad delayPad = new KeyPad(delayField,10,0,this);
 
 		/**

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -25,17 +25,23 @@ public abstract sealed class Element
 	private int id; 						// file-local reference index, reassigned on every save
 	private ElementId stableId = ElementId.mintFresh(); // permanent identity (#165)
 	private boolean stableIdFromFile = false; // whether stableId was declared by the loaded file
+	/** The x-coordinate of the upper left corner of this element. */
 	protected int x; 						// upper left corner of element
+	/** The y-coordinate of the upper left corner of this element. */
 	protected int y;						//   (snap-to position for most elements)
+	/** The width of this element in pixels. */
 	protected int width = 0; 				// size of element
+	/** The height of this element in pixels. */
 	protected int height = 0;
 	private boolean uneditable = false;		// to keep others from editing this element
 	private int tracePosition = -1;			// position in signal trace (-1 if none)
 
 	// running properties
+	/** Whether this element should be drawn highlighted. */
 	protected boolean highlight = false;	// whether the elements should be drawn highlighted
 	private int savex;						// so it can be put back after an aborted move
 	private int savey;
+	/** The circuit this element is part of. */
 	protected Circuit circuit;				// the circuit this element is part of
 
 	/**
@@ -43,7 +49,7 @@ public abstract sealed class Element
 	 * 
 	 * @param circuit The circuit this element is part of.
 	 *
-	 * @see jls.ui.UiHarnessPilotTest.EveryAssertionCanFail#onGridFails()
+	 * @jls.testedby jls.ui.UiHarnessPilotTest.EveryAssertionCanFail#onGridFails()
 	 */
 	public Element(Circuit circuit) {
 
@@ -53,7 +59,14 @@ public abstract sealed class Element
 	/**
 	 * Set up this element (overridden by most elements).
 	 *
-	 * @see jls.ui.DialogConstructionSmokeTest#constructAndCancel()
+	 * @param g The Graphics object to use to initialize sizes.
+	 * @param editWindow The editor window this element will be displayed in.
+	 * @param x The x-coordinate of the last known mouse position.
+	 * @param y The y-coordinate of the last known mouse position.
+	 *
+	 * @return false if cancelled, true otherwise (this default implementation always returns false).
+	 *
+	 * @jls.testedby jls.ui.DialogConstructionSmokeTest#constructAndCancel()
 	 */
 	public boolean setup(Graphics g, JPanel editWindow, int x, int y) {
 
@@ -66,7 +79,7 @@ public abstract sealed class Element
 	 * @param x The x-coordinate of the upper left corner of this element.
 	 * @param y The y-coordinate of the upper left corner of this element.
 	 *
-	 * @see jls.ui.UiHarnessPilotTest.EveryAssertionCanFail#onGridFails()
+	 * @jls.testedby jls.ui.UiHarnessPilotTest.EveryAssertionCanFail#onGridFails()
 	 */
 	public void setXY(int x, int y) {
 
@@ -109,17 +122,17 @@ public abstract sealed class Element
 	 * 
 	 * @return the x-coordinate.
 	 *
-	 * @see jls.StableElementIdTest#sidsByLogicalElement()
-	 * @see jls.edit.TriStateBundleConnectTest#elementAt()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.ui.CircuitAssert#describe()
-	 * @see jls.ui.EditorGestureTest#centerX()
-	 * @see jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
-	 * @see jls.ui.EditorGestureTest#pressAndDragMovesAnElement()
-	 * @see jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
-	 * @see jls.ui.GeometryAssert#assertElementAt()
-	 * @see jls.ui.GeometryAssert#assertOnGrid()
+	 * @jls.testedby jls.StableElementIdTest#sidsByLogicalElement()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#elementAt()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.ui.CircuitAssert#describe()
+	 * @jls.testedby jls.ui.EditorGestureTest#centerX()
+	 * @jls.testedby jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
+	 * @jls.testedby jls.ui.EditorGestureTest#pressAndDragMovesAnElement()
+	 * @jls.testedby jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
+	 * @jls.testedby jls.ui.GeometryAssert#assertElementAt()
+	 * @jls.testedby jls.ui.GeometryAssert#assertOnGrid()
 	 */
 	public int getX() {
 
@@ -131,17 +144,17 @@ public abstract sealed class Element
 	 * 
 	 * @return the y-coordinate.
 	 *
-	 * @see jls.StableElementIdTest#sidsByLogicalElement()
-	 * @see jls.edit.TriStateBundleConnectTest#elementAt()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.ui.CircuitAssert#describe()
-	 * @see jls.ui.EditorGestureTest#centerY()
-	 * @see jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
-	 * @see jls.ui.EditorGestureTest#pressAndDragMovesAnElement()
-	 * @see jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
-	 * @see jls.ui.GeometryAssert#assertElementAt()
-	 * @see jls.ui.GeometryAssert#assertOnGrid()
+	 * @jls.testedby jls.StableElementIdTest#sidsByLogicalElement()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#elementAt()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.ui.CircuitAssert#describe()
+	 * @jls.testedby jls.ui.EditorGestureTest#centerY()
+	 * @jls.testedby jls.ui.EditorGestureTest#movingOneOfTwoElementsLeavesTheOtherPut()
+	 * @jls.testedby jls.ui.EditorGestureTest#pressAndDragMovesAnElement()
+	 * @jls.testedby jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
+	 * @jls.testedby jls.ui.GeometryAssert#assertElementAt()
+	 * @jls.testedby jls.ui.GeometryAssert#assertOnGrid()
 	 */
 	public int getY() {
 
@@ -380,8 +393,10 @@ public abstract sealed class Element
 
 	/**
 	 * Initialize internal information for this element.
-	 * 
+	 *
 	 * @param g The graphics object to use.
+	 *
+	 * @throws Exception always, unless overridden by a subclass.
 	 */
 	public void init(Graphics g) throws Exception{
 		throw new Exception("ERROR: using undefined function from " + this.getName());
@@ -390,9 +405,11 @@ public abstract sealed class Element
 	/**
 	 * Placeholder for element copies.
 	 *
-	 * @see jls.AllElementsRoundTripTest#copyPreservesEverySavedAttribute()
-	 * @see jls.StableElementIdTest#copyMintsAFreshId()
-	 * @see jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
+	 * @return a copy of this element, or null from this placeholder implementation.
+	 *
+	 * @jls.testedby jls.AllElementsRoundTripTest#copyPreservesEverySavedAttribute()
+	 * @jls.testedby jls.StableElementIdTest#copyMintsAFreshId()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
 	 */
 	public Element copy() {
 
@@ -435,11 +452,11 @@ public abstract sealed class Element
 	 * @param dx Distance to move in the x-direction.
 	 * @param dy Distance to move in the y-direction.
 	 *
-	 * @see jls.DeterministicSaveTest#stateHashIsContentDetermined()
-	 * @see jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
-	 * @see jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
-	 * @see jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
-	 * @see jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
+	 * @jls.testedby jls.DeterministicSaveTest#stateHashIsContentDetermined()
+	 * @jls.testedby jls.DrawCullingParityTest#culledCandidatesMatchFullScan()
+	 * @jls.testedby jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
+	 * @jls.testedby jls.SpatialIndexTest#staysExactAfterMovesAndInvalidation()
+	 * @jls.testedby jls.edit.CircuitSnapshotTest#changedCircuitSnapshotsDifferently()
 	 */
 	public void move(int dx, int dy) {
 
@@ -462,10 +479,10 @@ public abstract sealed class Element
 	 * 
 	 * @return true if the point is in the display area, false if not.
 	 *
-	 * @see jls.SpatialIndexTest#everyContainingElementIsACandidate()
-	 * @see jls.SpatialIndexTest#reportsIndexVsScanTiming()
-	 * @see jls.elem.HollowVsFilledCollisionTest#containerInteriorDoesCollide()
-	 * @see jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
+	 * @jls.testedby jls.SpatialIndexTest#everyContainingElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#reportsIndexVsScanTiming()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#containerInteriorDoesCollide()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
 	 */
 	public boolean contains(int x, int y) {
 
@@ -480,14 +497,14 @@ public abstract sealed class Element
 	 *
 	 * @return true if this element intersects the other, false if not.
 	 *
-	 * @see jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
-	 * @see jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
-	 * @see jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
-	 * @see jls.elem.HollowVsFilledCollisionTest#containerInteriorDoesCollide()
-	 * @see jls.elem.HollowVsFilledCollisionTest#cornerCollisionIsAttributedToTheWireEnd()
-	 * @see jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
-	 * @see jls.elem.HollowVsFilledCollisionTest#edgeCrossingCollidesWithThatWireOnly()
-	 * @see jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#containerInteriorDoesCollide()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#cornerCollisionIsAttributedToTheWireEnd()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#edgeCrossingCollidesWithThatWireOnly()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#hollowInteriorDoesNotCollide()
 	 */
 	public boolean intersects(Element other) {
 
@@ -519,7 +536,7 @@ public abstract sealed class Element
 	 * 
 	 * @return true if the element is inside, false if not.
 	 *
-	 * @see jls.SpatialIndexTest#everyInsideElementIsACandidate()
+	 * @jls.testedby jls.SpatialIndexTest#everyInsideElementIsACandidate()
 	 */
 	public boolean isInside(Rectangle rect) {
 
@@ -532,7 +549,7 @@ public abstract sealed class Element
 	 * 
 	 * @param light True if item should be highlighted, false otherwise.
 	 *
-	 * @see jls.edit.CtrlWGestureTest#hoverSelect()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#hoverSelect()
 	 */
 	public void setHighlight(boolean light) {
 
@@ -547,7 +564,7 @@ public abstract sealed class Element
 	 *
 	 * @return true if highlighted.
 	 *
-	 * @see jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
+	 * @jls.testedby jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
 	 */
 	public boolean isHighlighted() {
 
@@ -559,11 +576,11 @@ public abstract sealed class Element
 	 *
 	 * @param id The id.
 	 *
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
-	 * @see jls.elem.AttributePersistenceTest#savedBytesMatchTheHandwrittenFormat()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
-	 * @see jls.elem.GroupOrientationTest#orientOf()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#copyIsFieldEquivalent()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#savedBytesMatchTheHandwrittenFormat()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.elem.GroupOrientationTest#orientOf()
 	 */
 	public void setID(int id) {
 
@@ -577,10 +594,10 @@ public abstract sealed class Element
 	 *
 	 * @return the stable id.
 	 *
-	 * @see jls.StableElementIdTest#copyMintsAFreshId()
-	 * @see jls.StableElementIdTest#idsAreUniqueWithinACircuit()
-	 * @see jls.StableElementIdTest#mintedIdsSkipIdsTheFileAlreadyUses()
-	 * @see jls.StableElementIdTest#sidsByLogicalElement()
+	 * @jls.testedby jls.StableElementIdTest#copyMintsAFreshId()
+	 * @jls.testedby jls.StableElementIdTest#idsAreUniqueWithinACircuit()
+	 * @jls.testedby jls.StableElementIdTest#mintedIdsSkipIdsTheFileAlreadyUses()
+	 * @jls.testedby jls.StableElementIdTest#sidsByLogicalElement()
 	 */
 	public ElementId getStableId() {
 
@@ -617,10 +634,10 @@ public abstract sealed class Element
 	 * 
 	 * @param output The print writer to use.
 	 *
-	 * @see jls.AllElementsRoundTripTest#saveElement()
-	 * @see jls.StringEscapeRoundTripTest#roundTrip()
-	 * @see jls.elem.AttributePersistenceTest#saveElement()
-	 * @see jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
+	 * @jls.testedby jls.AllElementsRoundTripTest#saveElement()
+	 * @jls.testedby jls.StringEscapeRoundTripTest#roundTrip()
+	 * @jls.testedby jls.elem.AttributePersistenceTest#saveElement()
+	 * @jls.testedby jls.elem.DisplayLegacyOrientTest#loadAndSaveElement()
 	 */
 	public void save(PrintWriter output) {
 
@@ -649,7 +666,7 @@ public abstract sealed class Element
 	 * 
 	 * @param g The Graphics object to draw with.
 	 *
-	 * @see jls.elem.MuxSymbolTest#render()
+	 * @jls.testedby jls.elem.MuxSymbolTest#render()
 	 */
 	public void draw(Graphics g) {
 
@@ -674,7 +691,13 @@ public abstract sealed class Element
 	/**
 	 * Get put near given x,y position (if one) - overridden.
 	 *
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @param x The x-coordinate of the position.
+	 * @param y The y-coordinate of the position.
+	 *
+	 * @return the put near the given position, or null if there is none
+	 * 		(this default implementation always returns null).
+	 *
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
 	 */
 	public Put getPut(int x, int y) {
 
@@ -693,6 +716,8 @@ public abstract sealed class Element
 	/**
 	 * See if this element is touching (for possible connections).
 	 * This is overridden in wire ends.
+	 *
+	 * @return true if touching, false if not (this default implementation always returns false).
 	 */
 	public boolean isTouching() {
 
@@ -710,10 +735,10 @@ public abstract sealed class Element
 	 * 
 	 * @return a set of all inputs and outputs.
 	 *
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
-	 * @see jls.edit.DragCandidateBoundTest#putLocations()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#putLocations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
 	 */
 	public Set<Put> getAllPuts() { return new HashSet<Put>(); }
 
@@ -722,18 +747,18 @@ public abstract sealed class Element
 	 *  
 	 * @return the bounding rectangle.
 	 *
-	 * @see jls.elem.GroupOrientationTest#horizontalGeometryIsUnchanged()
-	 * @see jls.elem.GroupOrientationTest#verticalBinderLoadsWithVerticalGeometry()
-	 * @see jls.elem.GroupOrientationTest#verticalSplitterLoadsWithVerticalGeometry()
-	 * @see jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
-	 * @see jls.elem.HollowVsFilledCollisionTest#indexShortlistsMatchOutlineGeometry()
-	 * @see jls.elem.OrientationGeometryTest#describe()
-	 * @see jls.ui.EditorGestureTest#centerX()
-	 * @see jls.ui.EditorGestureTest#centerY()
-	 * @see jls.ui.GeometryAssert#assertAbove()
-	 * @see jls.ui.GeometryAssert#assertDimensions()
-	 * @see jls.ui.GeometryAssert#assertLeftOf()
-	 * @see jls.ui.GeometryAssert#assertWithinGridUnits()
+	 * @jls.testedby jls.elem.GroupOrientationTest#horizontalGeometryIsUnchanged()
+	 * @jls.testedby jls.elem.GroupOrientationTest#verticalBinderLoadsWithVerticalGeometry()
+	 * @jls.testedby jls.elem.GroupOrientationTest#verticalSplitterLoadsWithVerticalGeometry()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#diagonalWireIsCandidateButNotCollisionOffTheDiagonal()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#indexShortlistsMatchOutlineGeometry()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.ui.EditorGestureTest#centerX()
+	 * @jls.testedby jls.ui.EditorGestureTest#centerY()
+	 * @jls.testedby jls.ui.GeometryAssert#assertAbove()
+	 * @jls.testedby jls.ui.GeometryAssert#assertDimensions()
+	 * @jls.testedby jls.ui.GeometryAssert#assertLeftOf()
+	 * @jls.testedby jls.ui.GeometryAssert#assertWithinGridUnits()
 	 */
 	public Rectangle getRect() {
 
@@ -749,10 +774,10 @@ public abstract sealed class Element
 	 *
 	 * @return the index bounds.
 	 *
-	 * @see jls.DrawCullingParityTest#mayBeVisible()
-	 * @see jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
-	 * @see jls.ProofBridgeTest#a5DrawMarginAndMayBeVisibleMatchModel()
-	 * @see jls.SpatialIndexTest#bruteForceNear()
+	 * @jls.testedby jls.DrawCullingParityTest#mayBeVisible()
+	 * @jls.testedby jls.ProofBridgeTest#a1IndexIntervalsAreNonEmpty()
+	 * @jls.testedby jls.ProofBridgeTest#a5DrawMarginAndMayBeVisibleMatchModel()
+	 * @jls.testedby jls.SpatialIndexTest#bruteForceNear()
 	 */
 	public Rectangle getIndexBounds() {
 
@@ -774,8 +799,8 @@ public abstract sealed class Element
 	 * 
 	 * @return The put.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freeInput()
-	 * @see jls.edit.TriStateBundleConnectTest#nonGroupPutsNeverMix()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freeInput()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#nonGroupPutsNeverMix()
 	 */
 	public Put getPut(String name) {
 
@@ -826,8 +851,10 @@ public abstract sealed class Element
 	 * Overridden by elements that can do it.
 	 * Should never be called.
 	 * 
+	 * @param sed The simple editor the menu item will be used in.
+	 *
 	 * @return a menu item (can be a menu with submenu items)
-	 * 
+	 *
 	 * @throws UnsupportedOperationException if called and not overridden.
 	 */
 	public JMenuItem setupQuickMenu(SimpleEditor sed) {
@@ -1019,7 +1046,7 @@ public abstract sealed class Element
 	 * 
 	 * @return false.
 	 *
-	 * @see jls.ui.CircuitAssert#assertWatched()
+	 * @jls.testedby jls.ui.CircuitAssert#assertWatched()
 	 */
 	public boolean isWatched() {
 

--- a/src/jls/elem/ElementDialog.java
+++ b/src/jls/elem/ElementDialog.java
@@ -76,7 +76,9 @@ public abstract class ElementDialog extends JDialog {
 	 */
 	protected static final class Violation {
 
+		/** The constraint message, stated in domain terms. */
 		private final String message;
+		/** The offending form field, or null for a structural violation. */
 		private final JComponent field;
 
 		/**

--- a/src/jls/elem/ElementDialog.java
+++ b/src/jls/elem/ElementDialog.java
@@ -62,6 +62,7 @@ public abstract class ElementDialog extends JDialog {
 	/** Inline validation-error message; hidden until an OK is rejected. */
 	private final JLabel errorLabel = new JLabel();
 
+	/** The help topic id for the Help button, or null for no Help button. */
 	private final String helpTopic;
 
 	/** True once finishDialog packed the window (so error messages repack). */
@@ -91,6 +92,8 @@ public abstract class ElementDialog extends JDialog {
 		} // end of constructor
 
 		/**
+		 * Get the constraint message.
+		 *
 		 * @return the constraint message.
 		 */
 		public String getMessage() {
@@ -99,6 +102,8 @@ public abstract class ElementDialog extends JDialog {
 		} // end of getMessage method
 
 		/**
+		 * Get the form field holding the offending value.
+		 *
 		 * @return the offending form field, or null.
 		 */
 		public JComponent getField() {

--- a/src/jls/elem/ElementId.java
+++ b/src/jls/elem/ElementId.java
@@ -180,7 +180,9 @@ public final class ElementId implements Comparable<ElementId> {
 		};
 	} // end of pinForTesting method
 
+	/** The replica id that minted this identity. */
 	private final String replica;
+	/** The creation counter within the minting replica. */
 	private final long counter;
 
 	/**

--- a/src/jls/elem/ElementId.java
+++ b/src/jls/elem/ElementId.java
@@ -95,11 +95,11 @@ public final class ElementId implements Comparable<ElementId> {
 	 *
 	 * @return the resolved replica id.
 	 *
-	 * @see jls.elem.ElementIdReplicaTest#overrideWinsOverEverything()
-	 * @see jls.elem.ElementIdReplicaTest#environmentBeatsPersistedConfig()
-	 * @see jls.elem.ElementIdReplicaTest#persistedReplicaIsReadBack()
-	 * @see jls.elem.ElementIdReplicaTest#freshDrawIsPersistedAndReused()
-	 * @see jls.elem.ElementIdReplicaTest#invalidCandidatesAreSkipped()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#overrideWinsOverEverything()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#environmentBeatsPersistedConfig()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#persistedReplicaIsReadBack()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#freshDrawIsPersistedAndReused()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#invalidCandidatesAreSkipped()
 	 */
 	static String resolveReplica(String override, String env,
 			java.nio.file.Path persisted) {
@@ -164,8 +164,8 @@ public final class ElementId implements Comparable<ElementId> {
 	 *
 	 * @return a handle that restores the previous replica and counter.
 	 *
-	 * @see jls.elem.ElementIdReplicaTest#pinnedConstructionMintsReproducibleIds()
-	 * @see jls.elem.ElementIdReplicaTest#pinnedFromScratchSavesAreByteIdentical()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#pinnedConstructionMintsReproducibleIds()
+	 * @jls.testedby jls.elem.ElementIdReplicaTest#pinnedFromScratchSavesAreByteIdentical()
 	 */
 	static AutoCloseable pinForTesting(String replica, long counter) {
 
@@ -203,7 +203,7 @@ public final class ElementId implements Comparable<ElementId> {
 	 *
 	 * @return the new identity.
 	 *
-	 * @see jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
+	 * @jls.testedby jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
 	 */
 	public static ElementId mintFresh() {
 
@@ -236,9 +236,9 @@ public final class ElementId implements Comparable<ElementId> {
 	 *             stable id (the loader reports this as an element error,
 	 *             issue #52 taxonomy).
 	 *
-	 * @see jls.DeterministicSaveTest#savedBlocksAreSortedByStableId()
-	 * @see jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
-	 * @see jls.StableElementIdTest#parseIsTheInverseOfToString()
+	 * @jls.testedby jls.DeterministicSaveTest#savedBlocksAreSortedByStableId()
+	 * @jls.testedby jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
+	 * @jls.testedby jls.StableElementIdTest#parseIsTheInverseOfToString()
 	 */
 	public static ElementId parse(String text) {
 
@@ -269,8 +269,8 @@ public final class ElementId implements Comparable<ElementId> {
 	/**
 	 * The canonical order (issue #166): by replica id, then by counter.
 	 *
-	 * @see jls.DeterministicSaveTest#savedBlocksAreSortedByStableId()
-	 * @see jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
+	 * @jls.testedby jls.DeterministicSaveTest#savedBlocksAreSortedByStableId()
+	 * @jls.testedby jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
 	 */
 	@Override
 	public int compareTo(ElementId other) {
@@ -315,9 +315,9 @@ public final class ElementId implements Comparable<ElementId> {
 	/**
 	 * The string form persisted in saved files: {@code replica:counter}.
 	 *
-	 * @see jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
-	 * @see jls.StableElementIdTest#parseIsTheInverseOfToString()
-	 * @see jls.StableElementIdTest#sidsByLogicalElement()
+	 * @jls.testedby jls.StableElementIdTest#freshMintsAreDistinctAndOrdered()
+	 * @jls.testedby jls.StableElementIdTest#parseIsTheInverseOfToString()
+	 * @jls.testedby jls.StableElementIdTest#sidsByLogicalElement()
 	 */
 	@Override
 	public String toString() {

--- a/src/jls/elem/Entry.java
+++ b/src/jls/elem/Entry.java
@@ -10,7 +10,9 @@ import java.awt.*;
 public abstract class Entry {
 	
 	// named constants
+	/** The default (and minimum) width of an entry. */
 	private final int defaultWidth = 10;
+	/** The default (and minimum) height of an entry. */
 	private final int defaultHeight = 10;
 	
 	// properties

--- a/src/jls/elem/Entry.java
+++ b/src/jls/elem/Entry.java
@@ -14,12 +14,19 @@ public abstract class Entry {
 	private final int defaultHeight = 10;
 	
 	// properties
+	/** The TruthTable object this entry is a part of. */
 	protected TruthTable ttelem;
+	/** The x-coordinate of this entry. */
 	protected int x;
+	/** The y-coordinate of this entry. */
 	protected int y;
+	/** The minimum width of this entry. */
 	protected int minWidth = defaultWidth;
+	/** The minimum height of this entry. */
 	protected int minHeight = defaultHeight;
+	/** The width of this entry. */
 	protected int width = defaultWidth;
+	/** The height of this entry. */
 	protected int height = defaultHeight;
 	
 	/**

--- a/src/jls/elem/Extend.java
+++ b/src/jls/elem/Extend.java
@@ -16,6 +16,7 @@ import java.util.*;
 public final class Extend extends Gate implements TriProp {
 	
 	// identity (#22); previous-settings unused: Extend has no repeat button
+	/** The kind descriptor shared by all Extend gates. */
 	private static final Kind KIND =
 			new Kind("Extend","Extend",1,0);
 	
@@ -29,6 +30,7 @@ public final class Extend extends Gate implements TriProp {
 	} // end of kind method
 	
 	// properties
+	/** Saved tri-state flag from the circuit file, applied when loading finishes. */
 	private boolean loadTriState = false;
 
 	/**

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -73,14 +73,21 @@ public abstract sealed class Gate extends LogicElement
 	 */
 	protected static final class Kind {
 		
+		/** The human-readable name of this gate kind. */
 		private final String displayName;	// e.g. "AND"
+		/** The save-file tag of this gate kind. */
 		private final String saveName;		// e.g. "AndGate" (a frozen tag:
 											// must match SaveTags / spec §7)
+		/** The forced input count, or -1 if the user chooses. */
 		private final int fixedInputs;		// forced input count, or -1 if the
 											// user chooses
+		/** The default propagation delay for this gate kind. */
 		private final int defaultDelay;
+		/** Input count of the previously created gate of this kind. */
 		private int previousInputs = defaultInputs;
+		/** Bits (gate count) of the previously created gate of this kind. */
 		private int previousBits = defaultBits;
+		/** Orientation of the previously created gate of this kind. */
 		private Orientation previousOrientation = defaultOrientation;
 		
 		/**
@@ -368,6 +375,7 @@ public abstract sealed class Gate extends LogicElement
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for the attributes shared by every gate kind.
+	/** The persistence attributes shared by every gate kind. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("bits") {
@@ -434,6 +442,7 @@ public abstract sealed class Gate extends LogicElement
 		}
 	);
 
+	/** Base attributes plus the shared gate attributes, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -936,6 +945,7 @@ public abstract sealed class Gate extends LogicElement
 // Simulation
 //-------------------------------------------------------------------------------
 
+	/** The output value currently propagating through this gate. */
 	private BitSet toBeValue;
 
 	/**

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -30,25 +30,34 @@ public abstract sealed class Gate extends LogicElement
 	// gates share the one JLSInfo.Orientation enum (issue #78 H3); only
 	// their persistence differs - lowercase names, kept byte-identical
 	// by the "orientation" attribute below
+	/** Default number of inputs. */
 	protected static final int defaultInputs = 2;
+	/** Default number of gates (bits). */
 	protected static final int defaultBits = 1;
+	/** Default orientation. */
 	protected static final Orientation defaultOrientation = Orientation.RIGHT;
-	
+
 	// saved properties
+	/** Number of inputs to this gate. */
 	protected int numInputs = defaultInputs;
+	/** Number of gates (bits). */
 	protected int bits = defaultBits;
+	/** Which way this gate faces. */
 	protected Orientation orientation = defaultOrientation;
+	/** Propagation delay of this gate. */
 	protected int propDelay;
-	
+
 	// running properties
+	/** Outline shape of this gate, set by the subclass. */
 	protected GeneralPath gateShape;
+	/** True if the creation dialog was cancelled. */
 	protected boolean cancelled;
 	
 	/**
 	 * Create a new Gate object.
 	 * Subclass constructors do most of the work.
 	 * 
-	 * @param circuit
+	 * @param circuit The circuit this element is part of.
 	 */
 	public Gate(Circuit circuit) {
 		
@@ -519,7 +528,7 @@ public abstract sealed class Gate extends LogicElement
 	 * or 1/2 space wider on each side (for up/down gates).
 	 * 
 	 * @return a rectangle that bounds the element on the screen.
-	 * @see jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
+	 * @jls.testedby jls.ui.EditorGestureTest#rubberBandSelectHighlightsEnclosedElements()
 	 */
 	@Override
 	public Rectangle getRect() {
@@ -549,6 +558,8 @@ public abstract sealed class Gate extends LogicElement
 	
 	/**
 	 * Get default propagation delay for this gate kind.
+	 *
+	 * @return the default propagation delay.
 	 */
 	public int getDefaultDelay() {
 		
@@ -697,15 +708,25 @@ public abstract sealed class Gate extends LogicElement
 	protected class GateCreate extends ElementDialog implements ActionListener {
 		
 		// properties
+		/** Button to repeat the previously created gate's settings. */
 		private JButton repeat;
+		/** Text field for the number of inputs. */
 		private JTextField inputsField = new JTextField(defaultInputs+"",5);
+		/** Text field for the number of gates (bits). */
 		private JTextField gatesField = new JTextField(defaultBits+"",5);
+		/** Keypad for the inputs field. */
 		private KeyPad inputsPad = new KeyPad(inputsField,10,defaultInputs,this);
+		/** Keypad for the gates field. */
 		private KeyPad gatesPad = new KeyPad(gatesField,10,defaultBits,this);
+		/** Left orientation choice. */
 		private JRadioButton left = new JRadioButton("left");
+		/** Up orientation choice. */
 		private JRadioButton up = new JRadioButton("up");
+		/** Down orientation choice. */
 		private JRadioButton down = new JRadioButton("down");
+		/** Right orientation choice. */
 		private JRadioButton right = new JRadioButton("right");
+		/** The type of gate (e.g. "AND"). */
 		private String type;
 		
 		/**

--- a/src/jls/elem/GridTransform.java
+++ b/src/jls/elem/GridTransform.java
@@ -29,7 +29,12 @@ public final class GridTransform {
 	 * Rotate a point 90 degrees clockwise within a w-by-h box; the result
 	 * lives in an h-by-w box.
 	 *
-	 * @see jls.elem.GridTransformTest#quarterTurnsCompose()
+	 * @param px the point's x offset within the box.
+	 * @param py the point's y offset within the box.
+	 * @param height the height of the box the point lives in.
+	 * @return the rotated point, as an offset in the h-by-w box.
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#quarterTurnsCompose()
 	 */
 	public static Point rotateCW(int px, int py, int height) {
 
@@ -40,8 +45,13 @@ public final class GridTransform {
 	 * Rotate a point 90 degrees counter-clockwise within a w-by-h box; the
 	 * result lives in an h-by-w box.
 	 *
-	 * @see jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
-	 * @see jls.elem.GridTransformTest#quarterTurnsCompose()
+	 * @param px the point's x offset within the box.
+	 * @param py the point's y offset within the box.
+	 * @param width the width of the box the point lives in.
+	 * @return the rotated point, as an offset in the h-by-w box.
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
+	 * @jls.testedby jls.elem.GridTransformTest#quarterTurnsCompose()
 	 */
 	public static Point rotateCCW(int px, int py, int width) {
 
@@ -51,7 +61,13 @@ public final class GridTransform {
 	/**
 	 * Rotate a point 180 degrees within a w-by-h box.
 	 *
-	 * @see jls.elem.GridTransformTest#quarterTurnsCompose()
+	 * @param px the point's x offset within the box.
+	 * @param py the point's y offset within the box.
+	 * @param width the width of the box the point lives in.
+	 * @param height the height of the box the point lives in.
+	 * @return the rotated point, as an offset in the same box.
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#quarterTurnsCompose()
 	 */
 	public static Point rotate180(int px, int py, int width, int height) {
 
@@ -61,8 +77,13 @@ public final class GridTransform {
 	/**
 	 * Mirror a point across the box's vertical axis (flip left/right).
 	 *
-	 * @see jls.elem.GridTransformTest#adderLeftIsMirrorOfRight()
-	 * @see jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
+	 * @param px the point's x offset within the box.
+	 * @param py the point's y offset within the box.
+	 * @param width the width of the box the point lives in.
+	 * @return the mirrored point, as an offset in the same box.
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#adderLeftIsMirrorOfRight()
+	 * @jls.testedby jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
 	 */
 	public static Point mirrorX(int px, int py, int width) {
 
@@ -72,7 +93,12 @@ public final class GridTransform {
 	/**
 	 * Mirror a point across the box's horizontal axis (flip up/down).
 	 *
-	 * @see jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
+	 * @param px the point's x offset within the box.
+	 * @param py the point's y offset within the box.
+	 * @param height the height of the box the point lives in.
+	 * @return the mirrored point, as an offset in the same box.
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#andGateOrientationsAreTransformsOfEachOther()
 	 */
 	public static Point mirrorY(int px, int py, int height) {
 
@@ -82,7 +108,11 @@ public final class GridTransform {
 	/**
 	 * The dimensions of a box after a quarter-turn rotation.
 	 *
-	 * @see jls.elem.GridTransformTest#quarterTurnsCompose()
+	 * @param width the box width before rotation.
+	 * @param height the box height before rotation.
+	 * @return the rotated dimensions (width and height swapped).
+	 *
+	 * @jls.testedby jls.elem.GridTransformTest#quarterTurnsCompose()
 	 */
 	public static Dimension rotatedSize(int width, int height) {
 
@@ -92,6 +122,10 @@ public final class GridTransform {
 	/**
 	 * Start a composed transform from a canonical box of the given size.
 	 * Operations are applied in the order they are chained.
+	 *
+	 * @param width the canonical box width.
+	 * @param height the canonical box height.
+	 * @return a new, empty chain over the canonical box.
 	 */
 	public static Chain chain(int width, int height) {
 
@@ -185,6 +219,10 @@ public final class GridTransform {
 		/**
 		 * Map a point from canonical coordinates through every chained
 		 * transform.
+		 *
+		 * @param px the point's x offset in the canonical box.
+		 * @param py the point's y offset in the canonical box.
+		 * @return the point's offset in the transformed box.
 		 */
 		public Point map(int px, int py) {
 
@@ -217,6 +255,9 @@ public final class GridTransform {
 
 		/**
 		 * The box dimensions after every chained transform.
+		 *
+		 * @return the canonical dimensions, with width and height swapped
+		 *         once per quarter-turn rotation in the chain.
 		 */
 		public Dimension size() {
 
@@ -233,6 +274,14 @@ public final class GridTransform {
 		/**
 		 * Draw a line whose endpoints are canonical coordinates, mapped
 		 * through the chain and offset by the element position.
+		 *
+		 * @param g the graphics object to draw on.
+		 * @param originX the x coordinate of the element's origin.
+		 * @param originY the y coordinate of the element's origin.
+		 * @param x1 the first endpoint's canonical x offset.
+		 * @param y1 the first endpoint's canonical y offset.
+		 * @param x2 the second endpoint's canonical x offset.
+		 * @param y2 the second endpoint's canonical y offset.
 		 */
 		public void drawLine(java.awt.Graphics g, int originX, int originY,
 				int x1, int y1, int x2, int y2) {

--- a/src/jls/elem/GridTransform.java
+++ b/src/jls/elem/GridTransform.java
@@ -140,10 +140,14 @@ public final class GridTransform {
 	 */
 	public static final class Chain {
 
+		/** Operation codes for the chained transforms. */
 		private static final int CW = 0, CCW = 1, R180 = 2, MX = 3, MY = 4;
 
+		/** The canonical box width. */
 		private final int canonicalWidth;
+		/** The canonical box height. */
 		private final int canonicalHeight;
+		/** The chained operation codes, in application order. */
 		private final java.util.List<Integer> ops =
 				new java.util.ArrayList<Integer>();
 

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -34,7 +34,7 @@ public abstract sealed class Group extends LogicElement
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#groupBitsRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#groupBitsRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkBits(int bits) {
 
@@ -42,15 +42,22 @@ public abstract sealed class Group extends LogicElement
 	} // end of checkBits method
 
 	// saved properties
+	/** The number of bits on the bundled side. */
 	protected int bits = defaultBits;
 	//protected SortedSet<GetRanges.Entry> ranges;
+	/** The bit groups, one entry per put on the narrow side. */
 	protected ArrayList<Entry> ranges;
+	/** True if the bundled wire is tri-state. */
 	protected boolean triState = false;
+	/** Which way the element faces (the direction of the bundled side). */
 	protected JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
-	
+
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	protected boolean cancelled;
+	/** True if the save file being loaded says the bundle is tri-state. */
 	protected boolean loadTriState = false;
+	/** True if loaded from the newer save format that allows non-contiguous bit groups. */
 	protected boolean noncontig = false; // False only for legacy saves
 	
 	/**
@@ -184,7 +191,7 @@ public abstract sealed class Group extends LogicElement
 	/**
 	 * This method will flip a group
 	 * @param g The current graphics context to facilitate recalculation of size when flipping
-	 * @see jls.elem.GroupOrientationTest#flipTogglesVerticalOrientations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#flipTogglesVerticalOrientations()
 	 */
 	@Override
 	public void flip(Graphics g)
@@ -201,7 +208,7 @@ public abstract sealed class Group extends LogicElement
 	 * Subclasses re-run init to rebuild the puts on the new axes.
 	 * @param direction The direction to rotate
 	 * @param g The current graphics context for use in recalculating size
-	 * @see jls.elem.GroupOrientationTest#rotateCyclesAllFourOrientations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#rotateCyclesAllFourOrientations()
 	 */
 	@Override
 	public void rotate(JLSInfo.Orientation direction, Graphics g)
@@ -224,8 +231,8 @@ public abstract sealed class Group extends LogicElement
 	 * Tells if a Group is capable of rotating: the same no-attachments
 	 * constraint as flipping, since both rebuild every put.
 	 * @return False if any input or output has a wire attached, True otherwise
-	 * @see jls.elem.GroupOrientationTest#attachedGroupRefusesRotateAndFlip()
-	 * @see jls.elem.GroupOrientationTest#rotateCyclesAllFourOrientations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#attachedGroupRefusesRotateAndFlip()
+	 * @jls.testedby jls.elem.GroupOrientationTest#rotateCyclesAllFourOrientations()
 	 */
 	@Override
 	public boolean canRotate()
@@ -236,8 +243,8 @@ public abstract sealed class Group extends LogicElement
 	/**
 	 * Tells if a Group is capable of flippiing, can only flip when inputs or outputs have no attachments.
 	 * @return False if any input or output has a wire attached, True otherwise
-	 * @see jls.elem.GroupOrientationTest#attachedGroupRefusesRotateAndFlip()
-	 * @see jls.elem.GroupOrientationTest#flipTogglesVerticalOrientations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#attachedGroupRefusesRotateAndFlip()
+	 * @jls.testedby jls.elem.GroupOrientationTest#flipTogglesVerticalOrientations()
 	 */
 	@Override
 	public boolean canFlip()
@@ -329,7 +336,7 @@ public abstract sealed class Group extends LogicElement
 	 *
 	 * @param output The output writer.
 	 *
-	 * @see jls.elem.GroupOrientationTest#orientOf()
+	 * @jls.testedby jls.elem.GroupOrientationTest#orientOf()
 	 */
 	@Override
 	public void save(PrintWriter output) {
@@ -405,19 +412,29 @@ public abstract sealed class Group extends LogicElement
 	protected class GroupCreate extends ElementDialog {
 
 		// properties
+		/** Input field for the number of bundled bits. */
 		private JTextField bitsField = new JTextField(defaultBits+"",10);
+		/** Pop-up keypad for the bits field. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Choice to split the bundle into single bits. */
 		private JRadioButton single = new JRadioButton("Single Bits");
+		/** Choice to pick bit groups by hand. */
 		private JRadioButton group = new JRadioButton("Group Bits");
+		/** Orientation choice: element faces left. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Orientation choice: element faces right (the default). */
 		private JRadioButton right = new JRadioButton("Right", true);
+		/** Orientation choice: element faces up. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Orientation choice: element faces down. */
 		private JRadioButton down = new JRadioButton("Down");
+		/** Either "Bundler" or "Unbundler". */
 		private String type;
-		
+
 		/**
 		 * Set up create dialog window.
-		 * 
+		 *
+		 * @param type Either "Bundler" or "Unbundler".
 		 */
 		protected GroupCreate(String type) {
 
@@ -572,16 +589,27 @@ public abstract sealed class Group extends LogicElement
 	protected class GetRanges extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Model of single bits available to choose from. */
 		private DefaultListModel<Entry> pick = new DefaultListModel<Entry>();
+		/** The "choose from" list display. */
 		private JList<Entry> choose = new JList<Entry>(pick); // LeftList?
+		/** Model of the bit groups chosen so far. */
 		private DefaultListModel<Entry> picked = new DefaultListModel<Entry>();
+		/** The "chosen" list display. */
 		private JList<Entry> chosen = new JList<Entry>(picked);
+		/** Button to bundle the selected bits into a new group. */
 		private JButton add = new JButton(">>");
+		/** Button to remove the selected group. */
 		private JButton remove = new JButton("<<");
+		/** Button to move the selected group to the top. */
 		private JButton upjumper = new JButton("Move bundle to top");
+		/** Button to move the selected group up one place. */
 		private JButton upshifter = new JButton("Move bundle up");
+		/** Button to move the selected group down one place. */
 		private JButton downshifter = new JButton("Move bundle down");
+		/** Button to move the selected group to the bottom. */
 		private JButton downjumper = new JButton("Move bundle to bottom");
+		/** Either "Bundler" or "Unbundler". */
 		private String type;
 		
 		/**
@@ -910,6 +938,8 @@ public abstract sealed class Group extends LogicElement
 		
 		/**
 		 * Return number of stored elements
+		 *
+		 * @return the number of stored indices
 		 */
 		public int getSize() {
 			return values.length;

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -20,10 +20,13 @@ public abstract sealed class Group extends LogicElement
 		permits Binder, Splitter {
 	
 	// default values
+	/** The bundled-side width a new binder/splitter starts with. */
 	private static final int defaultBits = 2;
 
 	// one constraint string, two surfaces: dialog and loader (issue #52)
+	/** The bundle-width rule, shared by the dialog and the loader. */
 	static final String BITS_CONSTRAINT = "Must be at least 2 bits";
+	/** The wire-index rule, shared by the dialog and the loader. */
 	static final String INDEX_CONSTRAINT =
 			"group wire indices must be non-negative";
 
@@ -871,7 +874,9 @@ public abstract sealed class Group extends LogicElement
 		// properties
 		//private int from;
 		//private int to;
+		/** The bit indices this entry covers, in stored order. */
 		private int[] values;
+		/** True once these bits have been bundled (so they can't be picked again). */
 		private boolean picked;
 		
 		/**

--- a/src/jls/elem/Input.java
+++ b/src/jls/elem/Input.java
@@ -49,8 +49,8 @@ public final class Input extends Put {
 	 * 
 	 * @param value The new value.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	public void setValue(BitSet value) {
 		
@@ -62,7 +62,7 @@ public final class Input extends Put {
 	 * 
 	 * @return the current value.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
 	 */
 	public BitSet getValue() {
 		

--- a/src/jls/elem/JumpEnd.java
+++ b/src/jls/elem/JumpEnd.java
@@ -46,9 +46,9 @@ public final class JumpEnd extends LogicElement {
 	 * 
 	 * @param circuit The circuit this element is part of.
 	 *
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureStillReachesDialogWithANamedWire()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureStillReachesDialogWithANamedWire()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
 	 */
 	public JumpEnd(Circuit circuit) {
 		
@@ -65,9 +65,9 @@ public final class JumpEnd extends LogicElement {
 	 * 
 	 * @return false if cancelled, true otherwise.
 	 *
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#endGestureStillReachesDialogWithANamedWire()
-	 * @see jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureFailsFastWhenNoNamedWiresExist()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#endGestureStillReachesDialogWithANamedWire()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
 	 */
 	@Override
 	public boolean setup(Graphics g, JPanel editWindow, int x, int y) {
@@ -377,7 +377,7 @@ public final class JumpEnd extends LogicElement {
 	 * 
 	 * @return the name.
 	 *
-	 * @see jls.ui.CircuitAssert#jumpAlias()
+	 * @jls.testedby jls.ui.CircuitAssert#jumpAlias()
 	 */
 	@Override
 	public String getName() {
@@ -604,7 +604,7 @@ public final class JumpEnd extends LogicElement {
 	 *
 	 * @param newName The wire name to attach to.
 	 *
-	 * @see jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
+	 * @jls.testedby jls.elem.JumpEndNoNamedWiresTest#matchGesturePresetNameBypassesGuardAndDialog()
 	 */
 	public void setName(String newName) {
 		name = newName;

--- a/src/jls/elem/JumpEnd.java
+++ b/src/jls/elem/JumpEnd.java
@@ -22,6 +22,7 @@ import javax.swing.*;
 public final class JumpEnd extends LogicElement {
 	
 	// default value
+	/** Default number of bits in the named wire. */
 	private static final int defaultBits = 1;
 
 	/**
@@ -32,13 +33,18 @@ public final class JumpEnd extends LogicElement {
 			"No named wires exist. Name a wire with START first.";
 	
 	// saved properties
+	/** Number of bits in the named wire. */
 	private int bits = defaultBits;
+	/** Name of the named wire this end connects to. */
 	private String name;
-	
+
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
+	/** True if the saved file marked the output tri-state. */
 	private boolean loadTriState = false;
-	
+
+	/** Which way the element points. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
 	
 	/**
@@ -237,6 +243,7 @@ public final class JumpEnd extends LogicElement {
 	// " int tristate 1" line reflects derived output state, not a plain
 	// field, so it stays hand-printed in save() and hand-loaded in
 	// setValue below.
+	/** This element's own saved attributes, in save order (#23). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -317,6 +324,7 @@ public final class JumpEnd extends LogicElement {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order (#23). */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -456,8 +464,11 @@ public final class JumpEnd extends LogicElement {
 	private class EndCreate extends ElementDialog {
 
 		// properties
+		/** List of named wire (jump start) names to pick from. */
 		private JList starts;
+		/** Selects leftward orientation. */
 		private JRadioButton left = new JRadioButton("left");
+		/** Selects rightward orientation. */
 		private JRadioButton right = new JRadioButton("right");
 		
 		/**
@@ -549,6 +560,7 @@ public final class JumpEnd extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The value currently on the output, or null when tri-stated off. */
 	private BitSet currentValue = new BitSet();
 	
 	/**

--- a/src/jls/elem/JumpStart.java
+++ b/src/jls/elem/JumpStart.java
@@ -22,17 +22,24 @@ import java.util.*;
 public final class JumpStart extends LogicElement implements TriProp {
 	
 	// default value
-	private static final int defaultBits = 1; 
-	
+	/** The default bit width for a new jump start. */
+	private static final int defaultBits = 1;
+
 	// saved properties
+	/** The wire name (shared with the matching jump ends). */
 	private String name;
+	/** The bit width of the wire. */
 	private int bits = defaultBits;
+	/** True if this jump start's value is watched during simulation. */
 	private boolean watched = false;
-	
+
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
+	/** A reference to this jump start, for use inside the dialog inner class. */
 	private JumpStart me;
-	
+
+	/** Which direction the element faces. */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.LEFT;
 	
 	/**
@@ -199,6 +206,7 @@ public final class JumpStart extends LogicElement implements TriProp {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes, in save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -298,6 +306,7 @@ public final class JumpStart extends LogicElement implements TriProp {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -483,10 +492,15 @@ public final class JumpStart extends LogicElement implements TriProp {
 	private class StartCreate extends ElementDialog {
 
 		// properties
+		/** The text field for the wire name. */
 		private JTextField nameField = new JTextField("",12);
+		/** The text field for the bit width. */
 		private JTextField bitsField = new JTextField("1",5);
+		/** The key pad for entering the bit width. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,1,this);
+		/** Selects left orientation. */
 		private JRadioButton left = new JRadioButton("left");
+		/** Selects right orientation. */
 		private JRadioButton right = new JRadioButton("right");
 		
 		/**
@@ -616,7 +630,9 @@ public final class JumpStart extends LogicElement implements TriProp {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The current value of the named wire during simulation. */
 	private BitSet currentValue = new BitSet();
+	/** The jump ends with a matching name, built at simulation start. */
 	private Set<JumpEnd> jumpEnds = new HashSet<JumpEnd>();
 	
 	/**

--- a/src/jls/elem/JumpStart.java
+++ b/src/jls/elem/JumpStart.java
@@ -339,7 +339,7 @@ public final class JumpStart extends LogicElement implements TriProp {
 	 * Get the name of this jumpstart.
 	 * 
 	 * @return the name.
-	 * @see jls.ui.CircuitAssert#jumpAlias()
+	 * @jls.testedby jls.ui.CircuitAssert#jumpAlias()
 	 */
 	@Override
 	public String getName() {

--- a/src/jls/elem/LogicElement.java
+++ b/src/jls/elem/LogicElement.java
@@ -22,11 +22,15 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	private int ly;
 	private int savex;				// position to return to if bad placement
 	private int savey;
+	/** The element's input connection points. */
 	protected Vector<Input> inputs = new Vector<Input>();
+	/** The element's output connection points. */
 	protected Vector<Output> outputs = new Vector<Output>();
-	
+
 	/**
 	 * Construct a new logic element.
+	 *
+	 * @param circuit The circuit this element is part of.
 	 */
 	public LogicElement(Circuit circuit) {
 		
@@ -39,11 +43,11 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 * @param x Initial x-coordinate.
 	 * @param y Initial y-coordinate.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wire()
-	 * @see jls.elem.HollowVsFilledCollisionTest#corner()
-	 * @see jls.elem.HollowVsFilledCollisionTest#probe()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wire()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#corner()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#probe()
 	 */
 	@Override
 	public void setXY(int x, int y) {
@@ -295,7 +299,7 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 *
 	 * @return a set of all inputs and outputs.
 	 *
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	@Override
 	public Set<Put> getAllPuts() {
@@ -313,9 +317,9 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 *
 	 * @return an unmodifiable view of the inputs, in order.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	public java.util.List<Input> getInputList() {
 
@@ -340,8 +344,8 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 * 
 	 * @return the put, or null if no such put.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
-	 * @see jls.ui.CircuitAssert#assertPutBits()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.ui.CircuitAssert#assertPutBits()
 	 */
 	@Override
 	public Put getPut(String name) {
@@ -435,7 +439,7 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	/**
 	 * Initialize all inputs to 0.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	public void initInputs() {
 		
@@ -465,8 +469,8 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 * Get the name of this element.
 	 * Overridden in elements that have names.
 	 *
-	 * @see jls.ui.CircuitAssert#assertElementPresent()
-	 * @see jls.ui.CircuitAssert#describe()
+	 * @jls.testedby jls.ui.CircuitAssert#assertElementPresent()
+	 * @jls.testedby jls.ui.CircuitAssert#describe()
 	 */
 	@Override
 	public String getName() {
@@ -514,7 +518,7 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 *
 	 * @throws UnsupportedOperationException always, on the base element.
 	 *
-	 * @see jls.ui.CircuitAssert#assertBits()
+	 * @jls.testedby jls.ui.CircuitAssert#assertBits()
 	 */
 	public int getBits() {
 		

--- a/src/jls/elem/LogicElement.java
+++ b/src/jls/elem/LogicElement.java
@@ -18,9 +18,13 @@ public abstract sealed class LogicElement extends Element implements Reacts
 		StateMachine, Stop, SubCircuit, TriState, TruthTable, WireEnd {
 	
 	// run time properties
+	/** The x-coordinate before snapping to a grid line. */
 	private int lx;					// position if not snapped to grid line
+	/** The y-coordinate before snapping to a grid line. */
 	private int ly;
+	/** The x-coordinate to return to if a move ends in a bad placement. */
 	private int savex;				// position to return to if bad placement
+	/** The y-coordinate to return to if a move ends in a bad placement. */
 	private int savey;
 	/** The element's input connection points. */
 	protected Vector<Input> inputs = new Vector<Input>();

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -49,7 +49,7 @@ public final class Memory extends LogicElement {
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#memoryCapacityRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#memoryCapacityRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkCapacity(int capacity) {
 
@@ -63,7 +63,7 @@ public final class Memory extends LogicElement {
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#memoryBitsRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#memoryBitsRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkBits(int bits) {
 
@@ -410,10 +410,10 @@ public final class Memory extends LogicElement {
 	 *
 	 * @return the encoded form, or null to use the raw encoding.
 	 *
-	 * @see jls.elem.MemoryInitEncodingTest#bigValuesSurvive()
-	 * @see jls.elem.MemoryInitEncodingTest#encodesRunsCompactly()
-	 * @see jls.elem.MemoryInitEncodingTest#refusesNonCanonicalText()
-	 * @see jls.elem.MemoryInitEncodingTest#toleratesMissingFinalNewline()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#bigValuesSurvive()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#encodesRunsCompactly()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#refusesNonCanonicalText()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#toleratesMissingFinalNewline()
 	 */
 	static String encodeInitRLE(String text) {
 
@@ -434,7 +434,7 @@ public final class Memory extends LogicElement {
 	 *
 	 * @return the encoded form, or null to use the raw encoding.
 	 *
-	 * @see jls.elem.MemoryInitEncodingTest#outOfCapacityAddressesStayRaw()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#outOfCapacityAddressesStayRaw()
 	 */
 	static String encodeInitRLE(String text, long maxWords) {
 
@@ -524,11 +524,11 @@ public final class Memory extends LogicElement {
 	 * @throws IllegalArgumentException if the encoding is malformed (the
 	 *             loader reports a load error).
 	 *
-	 * @see jls.elem.MemoryInitEncodingTest#bigValuesSurvive()
-	 * @see jls.elem.MemoryInitEncodingTest#decodeRejectsGarbage()
-	 * @see jls.elem.MemoryInitEncodingTest#decodeRejectsHostileRuns()
-	 * @see jls.elem.MemoryInitEncodingTest#encodesRunsCompactly()
-	 * @see jls.elem.MemoryInitEncodingTest#toleratesMissingFinalNewline()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#bigValuesSurvive()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#decodeRejectsGarbage()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#decodeRejectsHostileRuns()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#encodesRunsCompactly()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#toleratesMissingFinalNewline()
 	 */
 	static String decodeInitRLE(String rle) {
 
@@ -545,7 +545,7 @@ public final class Memory extends LogicElement {
 	 *
 	 * @return the canonical text.
 	 *
-	 * @see jls.elem.MemoryInitEncodingTest#decodeRejectsHostileRuns()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#decodeRejectsHostileRuns()
 	 */
 	static String decodeInitRLE(String rle, long maxWords) {
 
@@ -1746,7 +1746,7 @@ public final class Memory extends LogicElement {
 	 * 
 	 * @return the value at that location.
 	 *
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
 	 */
 	public BitSet getCurrentValue(int loc){
 		

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -26,19 +26,32 @@ public final class Memory extends LogicElement {
 	 * The two kinds of memory this element can be configured as: RAM
 	 * (readable and writable) or ROM (read-only).
 	 */
-	private static enum Type {RAM,ROM};
+	private static enum Type {
+		/** Readable and writable memory. */
+		RAM,
+		/** Read-only memory. */
+		ROM};
 	
 	// default values
+	/** The default element name (empty until the user supplies one). */
 	private static final String defaultName = "";
+	/** The default memory type. */
 	private static final Type defaultType = Type.RAM;
+	/** The default number of bits per word. */
 	private static final int defaultBits = 1;
+	/** The default capacity, in words. */
 	private static final int defaultCapacity = 2;
+	/** The default initialization file name (empty means no file). */
 	private static final String defaultFileName = "";
+	/** The default access time, in simulation time units. */
 	private static final int defaultAccessTime = 100; 
+	/** The default built-in initial value text (empty means all zeros). */
 	private static final String defaultInitialValue = "";
 	
 	// one constraint string, two surfaces: dialog and loader (issue #52)
+	/** Message reported when a proposed capacity is less than 1 word. */
 	static final String CAPACITY_CONSTRAINT = "Capacity must be at least 1";
+	/** Message reported when a proposed word size is less than 1 bit. */
 	static final String BITS_CONSTRAINT = "Must have at least 1 bit";
 
 	/**
@@ -71,21 +84,33 @@ public final class Memory extends LogicElement {
 	} // end of checkBits method
 
 	// absolute cap on RLE-decoded initial-memory words (issue #38)
+	/** The most words an RLE-encoded initialization is allowed to expand to. */
 	static final long MAX_INIT_WORDS = 1L << 24;
 
 	// saved properties
+	/** The name of this memory element. */
 	private String name = defaultName;
+	/** Whether this memory is RAM or ROM. */
 	private Type type = defaultType;
+	/** The number of bits per word. */
 	private int bits = defaultBits;
+	/** The capacity of this memory, in words. */
 	private int capacity = defaultCapacity;
+	/** The initialization file name, or empty if initialized internally. */
 	private String fileName = defaultFileName;
+	/** The access time (read/write delay), in simulation time units. */
 	private int accessTime = defaultAccessTime;
+	/** The built-in initial value text, or empty if none. */
 	private String initialValue = defaultInitialValue;
+	/** True if this memory is being watched during simulation. */
 	private boolean watched = false;
-	
+
 	// running properties
+	/** True if the user cancelled the create/change dialog. */
 	private boolean cancelled;
+	/** True if a change dialog altered the element so it must be resized. */
 	private boolean changed;
+	/** The "capacity x bits" type description drawn inside the element. */
 	private String specs;
 	
 	/**
@@ -747,16 +772,27 @@ public final class Memory extends LogicElement {
 	private class MemoryEdit extends ElementDialog implements ActionListener {
 		
 		// properties
+		/** Input field for the element name. */
 		private JTextField nameField = new JTextField(name);
+		/** Input field for the number of bits per word. */
 		private JTextField bitsField = new JTextField(bits+"",10);
+		/** Input field for the capacity in words. */
 		private JTextField capacityField = new JTextField(defaultCapacity+"",10);
+		/** Keypad for entering the bits per word. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,bits,this);
+		/** Keypad for entering the capacity. */
 		private KeyPad capacityPad = new KeyPad(capacityField,10,defaultCapacity,this);
+		/** Radio button selecting the RAM type. */
 		private JRadioButton ram = new JRadioButton("RAM");
+		/** Radio button selecting the ROM type. */
 		private JRadioButton rom = new JRadioButton("ROM");
+		/** Button choosing initialization from a file. */
 		private JButton fromFile = new JButton("from File");
+		/** Button choosing built-in initialization. */
 		private JButton builtIn = new JButton("Built In");
+		/** True if creating a new memory element, false if changing one. */
 		private boolean create;
+		/** Working copy of the built-in initial value text, committed on OK. */
 		String tempInit = initialValue;
 		
 		/**
@@ -1082,6 +1118,7 @@ public final class Memory extends LogicElement {
 		return true;
 	} // end of canChange method
 	
+	/** Graphics object saved by change() so the dialog can measure name widths. */
 	private Graphics saveg;
 	
 	/**
@@ -1273,8 +1310,11 @@ public final class Memory extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The running memory contents during simulation. */
 	private WordStore mem;
+	/** The initial memory image, copied to the running memory at simulation start. */
 	private WordStore initMem;
+	/** The value currently driven on the output, or null if none. */
 	private BitSet currentValue;
 	/**
 	 * One entry in the write history: the value written (what), the address
@@ -1282,15 +1322,26 @@ public final class Memory extends LogicElement {
 	 * to populate the activity dialog.
 	 */
 	private static class WriteRecord {
+		/** The value written. */
 		BitSet what;
+		/** The address written to. */
 		int where;
+		/** The simulation time of the write. */
 		long when;
+
+		/**
+		 * Create an empty record; the caller fills in the fields.
+		 */
+		private WriteRecord() {
+		}
 	};
 
 	// The write history exists to feed the activity dialog; letting it
 	// grow with every write made long simulations leak (#20), so it is
 	// bounded to the newest records.
+	/** The maximum number of write records kept in the history. */
 	private static final int ACTIVITY_LIMIT = 10_000;
+	/** The most recent writes, newest first, bounded by ACTIVITY_LIMIT. */
 	private LinkedList<WriteRecord> activity =
 		new LinkedList<WriteRecord>();
 
@@ -1303,16 +1354,35 @@ public final class Memory extends LogicElement {
 	 */
 	private interface WordStore {
 
-		/** The stored word, or null if this address was never set. */
+		/**
+		 * The stored word, or null if this address was never set.
+		 *
+		 * @param addr The word address.
+		 *
+		 * @return the word, or null if absent.
+		 */
 		BitSet get(int addr);
 
-		/** Store a word at an address. */
+		/**
+		 * Store a word at an address.
+		 *
+		 * @param addr The word address.
+		 * @param value The word to store.
+		 */
 		void put(int addr, BitSet value);
 
-		/** Addresses that have been set, in ascending order. */
+		/**
+		 * Addresses that have been set, in ascending order.
+		 *
+		 * @return the set addresses.
+		 */
 		SortedSet<Integer> addresses();
 
-		/** An independent copy (the running memory starts as a copy of the initial image). */
+		/**
+		 * An independent copy (the running memory starts as a copy of the initial image).
+		 *
+		 * @return the copy.
+		 */
 		WordStore copy();
 	}
 
@@ -1323,7 +1393,9 @@ public final class Memory extends LogicElement {
 	 */
 	private static final class DenseWordStore implements WordStore {
 
+		/** The stored words, one long per address. */
 		private final long[] words;
+		/** One bit per address: set if that address holds a word. */
 		private final BitSet present;
 
 		/**
@@ -1405,6 +1477,7 @@ public final class Memory extends LogicElement {
 	 */
 	private static final class SparseWordStore implements WordStore {
 
+		/** The stored words, keyed by address. */
 		private final Map<Integer,BitSet> map;
 
 		/**
@@ -1469,6 +1542,7 @@ public final class Memory extends LogicElement {
 
 	// dense storage allocates the full capacity eagerly; past this many
 	// words (32 MB of longs) assume sparse use and fall back to the map
+	/** The largest capacity, in words, given dense storage. */
 	private static final int DENSE_CAPACITY_LIMIT = 1 << 22;
 
 	/**
@@ -1570,7 +1644,13 @@ public final class Memory extends LogicElement {
 	 * The memory operation implied by the current input signals: WRITE a
 	 * word, READ a word, or OFF when the chip is not selected.
 	 */
-	private static enum MemoryAction {WRITE,READ,OFF};
+	private static enum MemoryAction {
+		/** Write a word to memory. */
+		WRITE,
+		/** Read a word from memory. */
+		READ,
+		/** The chip is not selected; drive no value. */
+		OFF};
 	
 	/**
 	 * React to an event.

--- a/src/jls/elem/Mux.java
+++ b/src/jls/elem/Mux.java
@@ -17,18 +17,27 @@ import javax.swing.*;
 public final class Mux extends LogicElement {
 
 	// default values
+	/** Default number of data inputs. */
 	private static final int defaultInputs = 2;
+	/** Default number of bits per input. */
 	private static final int defaultBits = 1;
-	private static final int defaultPropDelay = 25; 
-	
+	/** Default propagation delay. */
+	private static final int defaultPropDelay = 25;
+
 	// saved properties
+	/** The number of data inputs. */
 	private int numInputs = defaultInputs;
+	/** The number of bits in each input and the output. */
 	private int bits = defaultBits;
+	/** The propagation delay of this element. */
 	private int propDelay = defaultPropDelay;
+	/** The direction the output points. */
 	private JLSInfo.Orientation outputOrientation = JLSInfo.Orientation.RIGHT;
+	/** The side the selector input is on. */
 	private JLSInfo.Orientation selectorOrientation = JLSInfo.Orientation.DOWN;
-	
+
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
 
 	/**
@@ -123,6 +132,8 @@ public final class Mux extends LogicElement {
 	/**
 	 * The transform from canonical geometry (output RIGHT) to the current
 	 * output orientation.
+	 *
+	 * @return the transform for the current output orientation.
 	 */
 	private GridTransform.Chain placement() {
 
@@ -241,6 +252,7 @@ public final class Mux extends LogicElement {
 
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes (inputs, bits, delay, orientations). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("inputs") {
@@ -343,6 +355,7 @@ public final class Mux extends LogicElement {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -781,6 +794,7 @@ public final class Mux extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The value scheduled to reach the output, to suppress redundant events. */
 	private BitSet toBeValue;
 	
 	/**

--- a/src/jls/elem/Mux.java
+++ b/src/jls/elem/Mux.java
@@ -540,18 +540,31 @@ public final class Mux extends LogicElement {
 	protected class MuxCreate extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Text field for the number of inputs. */
 		private JTextField inputsField = new JTextField(defaultInputs+"",5);
+		/** Text field for the number of bits. */
 		private JTextField bitsField = new JTextField(defaultBits+"",5);
+		/** Keypad for the inputs field. */
 		private KeyPad inputsPad = new KeyPad(inputsField,10,defaultInputs,this);
+		/** Keypad for the bits field. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Left output orientation choice. */
 		private JRadioButton oLeft = new JRadioButton("Left");
+		/** Right output orientation choice. */
 		private JRadioButton oRight = new JRadioButton("Right", true);
+		/** Up output orientation choice. */
 		private JRadioButton oUp = new JRadioButton("Up");
+		/** Down output orientation choice. */
 		private JRadioButton oDown = new JRadioButton("Down");
+		/** Left selector orientation choice. */
 		private JRadioButton sLeft = new JRadioButton("Left");
+		/** Right selector orientation choice. */
 		private JRadioButton sRight = new JRadioButton("Right");
+		/** Up selector orientation choice. */
 		private JRadioButton sUp = new JRadioButton("Up");
+		/** Down selector orientation choice. */
 		private JRadioButton sDown = new JRadioButton("Down",true);
+		/** Label for the selector orientation panel. */
 		private JLabel olbl2 = new JLabel("Selector Orientation");
 		
 		/**

--- a/src/jls/elem/NandGate.java
+++ b/src/jls/elem/NandGate.java
@@ -17,6 +17,7 @@ import javax.swing.*;
 public final class NandGate extends Gate {
 
 	// identity and shared previous-settings state (#22)
+	/** The kind descriptor for NAND gates (identity and shared previous settings). */
 	private static final Kind KIND =
 			new Kind("NAND","NandGate",-1,5);
 	

--- a/src/jls/elem/NorGate.java
+++ b/src/jls/elem/NorGate.java
@@ -17,6 +17,7 @@ import javax.swing.*;
 public final class NorGate extends Gate {
 
 	// identity and shared previous-settings state (#22)
+	/** This gate type's identity and shared previous-settings state (#22). */
 	private static final Kind KIND =
 			new Kind("NOR","NorGate",-1,5);
 	

--- a/src/jls/elem/NotGate.java
+++ b/src/jls/elem/NotGate.java
@@ -16,6 +16,7 @@ import java.util.*;
 public final class NotGate extends Gate {
 
 	// identity and shared previous-settings state (#22)
+	/** Kind descriptor for NOT gates: display name "NOT", save tag "NotGate", one fixed input, default delay 5. */
 	private static final Kind KIND =
 			new Kind("NOT","NotGate",1,5);
 

--- a/src/jls/elem/OrGate.java
+++ b/src/jls/elem/OrGate.java
@@ -16,6 +16,7 @@ import javax.swing.*;
 public final class OrGate extends Gate {
 
 	// identity and shared previous-settings state (#22)
+	/** The kind descriptor shared by all OR gates (#22). */
 	private static final Kind KIND =
 			new Kind("OR","OrGate",-1,10);
 	

--- a/src/jls/elem/Output.java
+++ b/src/jls/elem/Output.java
@@ -12,6 +12,7 @@ import java.util.*;
 public final class Output extends Put {
 	
 	// properties
+	/** True if this output is tri-state (can be electrically disconnected). */
 	private boolean triState = false;
 
 	/**

--- a/src/jls/elem/Pause.java
+++ b/src/jls/elem/Pause.java
@@ -178,6 +178,7 @@ public final class Pause extends LogicElement {
 	//	Simulation
 	//	-------------------------------------------------------------------------------
 
+	/** The input value assumed at simulation start: all zeros, or null when the input net is tri-state. */
 	private BitSet currentValue = new BitSet();
 
 	/**

--- a/src/jls/elem/Pause.java
+++ b/src/jls/elem/Pause.java
@@ -185,7 +185,7 @@ public final class Pause extends LogicElement {
 	 * 
 	 * @param sim The simulator.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
 	 */
 	@Override
 	public void initSim(Simulator sim) {
@@ -209,7 +209,7 @@ public final class Pause extends LogicElement {
 	 * @param sim The simulator to post events to.
 	 * @param todo Should be null.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
 	 */
 	@Override
 	public void react(long now, Simulator sim, Object todo) {

--- a/src/jls/elem/Pin.java
+++ b/src/jls/elem/Pin.java
@@ -21,12 +21,17 @@ public abstract sealed class Pin extends LogicElement
 		permits InputPin, OutputPin {
 	
 	// saved properties
+	/** The name of this pin. */
 	protected String name;
+	/** The number of bits in this pin. */
 	protected int bits;
+	/** Whether this pin is watched (shown in the signal trace). */
 	protected boolean watched = false;
+	/** The direction this pin faces. */
 	protected JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
-	
+
 	// editting properties
+	/** Whether the setup dialog was cancelled. */
 	protected boolean cancelled;
 	
 	/**
@@ -54,12 +59,12 @@ public abstract sealed class Pin extends LogicElement
 	 * Get the name of this pin.
 	 * 
 	 * @return the name.
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#pinValue()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#pinValue()
-	 * @see jls.SimulationSemanticsRegressionTest#pinValue()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#pinValue()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#pinValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pinValue()
 	 */
 	@Override
 	public String getName() {
@@ -232,6 +237,8 @@ public abstract sealed class Pin extends LogicElement
 
 	/**
 	 * The pin kind for user-facing messages ("Input" or "Output").
+	 *
+	 * @return the pin kind, "Input" or "Output".
 	 */
 	protected abstract String pinKind();
 
@@ -453,19 +460,20 @@ public abstract sealed class Pin extends LogicElement
 	// Simulation state shared by both pins
 	// -----------------------------------------------------------------
 
+	/** The current simulated value of this pin. */
 	protected BitSet currentValue = new BitSet();
 
 	/**
 	 * Get the current value.
 	 *
 	 * @return the current value.
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#pinValue()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#pinValue()
-	 * @see jls.SimulationSemanticsRegressionTest#pinValue()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#pinValue()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#pinValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pinValue()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
 	 */
 	@Override
 	public BitSet getCurrentValue() {

--- a/src/jls/elem/Pin.java
+++ b/src/jls/elem/Pin.java
@@ -149,6 +149,7 @@ public abstract sealed class Pin extends LogicElement
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for the attributes shared by both pins.
+	/** The saved attributes shared by both pin types, in save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -200,6 +201,7 @@ public abstract sealed class Pin extends LogicElement
 		}
 	);
 
+	/** Base attributes plus the shared pin attributes, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -501,12 +503,19 @@ public abstract sealed class Pin extends LogicElement
 	private class PinCreate extends ElementDialog {
 		
 		// properties
+		/** The text field for the pin name. */
 		private JTextField nameField = new JTextField("",12);
+		/** The text field for the bit width. */
 		private JTextField bitsField = new JTextField("1",5);
+		/** The key pad for entering the bit width. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,1,this);
+		/** Selects left orientation. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Selects right orientation (the default). */
 		private JRadioButton right = new JRadioButton("Right", true);
+		/** Selects up orientation. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Selects down orientation. */
 		private JRadioButton down = new JRadioButton("Down");
 		
 		/**

--- a/src/jls/elem/Put.java
+++ b/src/jls/elem/Put.java
@@ -22,11 +22,15 @@ public abstract sealed class Put
 	protected int xr;					// x-coordinate of center relative to element
 	/** The y-coordinate of the center of this put relative to the element. */
 	protected int yr;					// y-coordinate of center relative to element
+	/** The x-coordinate saved by savePosition, for restorePosition. */
 	private int savex;
+	/** The y-coordinate saved by savePosition, for restorePosition. */
 	private int savey;
 	/** The number of bits in this put (0 implies arbitrary). */
 	protected int bits;					// number of bits
+	/** True if this put is touching a WireEnd. */
 	private boolean touching = false;	// touching a WireEnd?
+	/** The WireEnd this put is attached to, or null if unattached. */
 	private WireEnd wireEnd = null;		// the WireEnd this put attached to
 	/** The copy of this put, to help cut/paste. */
 	protected Put myCopy;				// to help cut/paste

--- a/src/jls/elem/Put.java
+++ b/src/jls/elem/Put.java
@@ -14,15 +14,21 @@ public abstract sealed class Put
 		permits Input, Output {
 
 	// properties
+	/** The name of this put. */
 	protected String name;				// name
+	/** The element this put is a part of. */
 	protected LogicElement element;		// the element it is a part of
+	/** The x-coordinate of the center of this put relative to the element. */
 	protected int xr;					// x-coordinate of center relative to element
+	/** The y-coordinate of the center of this put relative to the element. */
 	protected int yr;					// y-coordinate of center relative to element
 	private int savex;
 	private int savey;
+	/** The number of bits in this put (0 implies arbitrary). */
 	protected int bits;					// number of bits
 	private boolean touching = false;	// touching a WireEnd?
 	private WireEnd wireEnd = null;		// the WireEnd this put attached to
+	/** The copy of this put, to help cut/paste. */
 	protected Put myCopy;				// to help cut/paste
 	
 	/**
@@ -61,9 +67,9 @@ public abstract sealed class Put
 	 * 
 	 * @return the put's name.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
 	 */
 	public String getName() {
 		
@@ -75,10 +81,10 @@ public abstract sealed class Put
 	 * 
 	 * @return The x-coordinate.
 	 *
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
-	 * @see jls.edit.DragCandidateBoundTest#putLocations()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#putLocations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
 	 */
 	public int getX() {
 		
@@ -90,10 +96,10 @@ public abstract sealed class Put
 	 * 
 	 * @return The y-coordinate.
 	 *
-	 * @see jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
-	 * @see jls.edit.DragCandidateBoundTest#putLocations()
-	 * @see jls.elem.GroupOrientationTest#puts()
-	 * @see jls.elem.OrientationGeometryTest#describe()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#indexCandidatesFindExactlyTheSamePutsAsAFullScan()
+	 * @jls.testedby jls.edit.DragCandidateBoundTest#putLocations()
+	 * @jls.testedby jls.elem.GroupOrientationTest#puts()
+	 * @jls.testedby jls.elem.OrientationGeometryTest#describe()
 	 */
 	public int getY() {
 		
@@ -105,7 +111,7 @@ public abstract sealed class Put
 	 * 
 	 * @return the number of bits.
 	 *
-	 * @see jls.ui.CircuitAssert#assertPutBits()
+	 * @jls.testedby jls.ui.CircuitAssert#assertPutBits()
 	 */
 	public int getBits() {
 		
@@ -117,8 +123,8 @@ public abstract sealed class Put
 	 * 
 	 * @return the element.
 	 *
-	 * @see jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public LogicElement getElement() {
 		
@@ -128,8 +134,10 @@ public abstract sealed class Put
 	/**
 	 * Get wire end this put is attached to, or null if not attached.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @return the wire end this put is attached to, or null if not attached.
+	 *
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public WireEnd getWireEnd() {
 		
@@ -141,10 +149,10 @@ public abstract sealed class Put
 	 * 
 	 * @return true if it is attached, false if not.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
-	 * @see jls.edit.TriStateBundleConnectTest#freeInput()
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freeInput()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public boolean isAttached() {
 		
@@ -281,6 +289,7 @@ public abstract sealed class Put
 // Simulation
 //-------------------------------------------------------------------------------
 		
+	/** The current simulated value of this put. */
 	protected BitSet currentValue;
 	
 } // end of Put class

--- a/src/jls/elem/Register.java
+++ b/src/jls/elem/Register.java
@@ -24,28 +24,50 @@ public final class Register extends LogicElement {
 	 * The triggering modes a register can have: Latch (level triggered),
 	 * PosFF (positive-edge triggered), and NegFF (negative-edge triggered).
 	 */
-	private enum Type {Latch, PosFF, NegFF};
-	
+	private enum Type {
+		/** Transparent latch (level triggered). */
+		Latch,
+		/** Positive-edge triggered flip-flop. */
+		PosFF,
+		/** Negative-edge triggered flip-flop. */
+		NegFF};
+
 	// default values
+	/** Default register name (empty until the user supplies one). */
 	private static final String defaultName = "";
+	/** Default trigger type (level-triggered latch). */
 	private static final Register.Type defaultType = Type.Latch;
+	/** Default number of bits. */
 	private static final int defaultBits = 1;
+	/** Default initial value (zero). */
 	private static final BigInteger defaultInitValue = BigInteger.ZERO;
+	/** Default radix for displaying/entering the initial value. */
 	private static final int defaultBase = 10;
-	private static final int defaultPropDelay = 50; 
-	
+	/** Default propagation delay in simulation time units. */
+	private static final int defaultPropDelay = 50;
+
 	// saved properties
+	/** The name of this register. */
 	private String name = defaultName;
+	/** The trigger type of this register (latch, pos-edge or neg-edge FF). */
 	private Type type = defaultType;
+	/** The number of bits in this register. */
 	private int bits = defaultBits;
+	/** The value this register holds when simulation starts. */
 	private BigInteger initialValue = defaultInitValue;
+	/** The radix used to display/enter the initial value in the edit dialog. */
 	private int base = defaultBase;
+	/** The propagation delay of this register. */
 	private int propDelay = defaultPropDelay;
+	/** True if this register's value is watched during simulation. */
 	private boolean watched = false;
+	/** The direction this register faces (position of D/C inputs vs Q outputs). */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
-	
+
 	// running properties
+	/** True if the user cancelled the create/modify dialog. */
 	private boolean cancelled;
+	/** True if a modify dialog changed the name to one that no longer fits the box. */
 	private boolean nameChanged;
 	
 	/**
@@ -478,6 +500,7 @@ public final class Register extends LogicElement {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes (name, bits, init, orient, delay, type, watch). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -606,6 +629,7 @@ public final class Register extends LogicElement {
 		}
 	);
 
+	/** Base element attributes followed by this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -873,21 +897,37 @@ public final class Register extends LogicElement {
 	private class RegisterEdit extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Text field for the register's name. */
 		private JTextField nameField = new JTextField(name);
+		/** Text field for the number of bits. */
 		private JTextField bitsField = new JTextField(bits+"");
+		/** Text field for the initial value. */
 		private JTextField valueField = new JTextField("");
+		/** Keypad for entering the number of bits. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,bits,this);
+		/** Keypad for entering the initial value. */
 		private KeyPad valuePad = new KeyPad(valueField,16,initialValue.longValue(),this);
+		/** Radio button selecting binary display of the initial value. */
 		private JRadioButton base2 = new JRadioButton("2");
+		/** Radio button selecting decimal display of the initial value. */
 		private JRadioButton base10 = new JRadioButton("10");
+		/** Radio button selecting hexadecimal display of the initial value. */
 		private JRadioButton base16 = new JRadioButton("16");
+		/** Radio button selecting a level-triggered latch. */
 		private JRadioButton latch = new JRadioButton("Level-Trig");
+		/** Radio button selecting a positive-edge triggered flip-flop. */
 		private JRadioButton posFF = new JRadioButton("Pos-Trig");
+		/** Radio button selecting a negative-edge triggered flip-flop. */
 		private JRadioButton negFF = new JRadioButton("Neg-Trig");
+		/** Radio button selecting leftward orientation. */
 		private JRadioButton left = new JRadioButton("Left");
+		/** Radio button selecting rightward orientation. */
 		private JRadioButton right = new JRadioButton("Right");
+		/** Radio button selecting upward orientation. */
 		private JRadioButton up = new JRadioButton("Up");
+		/** Radio button selecting downward orientation. */
 		private JRadioButton down = new JRadioButton("Down");
+		/** True if creating a new register, false if modifying an existing one. */
 		private boolean creating;
 		
 		/**
@@ -1186,6 +1226,7 @@ public final class Register extends LogicElement {
 		return true;
 	} // end of canChange method
 	
+	/** Graphics object saved by change() for use by the valueFits method. */
 	private Graphics saveg;
 
 	/**
@@ -1290,8 +1331,11 @@ public final class Register extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The value scheduled to appear on the outputs after the propagation delay. */
 	private BitSet toBeValue;
+	/** The value currently stored in this register. */
 	private BitSet currentValue = new BitSet();
+	/** The most recent value seen on the clock (C) input. */
 	private int currentC;
 	
 	/**

--- a/src/jls/elem/Register.java
+++ b/src/jls/elem/Register.java
@@ -1298,7 +1298,7 @@ public final class Register extends LogicElement {
 	 * Get the current value stored in this register.
 	 * 
 	 * @return the current value.
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
 	 */
 	@Override
 	public BitSet getCurrentValue() {
@@ -1313,7 +1313,7 @@ public final class Register extends LogicElement {
 	 * Initialize this element by setting its output pin and to-be value to 0.
 	 * 
 	 * @param sim Unused.
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
 	 */
 	@Override
 	public void initSim(Simulator sim) {

--- a/src/jls/elem/SMUtil.java
+++ b/src/jls/elem/SMUtil.java
@@ -14,6 +14,12 @@ import jls.*;
 public class SMUtil {
 
 	/**
+	 * Creates a helper instance; all functionality is in static methods.
+	 */
+	public SMUtil() {
+	} // end of constructor
+
+	/**
 	 * Compute angle given a height and width of a rectangle.
 	 * 
 	 * @param w The width.

--- a/src/jls/elem/ShiftRegister.java
+++ b/src/jls/elem/ShiftRegister.java
@@ -45,7 +45,7 @@ public final class ShiftRegister extends LogicElement {
 	 *
 	 * @return the violated constraint message, or null if valid.
 	 *
-	 * @see jls.elem.DialogValidationTest#shiftRegisterBitsRuleIsOneStringOnTwoSurfaces()
+	 * @jls.testedby jls.elem.DialogValidationTest#shiftRegisterBitsRuleIsOneStringOnTwoSurfaces()
 	 */
 	static String checkBits(int bits) {
 

--- a/src/jls/elem/ShiftRegister.java
+++ b/src/jls/elem/ShiftRegister.java
@@ -60,21 +60,37 @@ public final class ShiftRegister extends LogicElement {
 	 * sign fill (arithmetic). Each constant's name is also its save-file
 	 * tag, so the names must not change.
 	 */
-	private enum Type {LogicalLeft, LogicalRight, ArithmeticRight};
+	private enum Type {
+		/** Shift toward the high bit, filling with zeros. */
+		LogicalLeft,
+		/** Shift toward the low bit, filling with zeros. */
+		LogicalRight,
+		/** Shift toward the low bit, filling with copies of the sign bit. */
+		ArithmeticRight
+	};
 
 	// default values
+	/** The shift kind a new instance starts with. */
 	private static final Type defaultType = Type.LogicalLeft;
+	/** The data width a new instance starts with. */
 	private static final int defaultBits = 8;
+	/** The propagation delay a new instance starts with. */
 	private static final int defaultPropDelay = 25;
 
 	// saved properties
+	/** The shift kind of this instance. */
 	private Type type = defaultType;
+	/** The width of the data input and output, in bits. */
 	private int bits = defaultBits;
+	/** The propagation delay of this instance. */
 	private int propDelay = defaultPropDelay;
+	/** Which side of the element the output is on. */
 	private JLSInfo.Orientation outputOrientation = JLSInfo.Orientation.RIGHT;
+	/** Which side of the element the amount input is on. */
 	private JLSInfo.Orientation amountOrientation = JLSInfo.Orientation.DOWN;
 
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
 
 	/**
@@ -169,6 +185,8 @@ public final class ShiftRegister extends LogicElement {
 	/**
 	 * The transform from canonical geometry (output RIGHT) to the current
 	 * output orientation.
+	 *
+	 * @return the transform chain mapping canonical points to displayed points.
 	 */
 	private GridTransform.Chain placement() {
 
@@ -238,6 +256,7 @@ public final class ShiftRegister extends LogicElement {
 	// dispatch, and copy for this element's own attributes. The names
 	// and save order are the fork's, so 4.6-era fork files load
 	// unchanged (issue #122 H2).
+	/** This element's own persisted attributes, in the fork's save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("type") {
@@ -367,6 +386,7 @@ public final class ShiftRegister extends LogicElement {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -562,31 +582,45 @@ public final class ShiftRegister extends LogicElement {
 			implements java.awt.event.ActionListener {
 
 		// properties
+		/** Input field for the number of data bits. */
 		private javax.swing.JTextField bitsField =
 				new javax.swing.JTextField(defaultBits+"",5);
+		/** Keypad for entering the number of data bits. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Selects logical left shift. */
 		private javax.swing.JRadioButton shiftLeft =
 				new javax.swing.JRadioButton("Shift Left",true);
+		/** Selects logical right shift. */
 		private javax.swing.JRadioButton shiftRight =
 				new javax.swing.JRadioButton("Shift Right");
+		/** Selects arithmetic right shift. */
 		private javax.swing.JRadioButton shiftRightArith =
 				new javax.swing.JRadioButton("Shift Right Arithmetic");
+		/** Puts the output on the left side. */
 		private javax.swing.JRadioButton oLeft =
 				new javax.swing.JRadioButton("Left");
+		/** Puts the output on the right side. */
 		private javax.swing.JRadioButton oRight =
 				new javax.swing.JRadioButton("Right", true);
+		/** Puts the output on the top side. */
 		private javax.swing.JRadioButton oUp =
 				new javax.swing.JRadioButton("Up");
+		/** Puts the output on the bottom side. */
 		private javax.swing.JRadioButton oDown =
 				new javax.swing.JRadioButton("Down");
+		/** Puts the amount input on the left side. */
 		private javax.swing.JRadioButton sLeft =
 				new javax.swing.JRadioButton("Left");
+		/** Puts the amount input on the right side. */
 		private javax.swing.JRadioButton sRight =
 				new javax.swing.JRadioButton("Right");
+		/** Puts the amount input on the top side. */
 		private javax.swing.JRadioButton sUp =
 				new javax.swing.JRadioButton("Up");
+		/** Puts the amount input on the bottom side. */
 		private javax.swing.JRadioButton sDown =
 				new javax.swing.JRadioButton("Down",true);
+		/** Label above the amount orientation buttons. */
 		private javax.swing.JLabel olbl2 =
 				new javax.swing.JLabel("Amount Orientation");
 
@@ -820,6 +854,7 @@ public final class ShiftRegister extends LogicElement {
 //	Simulation
 //	-------------------------------------------------------------------------------
 
+	/** The value currently propagating toward the output. */
 	private BitSet toBeValue;
 
 	/**

--- a/src/jls/elem/SigEntry.java
+++ b/src/jls/elem/SigEntry.java
@@ -21,6 +21,7 @@ import javax.swing.JPopupMenu;
 public abstract class SigEntry extends Entry implements ActionListener {
 
 	// properties
+	/** The name of this signal. */
 	protected String signal;
 
 	// menu items

--- a/src/jls/elem/SigEntry.java
+++ b/src/jls/elem/SigEntry.java
@@ -25,9 +25,13 @@ public abstract class SigEntry extends Entry implements ActionListener {
 	protected String signal;
 
 	// menu items
+	/** Menu item to delete this signal's column. */
 	private JMenuItem remove = new JMenuItem("delete");
+	/** Menu item to rename this signal. */
 	private JMenuItem rename = new JMenuItem("rename");
+	/** Menu item to move this signal's column left. */
 	private JMenuItem moveLeft = new JMenuItem("move left");
+	/** Menu item to move this signal's column right. */
 	private JMenuItem moveRight = new JMenuItem("move right");
 
 	/**

--- a/src/jls/elem/SigGen.java
+++ b/src/jls/elem/SigGen.java
@@ -19,13 +19,17 @@ import jls.util.Placement;
 public final class SigGen extends SigSim {
 	
 	// named constants
+	/** Title drawn inside the element's box. */
 	private final String title = " Signal Generator ";
+	/** Width and height of the edit dialog's text pane, in pixels. */
 	private final int size = 300;	// width and height of dialog
 	
 	// saved properties
+	/** The signal specification text entered by the user. */
 	private String signals = "";
 	
 	// running properties
+	/** True if the user cancelled the edit dialog or made no change. */
 	private boolean cancelled = false;
 
 	/**
@@ -140,6 +144,7 @@ public final class SigGen extends SigSim {
 	// dispatch, and copy for this element's own attributes. The
 	// handwritten save escaped backslash, quote and newline exactly as
 	// Attribute.StringAttribute does.
+	/** Declarations of this element's own saved attributes, in save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("signals") {
@@ -162,6 +167,7 @@ public final class SigGen extends SigSim {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -226,6 +232,7 @@ public final class SigGen extends SigSim {
 	private class EditSignals extends ElementDialog {
 
 		// properties
+		/** Text area holding the signal specification. */
 		private JTextArea textArea = new JTextArea();
 
 		/**

--- a/src/jls/elem/State.java
+++ b/src/jls/elem/State.java
@@ -49,13 +49,21 @@ import jls.sim.Simulator;
 public class State {
 
 	// properties
+	/** the state machine this state is in. */
 	private StateMachine machine;	// the state machine this state is in
+	/** the name of this state. */
 	private String name;
+	/** true if this is the initial state of the machine. */
 	private boolean initial = false;
+	/** the outputs asserted by this state. */
 	private Vector<Out> outs = new Vector<Out>();
+	/** the transitions from this state. */
 	private Set<Transition> trans = new HashSet<Transition>();
+	/** the x-coordinate of the center of this state. */
 	private int x;
+	/** the y-coordinate of the center of this state. */
 	private int y;
+	/** the diameter of the circle representing this state. */
 	private int diameter;
 	/**
 	 * Tracks the bit width and direction of a signal used within this state,
@@ -64,19 +72,35 @@ public class State {
 	 * removed from the bitmap when it drops to zero.
 	 */
 	private static class Check {
+		/** the bit width of the signal. */
 		public int bits;
+		/** true if the signal is an input, false if an output. */
 		public boolean isInput;	// false if output
+		/** the number of outputs/transitions using the signal. */
 		public int refs; // delete from map when 0
+
+		/**
+		 * Create an empty check record.
+		 */
+		private Check() {
+		}
 	};
+	/** signal names mapped to bit width/direction info, for consistency checks. */
 	private Map <String,Check> bitmap = new HashMap<String,Check>();
 	// signal names to number of bits, for consistency check
 
 	// other temporary properties
+	/** the saved x-coordinate, for restoring the position after a move. */
 	private int savex;
+	/** the saved y-coordinate, for restoring the position after a move. */
 	private int savey;
+	/** true if this state is drawn highlighted. */
 	private boolean highlight;
+	/** the most recently highlighted transition, so it can be deleted. */
 	private Transition lastHighlighted;
+	/** the output currently being constructed during a load. */
 	private Out buildOut;
+	/** the transition currently being constructed during a load. */
 	private Transition buildTrans;
 
 	/**
@@ -84,9 +108,18 @@ public class State {
 	 */
 	private static class Out {
 
+		/** the output signal name. */
 		public String signal;
+		/** the number of bits in the output signal. */
 		public int bits;
+		/** the value the signal is set to in this state. */
 		public long value;
+
+		/**
+		 * Create an empty output.
+		 */
+		private Out() {
+		}
 
 		/**
 		 * Text representation of this output.
@@ -102,17 +135,34 @@ public class State {
 	 */
 	private static class Transition {
 
+		/** the input signal tested by the condition (empty if none). */
 		public String signal = "";
+		/** the number of bits in the condition signal. */
 		public int bits = 1;
+		/** true if the condition tests for equality, false for inequality. */
 		public boolean equal = true;
+		/** the value the condition signal is compared with. */
 		public int value = 0;
+		/** true if this transition is always taken. */
 		public boolean unconditional = true;
+		/** true if this transition is taken when no other condition holds. */
 		public boolean other = false;
+		/** the state this transition goes to. */
 		public State nextState;
+		/** the name of the state this transition goes to. */
 		public String nextStateName = null; // temporarily used during load
+		/** the intermediate points the transition line is drawn through. */
 		public Vector<Point>points = new Vector<Point>();
+		/** the corner point currently highlighted, or null if none. */
 		public Point highlight = null;
+		/** true if this transition is drawn highlighted. */
 		public boolean highlighted;
+
+		/**
+		 * Create a transition with default (unconditional) settings.
+		 */
+		private Transition() {
+		}
 	} // end of Transition class
 
 	/**
@@ -1375,23 +1425,36 @@ public class State {
 	private class CreateTrans extends ElementDialog implements ActionListener {
 
 		// properties
+		/** the transition being created or edited. */
 		private Transition trans;
+		/** the state the transition is from. */
 		private State myState;
+		/** input field for the condition signal name. */
 		private JTextField signalField = new JTextField(10);
+		/** button to toggle the condition between = and !=. */
 		private JButton equalOrNot = new JButton("=");
+		/** input field for the condition value. */
 		private JTextField valueField = new JTextField(10);
+		/** keypad for entering the condition value. */
 		private KeyPad valuePad = new KeyPad(valueField,10,0,this);
+		/** input field for the number of bits in the condition signal. */
 		private JTextField bitsField = new JTextField(10);
+		/** keypad for entering the number of bits. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,1,this);
+		/** selects a conditional transition. */
 		private JRadioButton conditional = new JRadioButton("conditional");
+		/** selects an unconditional transition. */
 		private JRadioButton unconditional = new JRadioButton("unconditional");
+		/** selects a transition taken when no other condition holds. */
 		private JRadioButton otherwise = new JRadioButton("if no other condition");
+		/** true if the dialog was cancelled. */
 		private boolean cancelled;
 
 		/**
 		 * Initialize dialog.
-		 * 
+		 *
 		 * @param tr The transition to edit.
+		 * @param st The state the transition is from.
 		 */
 		public CreateTrans(Transition tr, State st) {
 
@@ -1723,15 +1786,25 @@ public class State {
 	private class EditOutputs extends ElementDialog implements ActionListener {
 
 		// properties
+		/** displays the outputs of this state. */
 		private JList<Out> outList;
+		/** the list model backing the output list. */
 		DefaultListModel<Out> model;
+		/** button to add a new output. */
 		private JButton add = new JButton("add new output");
+		/** button to delete the selected output. */
 		private JButton delete = new JButton("delete selected output");
+		/** input field for the output signal name. */
 		private JTextField signalField = new JTextField(10);
+		/** input field for the output value. */
 		private JTextField valueField = new JTextField("1");
+		/** keypad for entering the output value. */
 		private KeyPad valuePad = new KeyPad(valueField,10,0,this);
+		/** input field for the number of bits in the output signal. */
 		private JTextField bitsField = new JTextField("1");
+		/** keypad for entering the number of bits. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,1,this);
+		/** true if the dialog was cancelled. */
 		private boolean cancelled;
 
 		/**

--- a/src/jls/elem/State.java
+++ b/src/jls/elem/State.java
@@ -118,7 +118,8 @@ public class State {
 	/**
 	 * Create a new state.
 	 * Make its diameter large enough to contain the name.
-	 * 
+	 *
+	 * @param machine The state machine element this state is part of.
 	 * @param name The name of the state.
 	 * @param g The Graphics object to use.
 	 */
@@ -503,8 +504,8 @@ public class State {
 	 *
 	 * @return the comparator ordering states for save.
 	 *
-	 * @see jls.DeterministicSaveTest#stateMachineSavesStatesInNameOrder()
-	 * @see jls.DeterministicSaveTest#stateMachineStateHashIsContentDetermined()
+	 * @jls.testedby jls.DeterministicSaveTest#stateMachineSavesStatesInNameOrder()
+	 * @jls.testedby jls.DeterministicSaveTest#stateMachineStateHashIsContentDetermined()
 	 */
 	static java.util.Comparator<State> saveOrder() {
 
@@ -808,8 +809,10 @@ public class State {
 
 	/**
 	 * See if this state overlaps another state.
-	 * 
+	 *
 	 * @param other the other state
+	 *
+	 * @return true if the states overlap, false if not.
 	 */
 	public boolean overlaps(State other) {
 
@@ -932,9 +935,11 @@ public class State {
 
 	/**
 	 * Change the name of this state if it fits.
-	 * 
+	 *
 	 * @param name The new name.
 	 * @param g The Graphics object to use.
+	 *
+	 * @return true if the name fits and was changed, false if not.
 	 */
 	public boolean changeName(String name, Graphics g) {
 
@@ -954,6 +959,7 @@ public class State {
 	 * 
 	 * @param to The state the transition is to.
 	 * @param points The list of points in the transition (the last one will not be used).
+	 * @param mainDialog The dialog to display error messages in.
 	 */
 	public void newTransition(State to, Vector<Point> points, JDialog mainDialog) {
 

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -67,19 +67,26 @@ import jls.util.Placement;
 public final class StateMachine extends LogicElement implements Printable {
 
 	// default values
+	/** Propagation delay a new state machine starts with. */
 	private static final int defaultPropDelay = 30;
+	/** Trigger edge a new state machine starts with. */
 	private static int defaultTrigger = 1;	// 1=rising, -1=falling
 
 	// the initial-state rule (issue #52, M13), stated once: the editor
 	// refuses to close without an initial state, and simulation start
 	// falls back benignly when a hand-edited file lacks one
+	/** The user-visible message when the initial-state rule is violated. */
 	static final String INITIAL_STATE_CONSTRAINT =
 			"A state machine needs an initial state - mark one before closing";
 
 	// saved properties
+	/** Time units between a triggering clock edge and the new output values. */
 	private int propDelay = defaultPropDelay;
+	/** The states of this machine. */
 	private Set<State> states = new HashSet<State>();
+	/** Triggering clock edge: 1 for rising, -1 for falling. */
 	private int trigger = defaultTrigger;
+	/** The name of this state machine. */
 	private String name = "";
 	
 	// for loading from file
@@ -87,14 +94,29 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * Parser state while reading a state machine from a file, naming which
 	 * kind of element the loader is currently building.
 	 */
-	private enum LoadState {machine, newState, newOutput, newTransition};
+	private enum LoadState {
+		/** Reading the machine's own attributes. */
+		machine,
+		/** The last line read started a new state. */
+		newState,
+		/** The last line read set an output of the state being built. */
+		newOutput,
+		/** The last line read set a transition of the state being built. */
+		newTransition
+	};
+	/** Where the file loader is in the state/output/transition structure. */
 	private LoadState loadState = LoadState.machine;
+	/** The state currently being built by the file loader. */
 	private State buildState;
 	
 	// running properties
+	/** True if the user cancelled the edit dialog. */
 	private boolean canceled;
+	/** The open editor dialog, used as the owner of child dialogs. */
 	private JDialog currentDialog;
+	/** The bounding box of all states, computed for scaled printing. */
 	private Rectangle bounds;
+	/** A copy of this machine made before editing, restored on cancel. */
 	private StateMachine original;
 
 	/**
@@ -416,6 +438,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	// list (state/output/trans/next/pair lines) is structured data and
 	// stays handwritten in save(), the setValue load state machine and
 	// copy().
+	/** This element's own saved attributes (name, delay, trig). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -456,6 +479,7 @@ public final class StateMachine extends LogicElement implements Printable {
 		}
 	);
 
+	/** Base attributes plus this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -888,8 +912,24 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * is currently doing (idle, placing or moving states, drawing transitions,
 	 * selecting, etc.) so mouse events are handled accordingly.
 	 */
-	private enum DrawState {idle, created, placing, selecting, selected, moving,
-		newTrans, pointMoving};
+	private enum DrawState {
+		/** No gesture in progress. */
+		idle,
+		/** A new state has just been created. */
+		created,
+		/** A new state is following the cursor to its place. */
+		placing,
+		/** A selection rectangle is being dragged out. */
+		selecting,
+		/** A selection exists and awaits a command. */
+		selected,
+		/** Selected states are being dragged. */
+		moving,
+		/** A new transition is being drawn. */
+		newTrans,
+		/** A transition corner point is being dragged. */
+		pointMoving
+	};
 	
 	/**
 	 * Create dialog.
@@ -899,31 +939,57 @@ public final class StateMachine extends LogicElement implements Printable {
 		implements ActionListener, MouseListener, MouseMotionListener {
 
 		// properties
+		/** The drawing area the states are edited in. */
 		private JPanel editArea;
+		/** Message display at the top of the dialog. */
 		private JLabel msgLabel = new JLabel("");
+		/** Shows the current interaction mode at the top right. */
 		private JLabel stateLabel = new JLabel(" ");
+		/** The current interaction mode of the drawing area. */
 		private DrawState drawState = DrawState.idle;
+		/** The latest mouse x-coordinate. */
 		private int x;
+		/** The latest mouse y-coordinate. */
 		private int y;
+		/** The selection rectangle being dragged out, or null if none. */
 		private Rectangle selrect = null;
+		/** The currently selected states. */
 		private Set<State> selected = new HashSet<State>();
+		/** The state under the most recent mouse press, or null if none. */
 		private State on;
+		/** Selects triggering on the rising clock edge. */
 		private JRadioButton rising = new JRadioButton("rising edge");
+		/** Selects triggering on the falling clock edge. */
 		private JRadioButton falling = new JRadioButton("falling edge");
+		/** Expands the drawing area. */
 		private JButton enlarge = new JButton("+");
+		/** Input field for the state machine's name. */
 		private JTextField nameField = new JTextField(30);
+		/** Popup menu item to rename a state. */
 		private JMenuItem changeName = new JMenuItem("change name");
+		/** Popup menu item to make a state the initial state. */
 		private JMenuItem makeInit = new JMenuItem("make initial state");
+		/** Popup menu item to start a new transition from a state. */
 		private JMenuItem addTrans = new JMenuItem("add transition");
+		/** Popup menu item to delete all transitions from a state. */
 		private JMenuItem deleteAllTrans = new JMenuItem("delete all transitions");
+		/** Popup menu item to edit a state's outputs. */
 		private JMenuItem editOutputs = new JMenuItem("edit outputs");
+		/** Popup menu item to view a state's outputs. */
 		private JMenuItem showOutputs = new JMenuItem("view outputs");
+		/** Popup menu item to delete the selected state(s). */
 		private JMenuItem delete = new JMenuItem("delete state(s)");
+		/** Popup menu item to align the selected states horizontally. */
 		private JMenuItem alignHor = new JMenuItem("align states horizontally");
+		/** Popup menu item to align the selected states vertically. */
 		private JMenuItem alignVer = new JMenuItem("align states vertically");
+		/** Midpoints of the transition being drawn; the last entry is the current end point. */
 		private Vector<Point> points = new Vector<Point>();
+		/** The transition corner point being dragged. */
 		private Point movingPoint;
+		/** True if the machine's name was changed when the dialog was accepted. */
 		private boolean nameChange;
+		/** The state machine being edited. */
 		private StateMachine machine;
 
 		/**
@@ -1888,14 +1954,18 @@ public final class StateMachine extends LogicElement implements Printable {
 	@SuppressWarnings("serial")
 	private class CreateState extends ElementDialog {
 
+		/** The accepted state name. */
 		private String name;
+		/** Input field for the state name. */
 		private JTextField nameField = new JTextField(10);
+		/** True if the user cancelled this dialog. */
 		private boolean stateCancelled;
 
 		/**
 		 * Create a new state.
 		 *
 		 * @param title The partial title of this dialog (e.g., "Create" or "Change");
+		 * @param currentName The name the name field starts with.
 		 */
 		public CreateState(String title, String currentName) {
 
@@ -2071,9 +2141,13 @@ public final class StateMachine extends LogicElement implements Printable {
 //	Simulation
 //	-------------------------------------------------------------------------------
 	
+	/** The most recently seen clock input value. */
 	private int oldClock;
+	/** True between a triggering clock edge and the new output values. */
 	private boolean busy = false;	// true between edge and outputs value
+	/** The state the machine is currently in. */
 	private State currentState;
+	/** True once the no-matching-transition warning has been shown. */
 	private boolean noMatchReported = false;	// no-matching-transition warned already? (#98, S5)
 	
 	/**

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -102,8 +102,8 @@ public final class StateMachine extends LogicElement implements Printable {
 	 *
 	 * @param circuit The circuit this element is part of.
 	 *
-	 * @see jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
-	 * @see jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
+	 * @jls.testedby jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
+	 * @jls.testedby jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
 	 */
 	public StateMachine(Circuit circuit) {
 
@@ -133,7 +133,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * @return the violated constraint message, or null if an initial
 	 *         state exists.
 	 *
-	 * @see jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
+	 * @jls.testedby jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
 	 */
 	String checkInitialState() {
 
@@ -474,7 +474,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * @param name The instance variable name.
 	 * @param value The instance variable value.
 	 *
-	 * @see jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
+	 * @jls.testedby jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
 	 */
 	@Override
 	public void setValue(String name, String value) {
@@ -548,7 +548,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	 * @param name The instance variable name.
 	 * @param value The instance variable value.
 	 *
-	 * @see jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
+	 * @jls.testedby jls.elem.DialogValidationTest#stateMachineInitialStateRuleIsSharedWithSimStart()
 	 */
 	@Override
 	public void setValue(String name, int value) {
@@ -2082,7 +2082,7 @@ public final class StateMachine extends LogicElement implements Printable {
 	 *
 	 * @param sim Unused.
 	 *
-	 * @see jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
+	 * @jls.testedby jls.elem.ParameterValidationTest#stateMachineWithoutInitialStateSurvivesSimInit()
 	 */
 	@Override
 	public void initSim(Simulator sim) {

--- a/src/jls/elem/SubCircuit.java
+++ b/src/jls/elem/SubCircuit.java
@@ -20,10 +20,15 @@ import java.util.*;
 public final class SubCircuit extends LogicElement implements TriProp {
 	
 	// properties
+	/** The imported subcircuit this element represents. */
 	private Circuit subCircuit;		// the subcircuit
+	/** The name this subcircuit has in the circuit it was imported into. */
 	private String name;			// the name in the circuit imported into
+	/** Map from this element's inputs to the corresponding input pins in the subcircuit. */
 	private Map<Input,InputPin> inmap = new HashMap<Input,InputPin>();
+	/** Map from the subcircuit's output pins to this element's corresponding outputs. */
 	private Map<OutputPin,Output> outmap = new HashMap<OutputPin,Output>();
+	/** The direction this element faces (side its inputs are on). */
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
 	
 	// editing properties
@@ -544,6 +549,7 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	
 	// used by setTriState to avoid infinite recursion when an
 	// input of this elements is connected to a tri-state propagating output
+	/** Input pins already visited by setTriState, to avoid infinite recursion. */
 	private Set<InputPin> pinsChecked = new HashSet<InputPin>();
 	
 	/**
@@ -635,8 +641,11 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	 */
 	private class SubCreate extends ElementDialog {
 			// properties
+			/** Text field for the subcircuit's name in this circuit. */
 			private JTextField nameField = new JTextField("",12);
+			/** Radio button selecting leftward orientation. */
 			private JRadioButton left = new JRadioButton("Left");
+			/** Radio button selecting rightward orientation. */
 			private JRadioButton right = new JRadioButton("Right",true);
 			
 			/**

--- a/src/jls/elem/SubCircuit.java
+++ b/src/jls/elem/SubCircuit.java
@@ -27,6 +27,7 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	private JLSInfo.Orientation orientation = JLSInfo.Orientation.RIGHT;
 	
 	// editing properties
+	/** True if the user cancelled the most recent dialog. */
 	protected boolean cancelled;
 	
 	/**
@@ -69,8 +70,8 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	 * Create a new subcircuit element.
 	 * 
 	 * @param circuit The circuit this element is part of.
-	 * @see jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
-	 * @see jls.elem.HollowVsFilledCollisionTest#probe()
+	 * @jls.testedby jls.edit.SaveAsNameCheckTest#importedCircuitsAreSkipped()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#probe()
 	 */
 	public SubCircuit(Circuit circuit) {
 		
@@ -91,7 +92,7 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	 * Get the subcircuit this element represents.
 	 * 
 	 * @return the subcircuit.
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
 	 */
 	public Circuit getSubCircuit() {
 		

--- a/src/jls/elem/TestGen.java
+++ b/src/jls/elem/TestGen.java
@@ -21,6 +21,7 @@ import java.util.*;
 public final class TestGen extends SigSim {
 	
 	// properties
+	/** The name of the file to read test inputs from. */
 	private String file = null;
 	
 	/**

--- a/src/jls/elem/Text.java
+++ b/src/jls/elem/Text.java
@@ -18,19 +18,29 @@ import javax.swing.*;
 public final class Text extends DisplayElement {
 
 	// named constants
+	/** Width and height of the text edit dialog, in pixels. */
 	private final int size = 500;	// width and height of dialog
 
 	// saved properties
+	/** The text to display, lines separated by newlines. */
 	private String text = "";
+	/** The font family name; empty until set from a file or from defaults. */
 	private String fontName = "";
+	/** The font point size; 0 until set from a file or from defaults. */
 	private int fontSize = 0;
+	/** True if the text is drawn in bold. */
 	private boolean isBold = false;
+	/** True if the text is drawn in italics. */
 	private boolean isItalic = false;
+	/** The color the text is drawn in. */
 	private Color color = Color.black;
 
 	// running properties
+	/** The text split into individual display lines. */
 	private Vector<String> lines = new Vector<String>();
+	/** True if the user cancelled the creation or edit dialog. */
 	private boolean cancelled = false;
+	/** True if the user changed font, size, style or color in the dialog. */
 	private boolean changed;
 
 	/**
@@ -139,6 +149,7 @@ public final class Text extends DisplayElement {
 
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes, in save order (#23). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("text") {
@@ -251,6 +262,7 @@ public final class Text extends DisplayElement {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order (#23). */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -382,20 +394,33 @@ public final class Text extends DisplayElement {
 	private class TextEdit extends ElementDialog implements ActionListener {
 
 		// GUI elements
+		/** Font family selector. */
 		private JComboBox<String> fonts;
+		/** Choices offered by the font size selector. */
 		private String [] fontSizes = {"8","9","10","11","12","13","14","15","16","17","18","19","20","24","28","32","36","40","48","56","64","72"};
+		/** Font size selector. */
 		private JComboBox<String> fontSz = new JComboBox<String>(fontSizes);
+		/** Button selecting bold text. */
 		private JRadioButton bold = new JRadioButton("Bold");
+		/** Button selecting italic text. */
 		private JRadioButton italic = new JRadioButton("Italic");
+		/** Button that brings up the color chooser. */
 		private JButton colorButton = new JButton("Color");
+		/** Area the user types the text into. */
 		private JTextArea textArea = new JTextArea();
 
 		// properties
+		/** The text as accepted by the dialog. */
 		private String result = "";
+		/** The currently selected font family name. */
 		private String fn = "";
+		/** The currently selected font size. */
 		private int fs = 0;
+		/** True if bold is currently selected. */
 		private boolean isB = false;
+		/** True if italic is currently selected. */
 		private boolean isI = false;
+		/** The currently chosen text color. */
 		private Color col = Color.black;
 
 		/**

--- a/src/jls/elem/TriState.java
+++ b/src/jls/elem/TriState.java
@@ -21,15 +21,22 @@ import javax.swing.*;
 public final class TriState extends LogicElement {
 	
 	// defaults
+	/** Default number of bits (gates). */
 	private static final int defaultBits = 1;
+	/** Default propagation delay. */
 	private static final int defaultPropDelay = 5;
-	
+
 	// saved properties
+	/** The number of bits (parallel tri-state gates). */
 	private int bits = defaultBits;
+	/** The propagation delay of this element. */
 	private int propDelay = defaultPropDelay;
+	/** The direction the output points. */
 	private JLSInfo.Orientation gateOrientation = JLSInfo.Orientation.RIGHT;
+	/** The side the control input is on. */
 	private JLSInfo.Orientation controlOrientation = JLSInfo.Orientation.DOWN;
 	// running properties
+	/** True if the user cancelled the creation dialog. */
 	private boolean cancelled;
 	
 	/**
@@ -105,6 +112,8 @@ public final class TriState extends LogicElement {
 	/**
 	 * The transform from canonical geometry (gate RIGHT, control DOWN)
 	 * to the current orientation pair.
+	 *
+	 * @return the transform for the current orientation pair.
 	 */
 	private GridTransform.Chain placement() {
 
@@ -186,6 +195,7 @@ public final class TriState extends LogicElement {
 	
 	// Declarative persistence (#23): one declaration drives save, load
 	// dispatch, and copy for this element's own attributes.
+	/** This element's own saved attributes (bits, delay, orientations). */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.IntAttribute("bits") {
@@ -270,6 +280,7 @@ public final class TriState extends LogicElement {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -468,16 +479,27 @@ public final class TriState extends LogicElement {
 	private class TriStateCreate extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Text field for the number of bits (gates). */
 		private JTextField bitsField = new JTextField(defaultBits+"",10);
+		/** Keypad for entering the number of bits. */
 		private KeyPad bitsPad = new KeyPad(bitsField,10,defaultBits,this);
+		/** Output orientation choice: left. */
 		private JRadioButton oLeft = new JRadioButton("Left");
+		/** Output orientation choice: right (the default). */
 		private JRadioButton oRight = new JRadioButton("Right", true);
+		/** Output orientation choice: up. */
 		private JRadioButton oUp = new JRadioButton("Up");
+		/** Output orientation choice: down. */
 		private JRadioButton oDown = new JRadioButton("Down");
+		/** Control orientation choice: left. */
 		private JRadioButton sLeft = new JRadioButton("Left");
+		/** Control orientation choice: right. */
 		private JRadioButton sRight = new JRadioButton("Right");
+		/** Control orientation choice: up. */
 		private JRadioButton sUp = new JRadioButton("Up");
+		/** Control orientation choice: down (the default). */
 		private JRadioButton sDown = new JRadioButton("Down",true);
+		/** Label for the control orientation choices. */
 		private JLabel olbl2 = new JLabel("Control Orientation");
 		
 		/**
@@ -671,6 +693,7 @@ public final class TriState extends LogicElement {
 
 	// the value scheduled to reach the output, null meaning off (HiZ);
 	// used to suppress redundant output events (issue #98, S6)
+	/** The value scheduled to reach the output, null meaning off (HiZ). */
 	private BitSet toBeValue;
 
 	/**

--- a/src/jls/elem/TriState.java
+++ b/src/jls/elem/TriState.java
@@ -36,8 +36,8 @@ public final class TriState extends LogicElement {
 	 * Create a new Gate object.
 	 * Subclass constructors do most of the work.
 	 * 
-	 * @param circuit
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @param circuit The circuit this element is part of.
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	public TriState(Circuit circuit) {
 		
@@ -80,7 +80,7 @@ public final class TriState extends LogicElement {
 	 * Sets up size, inputs and output.
 	 * 
 	 * @param g Unused.
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	@Override
 	public void init(Graphics g) {
@@ -677,7 +677,7 @@ public final class TriState extends LogicElement {
 	 * Initialize this element by setting its output pin to off (null).
 	 *
 	 * @param sim Unused.
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	@Override
 	public void initSim(Simulator sim) {
@@ -695,7 +695,7 @@ public final class TriState extends LogicElement {
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
 	 * @param todo If null, an input has changed, otherwise it is the value to output.
-	 * @see jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	@Override
 	public void react(long now, Simulator sim, Object todo) {

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -51,12 +51,16 @@ import jls.sim.Simulator;
 public final class TruthTable extends LogicElement implements Printable {
 
 	// default values
-	private static final int defaultDelay = 30; 
+	/** Default propagation delay (simulation time units). */
+	private static final int defaultDelay = 30;
+	/** Initial width of the edit dialog, in pixels. */
 	private static final int dialogWidth = 300;
+	/** Initial height of the edit dialog, in pixels. */
 	private static final int dialogHeight = 500;
 
 	// dialog-side constraint (issue #52): a table with no signals cannot
 	// compute anything
+	/** Error message shown when the table has no input or no output signal. */
 	static final String SIGNALS_CONSTRAINT =
 			"Must have at least one input signal and one output signal";
 
@@ -79,24 +83,41 @@ public final class TruthTable extends LogicElement implements Printable {
 	} // end of entryConstraint method
 
 	// properties
+	/** The name of this truth table element. */
 	private String name = "";
+	/** Propagation delay from an input change to the outputs (simulation time units). */
 	private int propDelay = defaultDelay;
+	/** Names of the input signals, in column order. */
 	private Vector<String>inputNames = new Vector<String>();
+	/** Names of the output signals, in column order. */
 	private Vector<String>outputNames = new Vector<String>();
+	/** Table entries, indexed by row then column (inputs first, then outputs); 0, 1 or 2 (don't care). */
 	private int[][] table = new int[0][0];
 
 	// running properties
+	/** True if the user cancelled the edit dialog. */
 	private boolean cancelled;
+	/** True if the edit dialog changed the element's name. */
 	private boolean nameChanged;
+	/** True if the edit dialog changed the signals or table entries. */
 	private boolean anyChanges;
+	/** The current edit dialog (parent for error popups). */
 	TTEditor edit;
+	/** The panel that draws the truth table in the edit dialog and when printing. */
 	DisplayBool disp;
+	/** Number of rows in the table. */
 	private int rows;
+	/** Number of columns in the table (inputs plus outputs). */
 	private int cols;
+	/** Row of the next table entry read from a file. */
 	private int irow = 0;	// for reading from a file
+	/** Column of the next table entry read from a file. */
 	private int icol = 0;
+	/** Copy of the input names saved before an edit, restored on cancel. */
 	private Vector<String>iNCopy = new Vector<String>();
+	/** Copy of the output names saved before an edit, restored on cancel. */
 	private Vector<String>oNCopy = new Vector<String>();
+	/** Copy of the table entries saved before an edit, restored on cancel. */
 	private int[][] tcopy = new int[0][0];
 
 	/**
@@ -286,6 +307,7 @@ public final class TruthTable extends LogicElement implements Printable {
 	// dispatch, and copy for this element's simple attributes. The
 	// repeated " String input"/" String output" and " pair" lines are
 	// list-valued and stay handwritten in save(), setValue and setPair.
+	/** Declarations of this element's own saved attributes, in save order. */
 	private static final java.util.List<Attribute> OWN_ATTRIBUTES =
 			java.util.List.of(
 		new Attribute.StringAttribute("name") {
@@ -339,6 +361,7 @@ public final class TruthTable extends LogicElement implements Printable {
 		}
 	);
 
+	/** Base attributes followed by this element's own, in save order. */
 	private static final java.util.List<Attribute> ALL_ATTRIBUTES =
 			concatAttributes(OWN_ATTRIBUTES);
 
@@ -648,12 +671,17 @@ public final class TruthTable extends LogicElement implements Printable {
 	private class TTEditor extends ElementDialog implements ActionListener {
 
 		// properties
+		/** Text field for typing the name of a new input signal. */
 		private JTextField inputField = new JTextField(10);
+		/** Text field for typing the name of a new output signal. */
 		private JTextField outputField = new JTextField(10);
+		/** Text field for editing the element's name. */
 		private JTextField nameField = new JTextField(10);
 
 		/**
 		 * Initialize and show dialog.
+		 *
+		 * @param ttelem The truth table element being created or edited.
 		 */
 		public TTEditor(TruthTable ttelem) {
 
@@ -1571,6 +1599,7 @@ public final class TruthTable extends LogicElement implements Printable {
 	// Simulation
 	//-------------------------------------------------------------------------------
 
+	/** The value (0 or 1) each output will have once its pending event fires, indexed by output position. */
 	private int[] toBeValue;
 	/**
 	 * A pending output change carried through the simulator: an output pin's
@@ -1578,8 +1607,16 @@ public final class TruthTable extends LogicElement implements Printable {
 	 * should take on when the scheduled event fires.
 	 */
 	static class Out {
+		/** Index of the output pin in the outputs list. */
 		int position;
+		/** The value the output pin should take on. */
 		BitSet value;
+
+		/**
+		 * Create a pending output change.
+		 */
+		Out() {
+		}
 	}
 
 	/**

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -70,7 +70,7 @@ public final class TruthTable extends LogicElement implements Printable {
 	 *
 	 * @return the constraint message for that entry.
 	 *
-	 * @see jls.elem.DialogValidationTest#truthTableEntryRuleHasOneWording()
+	 * @jls.testedby jls.elem.DialogValidationTest#truthTableEntryRuleHasOneWording()
 	 */
 	static String entryConstraint(int row, int col) {
 
@@ -1517,6 +1517,8 @@ public final class TruthTable extends LogicElement implements Printable {
 
 	/**
 	 * Get default propagation delay.
+	 *
+	 * @return the default propagation delay.
 	 */
 	public int getDefaultDelay() {
 

--- a/src/jls/elem/ValEntry.java
+++ b/src/jls/elem/ValEntry.java
@@ -14,6 +14,7 @@ import java.awt.Graphics;
 public abstract class ValEntry extends Entry {
 
 	// properties
+	/** The value displayed in this cell: 0 or 1, or 2 for don't-care. */
 	int value = 0;  // 0 or 1, 2 = don't care
 
 	/**

--- a/src/jls/elem/Wire.java
+++ b/src/jls/elem/Wire.java
@@ -30,8 +30,8 @@ public final class Wire extends Element {
 	 * @param e1 One end of the wire.
 	 * @param e2 The other end of the wire.
 	 *
-	 * @see jls.edit.WireSweepSymmetryTest#wire()
-	 * @see jls.elem.HollowVsFilledCollisionTest#edge()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wire()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#edge()
 	 */
 	public Wire(WireEnd e1, WireEnd e2) {
 		
@@ -66,14 +66,14 @@ public final class Wire extends Element {
 	 * 
 	 * @return one end.
 	 *
-	 * @see jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
-	 * @see jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
-	 * @see jls.edit.WireSweepSymmetryTest#elementsMovingWithTheSelectionAreSkipped()
-	 * @see jls.edit.WireSweepSymmetryTest#endsOf()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
-	 * @see jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
-	 * @see jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
+	 * @jls.testedby jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#clearWireCollidesInNeitherDirection()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#elementsMovingWithTheSelectionAreSkipped()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#endsOf()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireCrossingWireStaysLegal()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireHangingOffAnElementDoesNotCollideWithIt()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wireSweepingAcrossElementCollidesLikeTheReverseDrag()
 	 */
 	public WireEnd getEnd() {
 		
@@ -87,8 +87,8 @@ public final class Wire extends Element {
 	 * 
 	 * @return the other end of the wire.
 	 *
-	 * @see jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
-	 * @see jls.edit.WireSweepSymmetryTest#endsOf()
+	 * @jls.testedby jls.UtilFunctionsTest#copyReproducesElementsWiresAndAttachment()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#endsOf()
 	 */
 	public WireEnd getOtherEnd(WireEnd end) {
 		

--- a/src/jls/elem/Wire.java
+++ b/src/jls/elem/Wire.java
@@ -17,11 +17,17 @@ import javax.swing.JLabel;
 public final class Wire extends Element {
 	
 	// properties
+	/** The wire net this wire is a part of. */
 	private WireNet net;		// the wire net it is a part of
+	/** One end of this wire. */
 	private WireEnd end1;		// the wire ends
+	/** The other end of this wire. */
 	private WireEnd end2;
+	/** Traversal flag used when partitioning a wire net into new nets. */
 	private boolean marked;		// used to partition wire net
+	/** True if the mouse is currently touching this wire, so it highlights. */
 	private boolean touching;	// touching a wire end?
+	/** The name of the probe on this wire, or null if it has no probe. */
 	private String probeName = null;
 	
 	/**

--- a/src/jls/elem/WireEnd.java
+++ b/src/jls/elem/WireEnd.java
@@ -15,19 +15,30 @@ import javax.swing.*;
 public final class WireEnd extends LogicElement {
 	
 	// properties
+	/** The wire net this end is a part of. */
 	private WireNet net;							// the net it is a part of
 	// insertion order keeps wire-net construction (and so multi-driver
 	// resolution) deterministic (issue #98, S1)
+	/** The wires this end is connected to, in insertion order. */
 	private Set<Wire> wires = new LinkedHashSet<Wire>();	// the wires it is connected to
+	/** The input or output this end is attached to, if any. */
 	private Put put = null;							// the put it is attached to
+	/** True when this end overlaps something it could connect to. */
 	private boolean touching = false;				// touching something (can connect)?
+	/** Visit flag used when partitioning a wire net. */
 	private boolean marked;							// used to partition wire net
+	/** The copy of this end made during cut/paste. */
 	private WireEnd myCopy;							// for cut/paste
+	/** Saved id of the element this end is attached to, while loading. */
 	private int loadAttach;							// for loading circuit
+	/** Saved name of the put this end is attached to, while loading. */
 	private String loadPut = null;					// for loading circuit
+	/** Saved tri-state flag of this end's net, while loading. */
 	private boolean loadTriState = false;			// for loading circuit
+	/** Saved ids of the wire ends this end is wired to, in file order, while loading. */
 	private Set<Integer> loadWires = 				// for loading circuit
 		new LinkedHashSet<Integer>();				// (file order - #98, S1)
+	/** Saved probe names, keyed by the other wire end's id, while loading. */
 	private Map<Integer,String> probeMap =			// for loading circuit
 		new HashMap<Integer,String>();
 	

--- a/src/jls/elem/WireEnd.java
+++ b/src/jls/elem/WireEnd.java
@@ -47,10 +47,10 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @param circuit The circuit the wire end is in.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
-	 * @see jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
-	 * @see jls.edit.WireSweepSymmetryTest#wire()
-	 * @see jls.elem.HollowVsFilledCollisionTest#corner()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#landingOnAStationaryWireEndStillCollides()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wire()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#corner()
 	 */
 	public WireEnd(Circuit circuit) {
 		
@@ -73,7 +73,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @param circ The circuit this wire end is in.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
 	 */
 	public void init(Circuit circ) {
 		
@@ -133,7 +133,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return The x-coordinate.
 	 *
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
 	 */
 	@Override
 	public int getX() {
@@ -146,7 +146,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return The y-coordinate.
 	 *
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
 	 */
 	@Override
 	public int getY() {
@@ -159,8 +159,8 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @param wire The wire to add.
 	 *
-	 * @see jls.edit.WireSweepSymmetryTest#wire()
-	 * @see jls.elem.HollowVsFilledCollisionTest#edge()
+	 * @jls.testedby jls.edit.WireSweepSymmetryTest#wire()
+	 * @jls.testedby jls.elem.HollowVsFilledCollisionTest#edge()
 	 */
 	public void addWire(Wire wire) {
 		
@@ -256,6 +256,8 @@ public final class WireEnd extends LogicElement {
 	
 	/**
 	 * Remove wire from this wire end, and do nothing else.
+	 *
+	 * @param wire The wire to remove.
 	 */
 	public void remove(Wire wire) {
 		
@@ -321,8 +323,8 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return the put attached to.
 	 *
-	 * @see jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.UtilFunctionsTest#copyOfAPartialSelectionDropsDanglingWires()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public Put getPut() {
 		
@@ -334,7 +336,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return true if it is, false if not.
 	 *
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public boolean isAttached() {
 		
@@ -399,8 +401,8 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return true if it is, false if it is not.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#danglingEnd()
-	 * @see jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#danglingEnd()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshWireMayAttachToTriStateBundle()
 	 */
 	public boolean isTriState() {
 		
@@ -469,7 +471,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @param net The new wire net.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
 	 */
 	public void setNet(WireNet net) {
 		
@@ -481,10 +483,10 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return This wire end's wire net.
 	 *
-	 * @see jls.UtilFunctionsTest#partitionRebuildsWireNets()
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
-	 * @see jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.UtilFunctionsTest#partitionRebuildsWireNets()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public WireNet getNet() {
 		
@@ -496,7 +498,7 @@ public final class WireEnd extends LogicElement {
 	 * 
 	 * @return true if dangling, false if not.
 	 *
-	 * @see jls.edit.TriStateBundleConnectTest#danglingEnd()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#danglingEnd()
 	 */
 	public boolean isDangling() {
 		

--- a/src/jls/elem/WireNet.java
+++ b/src/jls/elem/WireNet.java
@@ -15,10 +15,15 @@ public class WireNet {
 	// properties
 	// insertion order (file order for a loaded circuit) makes the
 	// multi-driver resolution in propagate deterministic (issue #98, S1)
+	/** The wire ends in this net, in insertion order. */
 	private Set<WireEnd>ends = new LinkedHashSet<WireEnd>();	// the wire ends in this net
+	/** The wires in this net, in insertion order. */
 	private Set<Wire>wires = new LinkedHashSet<Wire>();	// the wires in this net
+	/** The number of bits (0=not connected). */
 	private int bits = 0;								// the number of bits (0=not connected)
+	/** True once this net is connected to an Output. */
 	private boolean hasinput = false;					// connected to an Output yet?
+	/** True if this net is tri-stated. */
 	private boolean triState = false;					// true if tri-stated
 
 	/**
@@ -388,7 +393,9 @@ public class WireNet {
 // Simulation
 //-------------------------------------------------------------------------------
 		
+	/** The current value on this net (null when tri-stated off). */
 	private BitSet value = new BitSet(1);
+	/** True once a bus conflict has been reported, until it clears. */
 	private boolean conflictReported = false;	// bus-conflict warned already? (#98, S1)
 
 	/**

--- a/src/jls/elem/WireNet.java
+++ b/src/jls/elem/WireNet.java
@@ -20,7 +20,14 @@ public class WireNet {
 	private int bits = 0;								// the number of bits (0=not connected)
 	private boolean hasinput = false;					// connected to an Output yet?
 	private boolean triState = false;					// true if tri-stated
-	
+
+	/**
+	 * Create an empty wire net; wires and wire ends are added as they
+	 * are connected.
+	 */
+	public WireNet() {
+	} // end of constructor
+
 	/**
 	 * Make a copy of this element.
 	 * Wirenets are not copied.
@@ -35,7 +42,7 @@ public class WireNet {
 	 * Add a new wire end.
 	 * 
 	 * @param end The new wire end.
-	 * @see jls.edit.TriStateBundleConnectTest#freshEnd()
+	 * @jls.testedby jls.edit.TriStateBundleConnectTest#freshEnd()
 	 */
 	public void add(WireEnd end) {
 		
@@ -313,9 +320,9 @@ public class WireNet {
 	 * Get all wire ends in this net.
 	 * 
 	 * @return all wire ends.
-	 * @see jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
-	 * @see jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
-	 * @see jls.ui.CircuitAssert#reaches()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireClearsSelectionAndSelectsNewEnd()
+	 * @jls.testedby jls.edit.CtrlWGestureTest#startWireFromEmptySelectionMatchesOldBehavior()
+	 * @jls.testedby jls.ui.CircuitAssert#reaches()
 	 */
 	public Set<WireEnd> getAllEnds() {
 		

--- a/src/jls/elem/XorGate.java
+++ b/src/jls/elem/XorGate.java
@@ -16,6 +16,7 @@ import javax.swing.*;
 public final class XorGate extends Gate {
 
 	// identity and shared previous-settings state (#22)
+	/** The kind descriptor and shared previous-settings state for XOR gates. */
 	private static final Kind KIND =
 			new Kind("XOR","XorGate",-1,10);
 	

--- a/src/jls/hdl/HdlExporter.java
+++ b/src/jls/hdl/HdlExporter.java
@@ -126,18 +126,18 @@ public final class HdlExporter {
 	 * @throws HdlExportException if the circuit contains elements the
 	 * exporter cannot express; the message names all of them.
 	 *
-	 * @see jls.hdl.HdlPolicyTest#decoderWithUnattachedInputConstantlyDrivesBitZero()
-	 * @see jls.hdl.HdlPolicyTest#displayIsSkippedWithAWarning()
-	 * @see jls.hdl.HdlPolicyTest#memoryIsRejectedByName()
-	 * @see jls.hdl.HdlPolicyTest#muxWithUnattachedSelectPassesInputZeroThrough()
-	 * @see jls.hdl.HdlPolicyTest#rejectionListsEveryOffenderInOneMessage()
-	 * @see jls.hdl.HdlPolicyTest#simulationControlElementsAreAllSkipped()
-	 * @see jls.hdl.HdlPolicyTest#subCircuitIsRejectedCleanly()
-	 * @see jls.hdl.HdlPolicyTest#unconnectedOutputPinWarnsAndLeavesThePortUndriven()
-	 * @see jls.hdl.VerilogExportGoldenTest#assertGolden()
-	 * @see jls.hdl.VhdlEmitterPolicyTest#export()
-	 * @see jls.hdl.VhdlEmitterPolicyTest#verilogAndVhdlShareOneModelWalk()
-	 * @see jls.hdl.VhdlExportGoldenTest#assertGolden()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#decoderWithUnattachedInputConstantlyDrivesBitZero()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#displayIsSkippedWithAWarning()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#memoryIsRejectedByName()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#muxWithUnattachedSelectPassesInputZeroThrough()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#rejectionListsEveryOffenderInOneMessage()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#simulationControlElementsAreAllSkipped()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#subCircuitIsRejectedCleanly()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#unconnectedOutputPinWarnsAndLeavesThePortUndriven()
+	 * @jls.testedby jls.hdl.VerilogExportGoldenTest#assertGolden()
+	 * @jls.testedby jls.hdl.VhdlEmitterPolicyTest#export()
+	 * @jls.testedby jls.hdl.VhdlEmitterPolicyTest#verilogAndVhdlShareOneModelWalk()
+	 * @jls.testedby jls.hdl.VhdlExportGoldenTest#assertGolden()
 	 */
 	public static Result export(Circuit circ, HdlEmitter emitter)
 			throws HdlExportException {
@@ -155,7 +155,7 @@ public final class HdlExporter {
 	 *
 	 * @throws HdlExportException on inexpressible elements.
 	 *
-	 * @see jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
 	 */
 	public static HdlModel buildModel(Circuit circ)
 			throws HdlExportException {

--- a/src/jls/hdl/HdlModel.java
+++ b/src/jls/hdl/HdlModel.java
@@ -219,7 +219,10 @@ public final class HdlModel {
 		 * @param statement the statement to emit
 		 */
 		void visit(BitMapStatement statement);
-		/** Emit a selected-assignment (Mux/Decoder) statement. */
+		/**
+		 * Emit a selected-assignment (Mux/Decoder) statement.
+		 * @param statement the statement to emit
+		 */
 		void visit(SelectStatement statement);
 	} // end of StatementVisitor interface
 
@@ -559,10 +562,15 @@ public final class HdlModel {
 	 */
 	public static final class SelectStatement extends Statement {
 
+		/** The (always net) selector value. */
 		public final Operand selector;
+		/** Value taken per selector index. */
 		public final List<Operand> values;
+		/** Value taken for any other selector value. */
 		public final Operand defaultValue;
+		/** Net driven by the selection. */
 		public final String target;
+		/** Width of the target and every value in bits. */
 		public final int bits;
 		/**
 		 * State-variable name for emitters whose selected assignment
@@ -646,7 +654,7 @@ public final class HdlModel {
 	/**
 	 * Gives the internal nets.
 	 * @return the internal nets, unmodifiable
-	 * @see jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
 	 */
 	public List<Net> nets() {
 		return Collections.unmodifiableList(nets);

--- a/src/jls/hdl/HdlModel.java
+++ b/src/jls/hdl/HdlModel.java
@@ -582,6 +582,8 @@ public final class HdlModel {
 		public final String helperName;
 
 		/**
+		 * Create a selected-assignment statement.
+		 *
 		 * @param comment identifies the source element
 		 * @param selector the (always net) selector value
 		 * @param values value taken per selector index (defensively copied)

--- a/src/jls/hdl/VerilogEmitter.java
+++ b/src/jls/hdl/VerilogEmitter.java
@@ -24,7 +24,7 @@ public final class VerilogEmitter implements HdlEmitter {
 	 * Renders the elaborated model as one complete Verilog module.
 	 * @param model the HDL model (ports, nets, statements) to export
 	 * @return the module source text, deterministic and self-contained
-	 * @see jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
+	 * @jls.testedby jls.hdl.HdlPolicyTest#twoNetsBridgedByJumpsBecomeOneVerilogNet()
 	 */
 	@Override
 	public String emit(HdlModel model) {

--- a/src/jls/hdl/layout/LayoutException.java
+++ b/src/jls/hdl/layout/LayoutException.java
@@ -10,6 +10,7 @@ package jls.hdl.layout;
  */
 public class LayoutException extends Exception {
 
+	/** Serialization version. */
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/src/jls/hdl/layout/LayoutGraph.java
+++ b/src/jls/hdl/layout/LayoutGraph.java
@@ -116,6 +116,8 @@ public final class LayoutGraph {
 		}
 
 		/**
+		 * Lists this element's ports.
+		 *
 		 * @return the node's ports in declaration order, unmodifiable
 		 */
 		public List<Port> ports() {
@@ -194,6 +196,13 @@ public final class LayoutGraph {
 	private final List<Edge> edges = new ArrayList<Edge>();
 
 	/**
+	 * Creates an empty graph; the builder populates it with
+	 * {@link #add} and {@link #connect}.
+	 */
+	public LayoutGraph() {
+	}
+
+	/**
 	 * Adds an element to the graph.
 	 *
 	 * @param node the element to add
@@ -251,6 +260,8 @@ public final class LayoutGraph {
 	}
 
 	/**
+	 * Lists the elements to place.
+	 *
 	 * @return the elements in insertion order, unmodifiable
 	 */
 	public List<Node> nodes() {
@@ -276,6 +287,8 @@ public final class LayoutGraph {
 	}
 
 	/**
+	 * Lists the point-to-point connections.
+	 *
 	 * @return the connections in insertion order, unmodifiable
 	 */
 	public List<Edge> edges() {

--- a/src/jls/hdl/layout/LayoutGraph.java
+++ b/src/jls/hdl/layout/LayoutGraph.java
@@ -81,6 +81,7 @@ public final class LayoutGraph {
 		public final int width;
 		/** Element height in pixels (a positive multiple of the grid). */
 		public final int height;
+		/** The element's ports by name, in declaration order. */
 		private final Map<String, Port> ports =
 				new LinkedHashMap<String, Port>();
 
@@ -191,8 +192,10 @@ public final class LayoutGraph {
 		}
 	} // end of Edge class
 
+	/** The graph's elements by id, in insertion order. */
 	private final Map<String, Node> nodes =
 			new LinkedHashMap<String, Node>();
+	/** The graph's connections, in insertion order. */
 	private final List<Edge> edges = new ArrayList<Edge>();
 
 	/**

--- a/src/jls/hdl/layout/LayoutInvariants.java
+++ b/src/jls/hdl/layout/LayoutInvariants.java
@@ -18,6 +18,9 @@ import jls.JLSInfo;
  */
 public final class LayoutInvariants {
 
+	/**
+	 * Not instantiable; this class offers static checks only.
+	 */
 	private LayoutInvariants() {
 		// static checks only
 	}
@@ -150,6 +153,8 @@ public final class LayoutInvariants {
 	}
 
 	/**
+	 * Tests whether a pixel coordinate lies on the snap grid.
+	 *
 	 * @param coordinate a pixel coordinate
 	 *
 	 * @return true if the coordinate lies on the snap grid

--- a/src/jls/hdl/layout/LayoutMetrics.java
+++ b/src/jls/hdl/layout/LayoutMetrics.java
@@ -412,6 +412,8 @@ public final class LayoutMetrics {
 	}
 
 	/**
+	 * Tells whether the layout passes the quality rubric.
+	 *
 	 * @return true if the layout meets every numeric launch threshold
 	 */
 	public boolean meetsRubric() {

--- a/src/jls/hdl/layout/LayoutMetrics.java
+++ b/src/jls/hdl/layout/LayoutMetrics.java
@@ -106,10 +106,15 @@ public final class LayoutMetrics {
 	/** One axis-aligned wire segment, endpoints normalized. */
 	private static final class Segment {
 
+		/** The net this segment belongs to. */
 		final String netName;
+		/** The smaller x endpoint coordinate. */
 		final int x1;
+		/** The smaller y endpoint coordinate. */
 		final int y1;
+		/** The larger x endpoint coordinate. */
 		final int x2;
+		/** The larger y endpoint coordinate. */
 		final int y2;
 
 		/**
@@ -128,12 +133,20 @@ public final class LayoutMetrics {
 			this.y2 = Math.max(from.y, to.y);
 		}
 
-		/** @return true if the segment is horizontal */
+		/**
+		 * Tells whether this segment runs horizontally.
+		 *
+		 * @return true if the segment is horizontal
+		 */
 		boolean horizontal() {
 			return y1 == y2;
 		}
 
-		/** @return the segment's Manhattan length in pixels */
+		/**
+		 * The length of this segment.
+		 *
+		 * @return the segment's Manhattan length in pixels
+		 */
 		long length() {
 			return (long) (x2 - x1) + (y2 - y1);
 		}

--- a/src/jls/hdl/layout/LayoutResult.java
+++ b/src/jls/hdl/layout/LayoutResult.java
@@ -75,9 +75,12 @@ public final class LayoutResult {
 		}
 	} // end of Point class
 
+	/** The placement problem this result solves. */
 	private final LayoutGraph graph;
+	/** Placed top-left corner of each element, keyed by node id. */
 	private final Map<String, Point> positions =
 			new LinkedHashMap<String, Point>();
+	/** Waypoint chain of each routed connection, keyed by edge identity. */
 	private final Map<LayoutGraph.Edge, List<Point>> routes =
 			new IdentityHashMap<LayoutGraph.Edge, List<Point>>();
 

--- a/src/jls/hdl/layout/LayoutResult.java
+++ b/src/jls/hdl/layout/LayoutResult.java
@@ -95,6 +95,8 @@ public final class LayoutResult {
 	}
 
 	/**
+	 * Gets the graph this result was built for.
+	 *
 	 * @return the placement problem this result solves
 	 */
 	public LayoutGraph graph() {
@@ -203,6 +205,8 @@ public final class LayoutResult {
 	}
 
 	/**
+	 * Tells whether the layouter has finished filling this result.
+	 *
 	 * @return true once every node is placed and every edge routed
 	 */
 	public boolean isComplete() {

--- a/src/jls/hdl/scan/HdlScanException.java
+++ b/src/jls/hdl/scan/HdlScanException.java
@@ -36,6 +36,8 @@ public class HdlScanException extends Exception {
 	} // end of two-argument HdlScanException constructor
 
 	/**
+	 * Gets the source line the problem was found on.
+	 *
 	 * @return the 1-based source line of the problem, or 0 if unknown
 	 */
 	public int line() {

--- a/src/jls/hdl/scan/ScannedModule.java
+++ b/src/jls/hdl/scan/ScannedModule.java
@@ -42,6 +42,8 @@ public final class ScannedModule {
 	} // end of ScannedModule constructor
 
 	/**
+	 * Lists the module's ports.
+	 *
 	 * @return the ports in declaration order, unmodifiable
 	 */
 	public List<ScannedPort> ports() {
@@ -49,6 +51,8 @@ public final class ScannedModule {
 	} // end of ports method
 
 	/**
+	 * Lists the module's parameter/generic defaults.
+	 *
 	 * @return evaluated parameter/generic defaults in declaration
 	 *         order, unmodifiable
 	 */

--- a/src/jls/hdl/scan/VerilogHeaderScanner.java
+++ b/src/jls/hdl/scan/VerilogHeaderScanner.java
@@ -408,6 +408,7 @@ public final class VerilogHeaderScanner {
 	} // end of expand method
 
 	/**
+	 * Tests whether a character may appear in a Verilog identifier.
 	 * @param c the character to classify
 	 * @return true if c may appear in a Verilog identifier
 	 */
@@ -921,6 +922,7 @@ public final class VerilogHeaderScanner {
 	} // end of expectPunct method
 
 	/**
+	 * Tests the next token against a punctuation without consuming it.
 	 * @param punct the punctuation to test for
 	 * @return true if the next token is exactly that punctuation
 	 */
@@ -930,6 +932,7 @@ public final class VerilogHeaderScanner {
 	} // end of atPunct method
 
 	/**
+	 * Tests whether a token is a given punctuation.
 	 * @param t the token to test
 	 * @param punct the punctuation text
 	 * @return true if t is that punctuation
@@ -1089,6 +1092,7 @@ public final class VerilogHeaderScanner {
 	} // end of skipToTopLevelComma method
 
 	/**
+	 * Tells whether a port list declares directions inline.
 	 * @param slice the port-list tokens
 	 * @return true if any direction keyword appears (ANSI style)
 	 */
@@ -1102,6 +1106,7 @@ public final class VerilogHeaderScanner {
 	} // end of containsDirection method
 
 	/**
+	 * Tests whether an identifier is a direction keyword.
 	 * @param word an identifier
 	 * @return true if it is a Verilog direction keyword
 	 */
@@ -1111,6 +1116,7 @@ public final class VerilogHeaderScanner {
 	} // end of isDirection method
 
 	/**
+	 * Maps a direction keyword to a scanned-port direction.
 	 * @param word a Verilog direction keyword
 	 * @return the corresponding scanned-port direction
 	 */

--- a/src/jls/hdl/scan/VhdlEntityScanner.java
+++ b/src/jls/hdl/scan/VhdlEntityScanner.java
@@ -562,6 +562,8 @@ public final class VhdlEntityScanner {
 	// ------------------------------------------------------------------
 
 	/**
+	 * Tests whether a token is a particular punctuation mark.
+	 *
 	 * @param t the token to test
 	 * @param punct the punctuation text
 	 * @return true if t is that punctuation

--- a/src/jls/hdl/yosys/JsonValue.java
+++ b/src/jls/hdl/yosys/JsonValue.java
@@ -32,7 +32,18 @@ public final class JsonValue {
 
 	/** The kinds of JSON value. */
 	private enum Kind {
-		OBJECT, ARRAY, STRING, NUMBER, BOOLEAN, NULL
+		/** An object (insertion-ordered map of string keys to values). */
+		OBJECT,
+		/** An array of values. */
+		ARRAY,
+		/** A string. */
+		STRING,
+		/** An integer number. */
+		NUMBER,
+		/** A true or false literal. */
+		BOOLEAN,
+		/** The null literal. */
+		NULL
 	} // end of Kind enum
 
 	/** Which kind of value this is. */

--- a/src/jls/hdl/yosys/NetlistFormatException.java
+++ b/src/jls/hdl/yosys/NetlistFormatException.java
@@ -16,6 +16,7 @@ package jls.hdl.yosys;
  */
 public class NetlistFormatException extends Exception {
 
+	/** Serialization version. */
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/src/jls/sim/BatchSimulator.java
+++ b/src/jls/sim/BatchSimulator.java
@@ -34,23 +34,23 @@ public class BatchSimulator extends Simulator {
 	/**
 	 * Create a new Simulator object.
 	 *
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#simulate()
-	 * @see jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
-	 * @see jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-	 * @see jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#simulate()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
 	 */
 	public BatchSimulator() {
 
@@ -80,22 +80,22 @@ public class BatchSimulator extends Simulator {
 	/**
 	 * Run the simulator.
 	 *
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#simulate()
-	 * @see jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
-	 * @see jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
-	 * @see jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#simulate()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
 	 */
 	public void runSim() {
 
@@ -163,9 +163,9 @@ public class BatchSimulator extends Simulator {
 	 * Create and add TestGen element to circuit.
 	 * Remove any SigGen's in the circuit.
 	 *
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
 	 */
 	public void addTestGen() {
 
@@ -230,8 +230,8 @@ public class BatchSimulator extends Simulator {
 	 *
 	 * @return a read-only view of the trace map.
 	 *
-	 * @see jls.BatchTracePrinterTest#traceSamplesRecordTheWatchedRun()
-	 * @see jls.BatchTracePrinterTest#tracePrintableRendersTheRecordedSamples()
+	 * @jls.testedby jls.BatchTracePrinterTest#traceSamplesRecordTheWatchedRun()
+	 * @jls.testedby jls.BatchTracePrinterTest#tracePrintableRendersTheRecordedSamples()
 	 */
 	public Map<LogicElement,List<TraceSample>> getTraceSamples() {
 
@@ -245,8 +245,8 @@ public class BatchSimulator extends Simulator {
 	 *
 	 * @param fileName The VCD file to write, or null.
 	 *
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
 	 */
 	public void setVcdFile(@Nullable String fileName) {
 
@@ -261,7 +261,7 @@ public class BatchSimulator extends Simulator {
 	 * @throws IllegalStateException if setVcdFile has not been called
 	 *         with a non-null file name.
 	 *
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
 	 */
 	public void writeVcd() throws java.io.IOException {
 
@@ -285,8 +285,8 @@ public class BatchSimulator extends Simulator {
 	 *
 	 * @return the complete VCD text.
 	 *
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
 	 */
 	public String toVcd() {
 
@@ -443,7 +443,7 @@ public class BatchSimulator extends Simulator {
 	/**
 	 * Display reason for stopping and the time at which it stopped.
 	 *
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
 	 */
 	public void displayOutcome() {
 

--- a/src/jls/sim/InteractiveSimulator.java
+++ b/src/jls/sim/InteractiveSimulator.java
@@ -102,10 +102,10 @@ public final class InteractiveSimulator extends Simulator {
 	/**
 	 * Create a new Simulator object.
 	 *
-	 * @see jls.sim.InteractiveSimulatorFieldTest#buildSimulatorPanel()
-	 * @see jls.sim.TraceRetentionTest#parent()
-	 * @see jls.sim.TraceWindowingTest#parent()
-	 * @see jls.ui.EditorGestureSupport#EditorGestureSupport()
+	 * @jls.testedby jls.sim.InteractiveSimulatorFieldTest#buildSimulatorPanel()
+	 * @jls.testedby jls.sim.TraceRetentionTest#parent()
+	 * @jls.testedby jls.sim.TraceWindowingTest#parent()
+	 * @jls.testedby jls.ui.EditorGestureSupport#EditorGestureSupport()
 	 */
 	public InteractiveSimulator() {
 
@@ -531,8 +531,8 @@ public final class InteractiveSimulator extends Simulator {
 	 * 
 	 * @return the JPanel that displays the simulator
 	 *
-	 * @see jls.sim.InteractiveSimulatorFieldTest#button()
-	 * @see jls.sim.InteractiveSimulatorFieldTest#fieldWithColumns()
+	 * @jls.testedby jls.sim.InteractiveSimulatorFieldTest#button()
+	 * @jls.testedby jls.sim.InteractiveSimulatorFieldTest#fieldWithColumns()
 	 */
 	public JPanel getWindow() {
 
@@ -542,8 +542,8 @@ public final class InteractiveSimulator extends Simulator {
 	/**
 	 * Set the time limit from the tlimit text field.
 	 *
-	 * @see jls.sim.InteractiveSimulatorFieldTest#setMaxTimeRejectsHugeNegativeAndKeepsPreviousLimit()
-	 * @see jls.sim.InteractiveSimulatorFieldTest#setMaxTimeStillAcceptsValidLimits()
+	 * @jls.testedby jls.sim.InteractiveSimulatorFieldTest#setMaxTimeRejectsHugeNegativeAndKeepsPreviousLimit()
+	 * @jls.testedby jls.sim.InteractiveSimulatorFieldTest#setMaxTimeStillAcceptsValidLimits()
 	 */
 	public void setMaxTime() {
 
@@ -1122,8 +1122,8 @@ public final class InteractiveSimulator extends Simulator {
 		/**
 		 * Set up the window.
 		 *
-		 * @see jls.sim.TraceRetentionTest#parent()
-		 * @see jls.sim.TraceWindowingTest#parent()
+		 * @jls.testedby jls.sim.TraceRetentionTest#parent()
+		 * @jls.testedby jls.sim.TraceWindowingTest#parent()
 		 */
 		public Traces() {
 

--- a/src/jls/sim/Simulator.java
+++ b/src/jls/sim/Simulator.java
@@ -57,23 +57,23 @@ public abstract class Simulator {
 	 * Set the circuit that will be simulated.
 	 * 
 	 * @param circ The circuit.
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#simulate()
-	 * @see jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
-	 * @see jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
-	 * @see jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#simulate()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
 	 */
 	public void setCircuit(Circuit circ) {
 
@@ -84,22 +84,22 @@ public abstract class Simulator {
 	 * Set the time limit for the simulation.
 	 * 
 	 * @param limit The time limit.
-	 * @see jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
-	 * @see jls.BatchSimulationGoldenTest#simulate()
-	 * @see jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
-	 * @see jls.ElementSimulationGoldenTest#simulate()
-	 * @see jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
-	 * @see jls.SequentialGoldenTest#simulate()
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.ShiftRegisterTest#simulate()
-	 * @see jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
-	 * @see jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
-	 * @see jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
-	 * @see jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
-	 * @see jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#ramWriteStoresTheWord()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.BatchSimulationGoldenTest#watchedElementsPrintInNameOrder()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#simulate()
+	 * @jls.testedby jls.ElementSimulationGoldenTest#stopHaltsTheSimulationEarly()
+	 * @jls.testedby jls.SequentialGoldenTest#simulate()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.ShiftRegisterTest#simulate()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#agreeingTriStateDriversDoNotWarn()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#constantValueIsMaskedToTheNetWidth()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#multiDriverConflictResolvesDeterministicallyAndWarnsOnce()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#registerInitSimResetsTheWatchedCurrentValue()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#clockedRegisterVcdMatchesGoldenByteForByte()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.elem.MemoryInitEncodingTest#rleMemorySimulatesLikeRawMemory()
 	 */
 	public void setTimeLimit(long limit) {
 
@@ -110,9 +110,9 @@ public abstract class Simulator {
 	 * Set the simulation test input file name.
 	 * 
 	 * @param name The test file name, or null if none.
-	 * @see jls.SequentialGoldenTest#simulateWithVectors()
-	 * @see jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
-	 * @see jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
+	 * @jls.testedby jls.SequentialGoldenTest#simulateWithVectors()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#stateMachineWithNoMatchingTransitionStaysAliveAndWarnsOnce()
+	 * @jls.testedby jls.VcdExportGoldenTest#testVectorStimulusVcdMatchesGoldenAndCoversHiZ()
 	 */
 	public void setTestFile(@Nullable String name) {
 
@@ -144,7 +144,7 @@ public abstract class Simulator {
 	 * Initialize all inputs in the circuit.
 	 * 
 	 * @param circuit The circuit to initialize.
-	 * @see jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest#initInputsReachesInsideSubcircuits()
 	 */
 	public void initInputs(Circuit circuit) {
 
@@ -161,7 +161,7 @@ public abstract class Simulator {
 	 *
 	 * @param event The event to enqueue.
 	 *
-	 * @see jls.SimulationSemanticsRegressionTest.CountingSimulator#post()
+	 * @jls.testedby jls.SimulationSemanticsRegressionTest.CountingSimulator#post()
 	 */
 	public void post(SimEvent event) {
 

--- a/src/jls/sim/Trace.java
+++ b/src/jls/sim/Trace.java
@@ -99,13 +99,13 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 * @param width The current width of the trace area.
 	 * @param parent The parent object of this one.
 	 *
-	 * @see jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
-	 * @see jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
-	 * @see jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
-	 * @see jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
+	 * @jls.testedby jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
+	 * @jls.testedby jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
+	 * @jls.testedby jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
+	 * @jls.testedby jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
 	 */
 	public Trace(String name, Element el, int bits, int width,
 			InteractiveSimulator.Traces parent) {
@@ -153,8 +153,8 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 *
 	 * @param factor The scale factor.
 	 *
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
 	 */
 	public void setScaleFactor(int factor) {
 		
@@ -167,12 +167,12 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 * @param value The value to add to the list, or null for HiZ.
 	 * @param when The time at which the value occurred.
 	 *
-	 * @see jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
-	 * @see jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
-	 * @see jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
-	 * @see jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
+	 * @jls.testedby jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
+	 * @jls.testedby jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
+	 * @jls.testedby jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
+	 * @jls.testedby jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
 	 */
 	public synchronized void addValue(@Nullable BitSet value, long when) {
 
@@ -200,13 +200,13 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 *
 	 * @param time The current time.
 	 *
-	 * @see jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
-	 * @see jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
-	 * @see jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
-	 * @see jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
-	 * @see jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
+	 * @jls.testedby jls.sim.TraceRetentionTest#historyBeyondThePanelWidthSurvivesForScrollback()
+	 * @jls.testedby jls.sim.TraceRetentionTest#retentionIsBoundedAtTheDocumentedCap()
+	 * @jls.testedby jls.sim.TraceRetentionTest#unchangedValuesAreStillDeduplicated()
+	 * @jls.testedby jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForAMultiBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForASingleBitTrace()
+	 * @jls.testedby jls.sim.TraceWindowingTest#windowedRepaintMatchesFullRepaintForTheHeaderLabels()
 	 */
 	public synchronized void commit(long time) {
 
@@ -219,8 +219,8 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 * 
 	 * @param g The Graphics object to draw with.
 	 *
-	 * @see jls.sim.TraceRetentionTest#paint()
-	 * @see jls.sim.TraceWindowingTest#paint()
+	 * @jls.testedby jls.sim.TraceRetentionTest#paint()
+	 * @jls.testedby jls.sim.TraceWindowingTest#paint()
 	 */
 	@Override
 	public void paintComponent(Graphics g) {
@@ -462,7 +462,7 @@ public class Trace extends JPanel implements MouseListener, MouseMotionListener 
 	 *
 	 * @return See firstChangeAtOrBefore(list,time).
 	 *
-	 * @see jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
+	 * @jls.testedby jls.sim.TraceWindowingTest#firstChangeAtOrBeforeMatchesTheLinearScan()
 	 */
 	int firstChangeAtOrBefore(long time) {
 

--- a/src/jls/sim/TraceGeometry.java
+++ b/src/jls/sim/TraceGeometry.java
@@ -30,11 +30,11 @@ public final class TraceGeometry {
 	 *
 	 * @return The tic increment, in simulation time units.
 	 *
-	 * @see jls.sim.TraceGeometryTest#adjacentLabelsNeverOverlap()
-	 * @see jls.sim.TraceGeometryTest#labeledTicsStayDense()
-	 * @see jls.sim.TraceGeometryTest#realisticHeaderLabelsClearEachOtherInRealFontMetrics()
-	 * @see jls.sim.TraceGeometryTest#ticIncrementMatchesTheInlineOriginal()
-	 * @see jls.sim.TraceGeometryTest#ticPitchIsAtLeastFiftyPixelsAtEveryScaleFactor()
+	 * @jls.testedby jls.sim.TraceGeometryTest#adjacentLabelsNeverOverlap()
+	 * @jls.testedby jls.sim.TraceGeometryTest#labeledTicsStayDense()
+	 * @jls.testedby jls.sim.TraceGeometryTest#realisticHeaderLabelsClearEachOtherInRealFontMetrics()
+	 * @jls.testedby jls.sim.TraceGeometryTest#ticIncrementMatchesTheInlineOriginal()
+	 * @jls.testedby jls.sim.TraceGeometryTest#ticPitchIsAtLeastFiftyPixelsAtEveryScaleFactor()
 	 */
 	public static int ticIncrement(int scaleFactor) {
 
@@ -72,9 +72,9 @@ public final class TraceGeometry {
 	 *
 	 * @return The stride (at least 1) between labeled tics.
 	 *
-	 * @see jls.sim.TraceGeometryTest#adjacentLabelsNeverOverlap()
-	 * @see jls.sim.TraceGeometryTest#labeledTicsStayDense()
-	 * @see jls.sim.TraceGeometryTest#realisticHeaderLabelsClearEachOtherInRealFontMetrics()
+	 * @jls.testedby jls.sim.TraceGeometryTest#adjacentLabelsNeverOverlap()
+	 * @jls.testedby jls.sim.TraceGeometryTest#labeledTicsStayDense()
+	 * @jls.testedby jls.sim.TraceGeometryTest#realisticHeaderLabelsClearEachOtherInRealFontMetrics()
 	 */
 	public static int labelStride(int labelWidth, double ticPitch) {
 

--- a/src/jls/util/Placement.java
+++ b/src/jls/util/Placement.java
@@ -41,9 +41,9 @@ public final class Placement {
 	 *
 	 * @return the anchor point, in canvas coordinates.
 	 *
-	 * @see jls.util.PlacementTest#anchorPrefersTheKnownPositionOverTheCanvas()
-	 * @see jls.util.PlacementTest#missingCanvasAndPositionNeverCrashes()
-	 * @see jls.util.PlacementTest#partiallyUnknownPositionAlsoFallsBack()
+	 * @jls.testedby jls.util.PlacementTest#anchorPrefersTheKnownPositionOverTheCanvas()
+	 * @jls.testedby jls.util.PlacementTest#missingCanvasAndPositionNeverCrashes()
+	 * @jls.testedby jls.util.PlacementTest#partiallyUnknownPositionAlsoFallsBack()
 	 */
 	public static Point anchor(Component canvas, int x, int y) {
 
@@ -71,10 +71,10 @@ public final class Placement {
 	 *
 	 * @return the top left corner for the element, in canvas coordinates.
 	 *
-	 * @see jls.util.PlacementTest#dropCentersElementOnLastKnownPosition()
-	 * @see jls.util.PlacementTest#dropUsesIntegerCenteringForOddSizes()
-	 * @see jls.util.PlacementTest#originIsAValidKnownPosition()
-	 * @see jls.util.PlacementTest#unknownPositionFallsBackToCanvasCenter()
+	 * @jls.testedby jls.util.PlacementTest#dropCentersElementOnLastKnownPosition()
+	 * @jls.testedby jls.util.PlacementTest#dropUsesIntegerCenteringForOddSizes()
+	 * @jls.testedby jls.util.PlacementTest#originIsAValidKnownPosition()
+	 * @jls.testedby jls.util.PlacementTest#unknownPositionFallsBackToCanvasCenter()
 	 */
 	public static Point dropPoint(Component canvas, int x, int y,
 			int width, int height) {


### PR DESCRIPTION
## What &amp; why

The documentation gate (`doclint-gate` execution in `pom.xml`) never actually bound, and this PR both fixes that and completes #192's endgame by tightening it to private visibility. Three silent-disarm vectors were found and closed:

1. **`failOnWarnings` regex vs digit grouping.** maven-javadoc-plugin 3.12.0 detects warnings by regex-matching javadoc's **last output line** against `\d+ warnings?`, and javadoc 25 digit-groups its summary (`1,509 warnings` at the gate's introduction commit `7a06c2b`), so any count ≥ 1,000 passed silently. Fix: javadoc's own **`-Werror`** (via `additionalOptions`) turns any warning into a nonzero exit, failing the goal on the exit code — immune to output formatting. `failOnWarnings` stays as a second net.
2. **Unresolvable generated `@see` tags.** All 878 attribution `@see` tags in main source point at the test tree, deliberately off the javadoc sourcepath — they produced 1,130 unresolvable-reference warnings (at the gate's own protected scope; the pom note claiming this only happened under `-private` was wrong) and pushed the count over the digit-grouping cliff. Fix: a registered custom block tag **`@jls.testedby`** (rendered "Tested by:") needs no resolution, and doclint's `reference` group is enforced again — real broken `@see`/`@link` now fail the build.
3. **The stale-data up-to-date skip.** The plugin's staleness check compares only the javadoc **argument list** (never source contents), so with unchanged options a rerun after a source edit skipped javadoc entirely and reported vacuous success. Fix: a per-build timestamp nonce in the `-bottom` text makes the argument list differ every build, forcing a real run (the text appears only in the throwaway gate output under `target/`).

With the gate genuinely binding, the whole documentation debt is retired:

- **Protected scope (292 warnings):** missing member comments, missing `@param`/`@return`/`@throws`, tag-only comments, 8 undocumented default constructors.
- **Private scope (684 warnings, #192's endgame):** 630 undocumented private/package-private members, 49 missing tags/main descriptions, 5 undocumented default constructors — and the gate is tightened to `<show>private</show>`.

Beyond doc comments, the only code changes are explicit no-op constructors (unchanged visibility) and enum-constant line splits needed to attach per-constant docs.

Closes #192

(The branch's first commit also records the 2026-07-19 issue-progress pass report, `ISSUE-PROGRESS-2026-07-19.md`.)

## Testing

The gate is its own regression test, validated behaviorally in both directions at each stage:

- `mvn javadoc:javadoc` on the final tree: **0 warnings at `-private`, BUILD SUCCESS**.
- Negative tests: a deleted `@return` (protected stage) and an injected undocumented private field (private stage) each make the build **fail** with the exact expected warning — including on an immediate rerun after a green build, proving the stale-skip is closed.
- Full CI-parity build locally: `xvfb-run -a mvn -B verify -Djls.test.headless=false` is **BUILD SUCCESS** (tests, SpotBugs, coverage ratchets, doclint gate).

The earlier CI runs on this PR trace the story live: green at the protected stage, red on the interim commits where the gate was flipped to private before the debt landed (the gate biting, as designed), and green again at the final head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ccBCXMns2pdfLyyESRxYW