### PR TITLE
#75: keyboard operability & accessibility (shared Actions + keyboard-only construction)

### DIFF
--- a/docs/keyboard-a11y-verification.md
+++ b/docs/keyboard-a11y-verification.md
@@ -1,0 +1,146 @@
+# How we know #75 works for users — keyboard operability & accessibility
+
+This is the standing checklist for issue #75 (keyboard operability &
+accessibility). It enumerates every user-observable behavior the feature
+promises, the concrete signal that shows the behavior happened, and the test
+that pins that signal. When you change the editor's input handling, focus
+handoff, menus, accelerators, or the shared-`Action` wiring, re-check this
+list: each row's test must still go **red if that behavior breaks**.
+
+Run the whole thing with the authoritative green bar:
+
+```
+xvfb-run -a mvn -B verify -Djls.test.headless=false
+```
+
+The `@Tag("display")` UI tests run under the #162 Xvfb substrate; display
+tests carry `rerunFailingTestsCount=2` for transient popup-timing flakes.
+
+## Why "the test is green" has to mean "a real user's key works"
+
+The original H2 focus bug — choosing a gate from the tool bar left keyboard
+focus on the palette *button*, so a real user's arrow/Enter keys never
+reached the canvas — **passed the tests** for a while. The reason: the gesture
+harness drove keys with `canvas.dispatchEvent(keyEvent)` on a hardcoded canvas
+reference, which force-feeds the canvas regardless of where focus actually is.
+A green test proved nothing about a real keystroke.
+
+The fix is a **focus-faithful driver**. Keyboard input is dispatched to the
+**live `KeyboardFocusManager` focus owner**, read at dispatch time — the same
+authority the AWT event pipeline consults when routing a real user's key:
+
+- `EditorGestureSupport.focusOwner()` — reads
+  `KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner()` on
+  the EDT.
+- `EditorGestureSupport.pressKeyThroughFocusOwner(keyCode[, mods])` —
+  dispatches `KEY_PRESSED` to that live owner (throws if there is none, since a
+  real keystroke would also have nowhere to go).
+- `EditorGestureSupport.focusCanvas()` / `giveFocusTo(c)` — stage a focus
+  owner and **poll the KFM until the handoff actually lands**, so driving is
+  deterministic rather than racing a transient focus state.
+
+Because the driver reads the real focus owner, a regression that strands focus
+off the canvas turns the faithful tests **red**, where the old
+`canvas.dispatchEvent` path stayed green. This is proven, not asserted: two
+independent mutations were demonstrated to flip the suite red — (A) deleting
+the `setup()` `requestFocusInWindow()` handoff (three faithful tests hard-red),
+and (B) making the driver force-feed the canvas instead of the live owner
+(`FocusFaithfulKeyboardTest` leg 1 hard-red, proving the faithfulness guard is
+not a no-op).
+
+Why dispatch to the focus owner rather than `java.awt.Robot`: under the
+WM-less #162 Xvfb a single `Robot` key press auto-repeats into ~30
+`KEY_PRESSED` events, which makes exact "moved one grid step" assertions flaky.
+Focus-owner dispatch delivers exactly one event while still honoring the real
+focus subsystem (it routes to the button, not the canvas, when the button
+holds focus, and vice versa — both verified). `Robot` *is* used where a genuine
+pointer is unavoidable (paste reads `getMousePosition()`), and `Robot`-real
+focus is confirmed feasible here (`EditorKeyboardConstructionTest` becomes the
+canvas focus owner after a real tool-bar `doClick()`).
+
+## Behavior → observable signal → faithful test
+
+### H2 — keyboard-only construction (the crux: focus-faithful)
+
+| User-observable behavior | Observable signal | Test (faithful unless noted) |
+|---|---|---|
+| Choosing a palette element hands focus to the canvas (so the next key reaches it) | The live KFM focus owner becomes the canvas after a tool-bar `doClick()` | `FocusFaithfulKeyboardTest.*` (leg 2); `EditorKeyboardConstructionTest` re-checks after **both** the OR-gate and NOT-gate choices |
+| An arrow moves the placing element / caret one grid step | The placing gate's / caret's model position advances exactly one `JLSInfo.spacing` | `FocusFaithfulKeyboardTest` (leg 2); `KeyboardEditingFaithfulTest.arrowNudge…` |
+| Enter places (commits) the positioned element | After Enter the editor is idle: a further arrow moves only the caret, the committed gate stays put | `KeyboardPlacementFaithfulTest.enterThroughFocusOwnerCommitsThePlacedGate` (waits on a positive observable — the caret moving — not a fixed sleep) |
+| Arrow-nudge of a selection is undoable | Ctrl+Z restores the pre-nudge X; Ctrl+Y re-applies it | `KeyboardEditingFaithfulTest.arrowNudge…IsUndoableWithCtrlZ`, `.redoThroughFocusOwnerReappliesTheNudge` |
+| `R` rotates / `F` flips the selection | The element's persisted `save` block (orientation + geometry) changes | `KeyboardEditingFaithfulTest.rotateKeyRotates…`, `.flipKeyFlips…` |
+| `Delete` removes the selection | The gate is gone from the circuit model | `KeyboardEditingFaithfulTest.deleteKeyRemoves…` |
+| `W` starts a wire, `Esc` abandons it | A `WireEnd` appears in the model, then disappears | `KeyboardEditingFaithfulTest.wireStartAndEscape…`; `EditorKeyboardConstructionTest.keyboardDrawsAWireInOpenSpace` |
+| The whole two-gate tutorial circuit builds with no pointer | An OR + NOT gate, wired output-to-input, exactly as the mouse tutorial produces | `EditorKeyboardConstructionTest.keyboardBuildsTheTwoGateCircuit` (every post-choice key faithful; both palette handoffs re-checked) |
+| Selecting an editor tab hands focus to its canvas (focus no longer follows the mouse) | The live KFM focus owner becomes that editor's canvas after the tab is selected | `TabSelectionFocusTest` |
+
+### H1 — one shared `Action` per op, reused across three surfaces
+
+| User-observable behavior | Observable signal | Test |
+|---|---|---|
+| Canvas key, popup item, and menu-bar item are the **same** `Action` object per op | Object identity over all `EditOp.values()` and the menu items | `EditActionMatrixTest` (identity); `KeyboardEditingFaithfulTest.faithfulKeysDriveTheSharedActions` |
+| Popup Rotate CW / Rotate CCW / Flip actually run the op | The gate's persisted `save` block changes after `doClick` on the shown item | `PopupOperationBehaviorTest` (popup-open hardened with a bounded right-press retry) |
+| Cut / Copy / Paste run (pre-#75 ops, re-homed onto the shared `Action`) | Clipboard-circuit model contents | `EditorSaveAndClipboardTest` + identity tie in `EditActionMatrixTest` |
+| A window-scoped menu accelerator fires from a **non-canvas** focus owner | Ctrl+A selects the whole circuit; Delete removes it — both fired from a focused tool-bar button | `MenuAcceleratorFiringTest.windowScopedAcceleratorsFireFromANonCanvasFocusOwner` |
+| Ctrl/Cmd+S saves from any focus location (the literal P1 prediction) | Firing Ctrl+S from a focused tool-bar button clears the dirty flag and writes the `.jls` file | `MenuAcceleratorFiringTest.fileSaveAcceleratorSavesFromANonCanvasFocusOwner` |
+| Ctrl/Cmd+W → Watch (the overload split from plain-W → wire-start) | Firing Ctrl+W flips the selected element's watched flag; plain-W instead starts a wire | `KeyboardEditingFaithfulTest.watchKeyTogglesWatchedThroughFocusOwner` (Ctrl+W) + `.wireStartAndEscape…` (plain-W); `EditActionMatrixTest` (map identity) |
+| Edit + Element menus present, correctly ordered, accelerators shown | The canonical booted-menu-bar tree | `MenuBarSpecTest` |
+
+### Accessibility (the delivered #75 scope, items 1–7)
+
+| User-observable behavior | Observable signal | Test |
+|---|---|---|
+| Top-level menus have distinct mnemonics | `menu.getMnemonic()` on the real booted bar, all distinct | `MenuMnemonicAndAccessibleNameTest` |
+| Menu items announce an accessible name | `getAccessibleContext().getAccessibleName()` == label, on the real bar | `MenuMnemonicAndAccessibleNameTest` |
+| Palette buttons announce an accessible name and are keyboard-focusable | Real `getAccessibleName()` is non-blank; button is focusable | `PaletteButtonAccessibilityTest` (pins the `SimpleEditor` fix that set the name from the tooltip on icon-only buttons) |
+| In-app keyboard help exists, is reachable, and its documented keys match the code | Map target resolves; TOC-reachable; inline links resolve; **every documented hot key equals the `EditOp` accelerator** | `HelpTopicsTest` (existence/reachability) + `HotkeysHelpAccuracyTest` (content: `hotkeys.html` keys pinned against `EditOp.accelerator`, so the docs cannot silently desync) |
+
+## Real implementation gap this verification caught and fixed
+
+Icon-only palette buttons had `Action.NAME == ""`, so
+`getAccessibleContext().getAccessibleName()` returned the empty string — a
+screen reader focusing a palette button announced nothing. Fixed in
+`SimpleEditor.makeElement` by setting the accessible name from the tooltip on
+both the tool-bar button and its mirror "elements" menu item. Falsification
+confirmed: with the fix reverted, `PaletteButtonAccessibilityTest` goes red on
+all reruns.
+
+## Red-on-break evidence (re-runnable)
+
+- Delete the `setup()` `requestFocusInWindow()` handoff → the faithful
+  keyboard-construction tests hard-red (the palette handoff proof).
+- Make the driver force-feed the canvas → `FocusFaithfulKeyboardTest` leg 1
+  hard-red (the faithfulness guard is real).
+- No-op the `WATCH` op's `submitOp(new ToggleWatched(...))` →
+  `KeyboardEditingFaithfulTest.watchKeyTogglesWatchedThroughFocusOwner`
+  times out red (all reruns).
+- Change any key in `hotkeys.html` →
+  `HotkeysHelpAccuracyTest.documentedKeysMatchTheEditOpAccelerators` red.
+- Revert the palette a11y-name fix → `PaletteButtonAccessibilityTest` red.
+
+## Deliberately out of scope / deferred (not covered, and why)
+
+- **Canvas scene-model assistive-technology boundary.** Elements drawn on the
+  editor canvas are not exposed as individual accessible objects to a screen
+  reader (the canvas is a single custom-painted component). #75 scopes this as
+  future work (§10); it is a genuine residual, not a regression, and no test
+  pins it because the behavior does not yet exist.
+- **Alt+letter physically *opening* a menu.** The mnemonic *property* is read
+  on the real components, but no test drives the look-and-feel's Alt-navigation
+  state machine to pop a menu open. That needs `Robot` Alt-key delivery into
+  the menu-selection manager, exactly the auto-repeat/timing surface the
+  focus-owner driver avoids; property-level verification is the robust bound.
+- **Modal `TellUser` dialog accelerator inertness.** Asserting that a raised
+  modal dialog does not leak window accelerators blocks the EDT and is
+  inherently timing-fragile in this suite; not added.
+- **mac-only keymap** (Cmd, Backspace-delete, Shift+Cmd+Z / Cmd+Y redo alias).
+  Policy-pinned in `MenuAcceleratorPolicyTest`; this Linux substrate cannot
+  exercise the mac keymap behaviorally.
+- **Probe / Modify / Timing popup ops fired behaviorally.** These open modal
+  dialogs; they are identity-pinned (`EditActionMatrixTest`) and
+  structure-pinned (`MenuBarSpecTest`). Rotate/Flip (the geometry-mutating
+  popup ops) are the ones covered behaviorally.
+
+A known pre-existing flake, `EditorGestureTest.undoRestoresADeletedElement…`
+(popup timing), is absorbed by `rerunFailingTestsCount=2` and is not
+attributable to #75.

--- a/resources/help/JLSHelpTOC.xml
+++ b/resources/help/JLSHelpTOC.xml
@@ -43,6 +43,7 @@
 	<tocitem text="Paste" target="paste"/>
 	<tocitem text="Undo/Redo" target="undoredo"/>
 	<tocitem text="Keyboard Accelerators" target="hotkeys"/>
+	<tocitem text="Keyboard-only Construction" target="keyboard"/>
     </tocitem>
     <tocitem text="Circuits" target="circuit.over">
    	<tocitem text="Wiring" target="wires">

--- a/resources/help/Map.jhm
+++ b/resources/help/Map.jhm
@@ -7,6 +7,7 @@
 	<mapID target="sigformat" url="elements/other/sigformat.html" />
 	<mapID target="edit.over" url="editor/editor.html" />
 	<mapID target="hotkeys" url="editor/editing/hotkeys.html" />
+	<mapID target="keyboard" url="editor/editing/keyboard.html" />
 	<mapID target="picking" url="editor/editing/picking.html" />
 	<mapID target="wiring" url="editor/editing/wiring.html" />
 	<mapID target="selecting" url="editor/editing/selecting.html" />

--- a/resources/help/editor/editing/hotkeys.html
+++ b/resources/help/editor/editing/hotkeys.html
@@ -46,7 +46,7 @@ The keys and their functions are:
     </tr>
 <tr>
     <td> Start Wire </td>
-    <td> ctrl-w </td>
+    <td> w </td>
     </tr>
 <tr>
     <td> End Wire </td>
@@ -88,22 +88,39 @@ The keys and their functions are:
     <td> Lock Element </td>
     <td> ctrl-l </td>
     </tr>
+<tr>
+    <td> Move Caret / Following Element / Wire End / Selection </td>
+    <td> arrow keys </td>
+    </tr>
+<tr>
+    <td> Place, Wire, or Select (keyboard commit) </td>
+    <td> enter </td>
+    </tr>
 </table>
 
 <p>
 Many keys only work when the cursor is in a certain place (e.g., on an element,
 on a wire, in "empty" space) - otherwise they have no effect.
-The ctrl-w key is context sensitive:
-if the cursor is on an element that can be modified the function is
-"Modify"; if it is in "empty" space the function is "Start Wire".
+Start Wire and Watch/Unwatch used to share ctrl-w, which put two
+functions on one stroke.  They are now separate: plain <b>w</b> starts a
+wire, and <b>ctrl-w</b> (cmd-w on macOS) toggles watch on a single
+selected element.
 
 <p>
 The editing area holds keyboard focus like any other component: click
 in it (or just select its tab) and the hot keys above work until you
 click somewhere else.  Focus no longer follows the mouse pointer.
-File operations (New, Open, Save, Save As, Exit) have their own menu
-accelerators, shown in the File menu, and those work no matter which
-part of the window has focus.
+The editing operations also appear in the menu bar's <b>Edit</b> and
+<b>Element</b> menus, each showing its accelerator; those Ctrl/Cmd
+accelerators work no matter which part of the window has focus.
+File operations (New, Open, Save, Save As, Exit) likewise have their own
+menu accelerators, shown in the File menu.
+
+<p>
+The arrow keys and Enter make it possible to build a circuit with no
+pointing device at all.  See
+<a href="keyboard.html">Keyboard-only Construction</a> for the full
+workflow.
 
 </body>
 

--- a/resources/help/editor/editing/keyboard.html
+++ b/resources/help/editor/editing/keyboard.html
@@ -1,0 +1,85 @@
+<html>
+<head>
+<title>Keyboard-only Construction</title>
+</head>
+
+<body>
+<h1>Keyboard-only Construction</h1>
+
+<p>
+You can lay out and wire a circuit entirely from the keyboard, with no
+pointing device.  The editing area behaves like any other component: give
+it keyboard focus by selecting its tab (or clicking in it once), and the
+keys below then drive the whole construction.
+
+<h2>The caret</h2>
+<p>
+The <b>arrow keys</b> move a small crosshair called the <i>caret</i>
+around the drawing grid.  The caret is the keyboard's equivalent of the
+mouse pointer: it marks where the next element will drop and where a wire
+will start or end.  It always sits on a grid line, so wires you start or
+finish at the caret line up exactly with the ports on gates and pins.
+
+<h2>Placing an element</h2>
+<ol>
+<li>Choose an element from the <b>Element</b> menu on the tool bar (it is
+    fully keyboard navigable) and answer its creation dialog as usual.</li>
+<li>The new element appears attached to the keyboard.  Use the
+    <b>arrow keys</b> to move it one grid step at a time to where you want
+    it.</li>
+<li>Press <b>Enter</b> to drop it.  If a message warns of an overlap, move
+    it clear first; Enter has no effect while it overlaps something.</li>
+</ol>
+
+<h2>Moving something already placed</h2>
+<p>
+With nothing being placed, move the caret over an element and press
+<b>Enter</b> to select it.  The <b>arrow keys</b> then nudge the selected
+element one grid step at a time (this is undoable, like a mouse drag).
+Press <b>Enter</b> again to finish and deselect.
+
+<h2>Wiring port to port</h2>
+<p>
+To connect two elements with a wire:
+<ol>
+<li>Move the caret onto the source port (for example a gate's output).</li>
+<li>Press <b>w</b> to start a wire there.</li>
+<li>Press <b>Enter</b> to anchor the wire to that port.</li>
+<li>Use the <b>arrow keys</b> to run the wire's free end across to the
+    destination port (a gate input or a pin).</li>
+<li>Press <b>Enter</b> on the destination port to complete the
+    connection.  Press <b>Esc</b> at any time to abandon the wire.</li>
+</ol>
+<p>
+Because the caret and every port share the grid, ending a wire on a port
+connects them exactly, the same way touching two ports with the mouse
+does.
+
+<h2>Rotating, flipping, and the rest</h2>
+<p>
+The plain keys <b>r</b> (rotate clockwise), <b>shift-r</b> (rotate
+counter-clockwise), and <b>f</b> (flip) act on the selected element, and
+every other operation on the
+<a href="hotkeys.html">Keyboard Accelerators</a> page works from the
+keyboard too.  When the circuit is built, press <b>F5</b> to simulate it.
+
+<h2>A worked example: A + ~B</h2>
+<p>
+This is the first circuit in the tutorial, built with no mouse:
+<ol>
+<li>Choose an OR gate, move it to the center with the arrow keys, and
+    press <b>Enter</b>.</li>
+<li>Choose a NOT gate, move it with the arrow keys so its output is a
+    little to the left of one of the OR gate's inputs, and press
+    <b>Enter</b>.</li>
+<li>Move the caret onto the NOT gate's output, press <b>w</b>, press
+    <b>Enter</b>, move the caret across to the OR gate's input, and press
+    <b>Enter</b> to wire them.</li>
+</ol>
+<p>
+The two gates are now the A + ~B skeleton, ready for input and output
+pins and simulation.
+
+</body>
+
+</html>

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -33,11 +33,13 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.InputMismatchException;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Scanner;
 import java.util.Vector;
 
 import javax.print.PrintService;
+import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.ButtonGroup;
 import javax.swing.JColorChooser;
@@ -55,6 +57,7 @@ import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import jls.edit.EditOp;
 import jls.edit.Editor;
 import jls.elem.Element;
 import jls.hdl.HdlEmitter;
@@ -119,6 +122,16 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private JSplitPane both;
 	/** The tabbed pane holding one editor per open circuit. */
 	private JTabbedPane edits;
+	/**
+	 * The menu-bar Edit and Element menu items, keyed by operation
+	 * (issue #75). On every tab change {@link #retargetEditMenus()}
+	 * points each item at the currently selected editor's shared
+	 * {@link Action} for that operation, so the menu bar, the popup
+	 * menus, and the canvas key bindings all dispatch through one object
+	 * instead of three copies.
+	 */
+	private final EnumMap<EditOp,JMenuItem> editMenuItems =
+			new EnumMap<EditOp,JMenuItem>(EditOp.class);
 	/** Pseudo-circuit holding the elements most recently cut or copied. */
 	private Circuit clipboard = new Circuit("clipboard");		// for cut and paste
 	/** Persistent user preferences, opened at startup. */
@@ -1116,6 +1129,9 @@ public class JLSStart extends JFrame implements ChangeListener {
 		// set up menu bar
 		JMenuBar bar = new JMenuBar();
 		bar.add(fileMenu());
+		// Edit and Element reuse the selected editor's shared Actions (#75)
+		bar.add(editMenu());
+		bar.add(elementMenu());
 		bar.add(simMenu());
 		bar.add(viewMenu());
 		bar.add(globalMenu());
@@ -1171,6 +1187,10 @@ public class JLSStart extends JFrame implements ChangeListener {
 	 */
 	@Override
 	public void stateChanged(ChangeEvent event) {
+
+		// point the Edit and Element menu items at the newly selected
+		// editor's shared Actions (or disable them when no tab is left) (#75)
+		retargetEditMenus();
 
 		Editor ed = (Editor)edits.getSelectedComponent();
 		if (ed == null) {
@@ -1441,6 +1461,106 @@ public class JLSStart extends JFrame implements ChangeListener {
 
 		return menu;
 	} // end of fileMenu method
+
+	/**
+	 * Set up the Edit menu (issue #75): undo, redo, cut, copy, paste,
+	 * delete, and select-all. Each item reuses the currently selected
+	 * editor's shared {@link Action} for that operation - the same
+	 * object the popup menus and canvas key bindings dispatch through -
+	 * retargeted on every tab change by {@link #retargetEditMenus()}.
+	 * The items are always enabled and no-op when no editor is
+	 * selected, matching the rest of the menu bar.
+	 *
+	 * @return the menu.
+	 */
+	public JMenu editMenu() {
+
+		JMenu menu = new JMenu("Edit");
+		menu.setMnemonic(MenuAcceleratorPolicy.editMenuMnemonic());
+		menu.add(makeEditItem(EditOp.UNDO));
+		menu.add(makeEditItem(EditOp.REDO));
+		menu.addSeparator();
+		menu.add(makeEditItem(EditOp.CUT));
+		menu.add(makeEditItem(EditOp.COPY));
+		menu.add(makeEditItem(EditOp.PASTE));
+		menu.add(makeEditItem(EditOp.DELETE));
+		menu.addSeparator();
+		menu.add(makeEditItem(EditOp.SELECT_ALL));
+		return menu;
+	} // end of editMenu method
+
+	/**
+	 * Set up the Element menu (issue #75): rotate clockwise / counter-
+	 * clockwise, flip, watch, probe, modify, and change timing. Like
+	 * the Edit menu, each item reuses the selected editor's shared
+	 * {@link Action}, retargeted on tab change.
+	 *
+	 * @return the menu.
+	 */
+	public JMenu elementMenu() {
+
+		JMenu menu = new JMenu("Element");
+		menu.setMnemonic(MenuAcceleratorPolicy.elementMenuMnemonic());
+		menu.add(makeEditItem(EditOp.ROTATE_CW));
+		menu.add(makeEditItem(EditOp.ROTATE_CCW));
+		menu.add(makeEditItem(EditOp.FLIP));
+		menu.addSeparator();
+		menu.add(makeEditItem(EditOp.WATCH));
+		menu.add(makeEditItem(EditOp.PROBE));
+		menu.add(makeEditItem(EditOp.MODIFY));
+		menu.add(makeEditItem(EditOp.TIMING));
+		return menu;
+	} // end of elementMenu method
+
+	/**
+	 * Create one menu-bar editing item, showing the operation's label
+	 * and accelerator (issue #75). It starts with no action - a no-op
+	 * until an editor is selected - and is registered in
+	 * {@link #editMenuItems} so {@link #retargetEditMenus()} can point
+	 * it at the selected editor's shared {@link Action}. Because a menu
+	 * item's accelerator lives in the window's WHEN_IN_FOCUSED_WINDOW
+	 * map, this also gives every Ctrl/Cmd-modified operation window-wide
+	 * scope, so the shortcut fires with the pointer anywhere in the
+	 * frame; a modal {@link jls.TellUser} dialog is a separate focused
+	 * window and so never receives these.
+	 *
+	 * @param op the editing operation the item performs.
+	 * @return the menu item.
+	 */
+	private JMenuItem makeEditItem(EditOp op) {
+
+		JMenuItem item = new JMenuItem(op.label());
+		item.setAccelerator(op.accelerator(System.getProperty("os.name")));
+		editMenuItems.put(op, item);
+		return item;
+	} // end of makeEditItem method
+
+	/**
+	 * Point every Edit and Element menu item at the currently selected
+	 * editor's shared {@link Action} for its operation (issue #75), so
+	 * the menu bar drives the same object as that editor's popups and
+	 * key bindings. When no editor is selected the items fall back to
+	 * their label and accelerator with no action - always enabled, but
+	 * a no-op.
+	 */
+	private void retargetEditMenus() {
+
+		Editor ed = (Editor)edits.getSelectedComponent();
+		String osName = System.getProperty("os.name");
+		for (EditOp op : editMenuItems.keySet()) {
+			JMenuItem item = editMenuItems.get(op);
+			if (item == null)
+				continue;
+			if (ed == null) {
+				item.setAction(null);
+				item.setText(op.label());
+				item.setAccelerator(op.accelerator(osName));
+			}
+			else {
+				item.setAction(ed.editAction(op));
+			}
+		}
+	} // end of retargetEditMenus method
 
 	/**
 	 * Set up simulator menu.

--- a/src/jls/MenuAcceleratorPolicy.java
+++ b/src/jls/MenuAcceleratorPolicy.java
@@ -249,6 +249,26 @@ public final class MenuAcceleratorPolicy {
 	} // end of flipStroke method
 
 	/**
+	 * The wire-start canvas binding: plain W, no modifier, on every
+	 * platform. Historically wire-start shared the menu-mask + W chord
+	 * with toggle-watch, a two-functions-on-one-stroke overload
+	 * (issue #75): the same Ctrl/Cmd+W was shown as the accelerator on
+	 * both the Wire and the Watch popup items. Moving wire-start to plain
+	 * W frees Ctrl/Cmd+W to mean toggle-watch alone. W is the natural
+	 * mnemonic for "Wire" and, like rotate/flip, a bare letter cannot
+	 * collide with any menu-mask chord and the canvas has no text field
+	 * to steal typing from.
+	 *
+	 * @return the wire-start keystroke.
+	 *
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#wireStartIsPlainW()
+	 */
+	public static KeyStroke wireStartStroke() {
+
+		return KeyStroke.getKeyStroke(KeyEvent.VK_W, 0);
+	} // end of wireStartStroke method
+
+	/**
 	 * The view-current-value canvas binding: plain V, no modifier, on
 	 * every platform. Historically this was menu-mask + S, which would
 	 * shadow the menu bar's Save accelerator whenever the canvas had
@@ -278,6 +298,34 @@ public final class MenuAcceleratorPolicy {
 
 		return KeyEvent.VK_F;
 	} // end of fileMenuMnemonic method
+
+	/**
+	 * The Edit menu mnemonic (issue #75): the menu-bar Edit menu holding
+	 * the undo/redo/cut/copy/paste/delete/select-all operations.
+	 *
+	 * @return the Edit menu mnemonic key code.
+	 *
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 */
+	public static int editMenuMnemonic() {
+
+		return KeyEvent.VK_E;
+	} // end of editMenuMnemonic method
+
+	/**
+	 * The Element menu mnemonic (issue #75): the menu-bar Element menu
+	 * holding the rotate/flip/watch/probe/modify/timing operations. E is
+	 * taken by the Edit menu, so Element uses L (its second consonant),
+	 * keeping every top-level mnemonic distinct.
+	 *
+	 * @return the Element menu mnemonic key code.
+	 *
+	 * @jls.testedby jls.MenuAcceleratorPolicyTest#menuMnemonicsAreDistinct()
+	 */
+	public static int elementMenuMnemonic() {
+
+		return KeyEvent.VK_L;
+	} // end of elementMenuMnemonic method
 
 	/**
 	 * The Simulator menu mnemonic.

--- a/src/jls/edit/EditOp.java
+++ b/src/jls/edit/EditOp.java
@@ -1,0 +1,155 @@
+package jls.edit;
+
+import java.awt.event.KeyEvent;
+
+import javax.swing.KeyStroke;
+
+import jls.MenuAcceleratorPolicy;
+
+/**
+ * The editing operations that the interactive editor exposes through
+ * more than one surface (issue #75).
+ *
+ * <p>Before this enum each operation existed as several independent
+ * copies: a popup {@code JMenuItem} wired to a giant source-equality
+ * {@code actionPerformed} switch, and a separate anonymous
+ * {@code AbstractAction} registered in the canvas key bindings. Adding a
+ * menu-bar item would have made a third copy. Instead each editor builds
+ * exactly one {@link javax.swing.Action} per {@code EditOp}
+ * (see {@link SimpleEditor#editAction(EditOp)}) and the popup menus, the
+ * canvas key bindings, and the menu-bar Edit and Element menus all reuse
+ * that single {@code Action} object &mdash; so the three surfaces are no
+ * longer separate copies.</p>
+ *
+ * <p>Each constant carries the human-readable label its menu items show.
+ * The accelerator keystroke is not stored here: it is platform-aware and
+ * comes from {@link jls.MenuAcceleratorPolicy} /
+ * {@link DeleteKeyPolicy} when the editor builds the {@code Action}, so
+ * this enum stays a pure, headless-safe descriptor.</p>
+ *
+ * @jls.testedby jls.ui.EditActionMatrixTest
+ */
+public enum EditOp {
+
+	/** Attach or remove a probe on the selected wire. */
+	PROBE("Probe"),
+	/** Toggle watched status of the selected element. */
+	WATCH("Watch"),
+	/** View or modify the selected element's details. */
+	MODIFY("Modify"),
+	/** Change the selected element's propagation delay or access time. */
+	TIMING("Change Timing"),
+	/** Show the selected element's current simulated value. */
+	VIEW_VALUE("View Contents"),
+	/** Cut the selection to the clipboard. */
+	CUT("Cut"),
+	/** Copy the selection to the clipboard. */
+	COPY("Copy"),
+	/** Paste the clipboard contents. */
+	PASTE("Paste"),
+	/** Delete the selection. */
+	DELETE("Delete"),
+	/** Make the selection uneditable. */
+	LOCK("Lock"),
+	/** Select every element in the circuit. */
+	SELECT_ALL("Select All"),
+	/** Undo the latest change. */
+	UNDO("Undo"),
+	/** Redo the latest undone change. */
+	REDO("Redo"),
+	/** Rotate the selected element clockwise. */
+	ROTATE_CW("Rotate Clockwise"),
+	/** Rotate the selected element counter-clockwise. */
+	ROTATE_CCW("Rotate Counter-Clockwise"),
+	/** Flip the selected element. */
+	FLIP("Flip"),
+	/** Start drawing a wire. */
+	WIRE_START("Wire(s)"),
+	/** Close the current circuit. */
+	CLOSE("Close");
+
+	/** The human-readable label the operation's menu items display. */
+	private final String label;
+
+	/**
+	 * Create an edit operation with its menu label.
+	 *
+	 * @param label the human-readable label for menu items.
+	 */
+	EditOp(String label) {
+
+		this.label = label;
+	} // end of EditOp constructor
+
+	/**
+	 * The human-readable label the operation's menu items display. The
+	 * popup Watch and Probe items override it with a state-dependent
+	 * caption (Watch/Un-watch, Attach/Remove Probe), but the menu-bar
+	 * items and every other surface use this stable label.
+	 *
+	 * @return the menu label.
+	 */
+	public String label() {
+
+		return label;
+	} // end of label method
+
+	/**
+	 * The accelerator keystroke this operation's menu items and canvas
+	 * key binding use (issue #75). This is the single source of truth for
+	 * the operation's shortcut, shared by the editor (which tags its
+	 * shared {@link javax.swing.Action} with it) and the main window's
+	 * Edit and Element menus (which show and window-scope it), so the
+	 * surfaces never drift. The mask is the platform menu modifier (Cmd
+	 * on macOS, Ctrl elsewhere), derived headless-safely from the given
+	 * {@code os.name} rather than from {@code Toolkit}.
+	 *
+	 * @param osName value of the os.name system property (null-safe).
+	 * @return the accelerator keystroke; never null.
+	 */
+	public KeyStroke accelerator(String osName) {
+
+		int mask = MenuAcceleratorPolicy.menuMask(osName);
+		switch (this) {
+			case PROBE:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_P, mask);
+			case WATCH:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_W, mask);
+			case MODIFY:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_M, mask);
+			case TIMING:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_T, mask);
+			case VIEW_VALUE:
+				return MenuAcceleratorPolicy.viewValueStroke();
+			case CUT:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_X, mask);
+			case COPY:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_C, mask);
+			case PASTE:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_V, mask);
+			case DELETE:
+				return DeleteKeyPolicy.menuAccelerator(osName);
+			case LOCK:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_L, mask);
+			case SELECT_ALL:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_A, mask);
+			case UNDO:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_Z, mask);
+			case REDO:
+				return MenuAcceleratorPolicy.redoDisplayed(osName);
+			case ROTATE_CW:
+				return MenuAcceleratorPolicy.rotateCwStroke();
+			case ROTATE_CCW:
+				return MenuAcceleratorPolicy.rotateCcwStroke();
+			case FLIP:
+				return MenuAcceleratorPolicy.flipStroke();
+			case WIRE_START:
+				return MenuAcceleratorPolicy.wireStartStroke();
+			case CLOSE:
+				return KeyStroke.getKeyStroke(KeyEvent.VK_E, mask);
+			default:
+				throw new AssertionError("no accelerator for " + this);
+		}
+	} // end of accelerator method
+
+} // end of EditOp enum

--- a/src/jls/edit/KeyboardConstructionPolicy.java
+++ b/src/jls/edit/KeyboardConstructionPolicy.java
@@ -1,0 +1,158 @@
+package jls.edit;
+
+import java.awt.event.KeyEvent;
+import java.util.Optional;
+
+import javax.swing.KeyStroke;
+
+/**
+ * The keyboard-only construction bindings and pure geometry that let a
+ * user build a circuit with no pointing device (issue #75, the H2 half).
+ *
+ * <p>The interactive editor is normally driven by the mouse: elements are
+ * dropped, dragged, and wired by pointing. This policy supplies the
+ * platform-independent pieces the editor needs to offer the same
+ * capabilities from the keyboard - an arrow-key grid caret, Enter to
+ * place or commit, arrow-key nudging of a selection, and W to start a
+ * wire at the caret - so a keyboard user can lay out and wire the
+ * tutorial's first two-gate circuit unaided.</p>
+ *
+ * <p>Every method here is a pure, Swing-free, headless-safe function of
+ * its arguments (no {@code Toolkit}, no component state), which is why it
+ * lives beside {@link DeleteKeyPolicy} rather than inside the Swing
+ * editor: the arrow-to-direction mapping and the grid-step arithmetic can
+ * then be unit-tested without a display. The editor owns the stateful
+ * half (the caret position, the wire state machine); this class owns only
+ * the decisions.</p>
+ *
+ * @jls.testedby jls.edit.KeyboardConstructionPolicyTest
+ */
+public final class KeyboardConstructionPolicy {
+
+	/**
+	 * Prevents instantiation; the class holds only static policy methods
+	 * and the {@link Nudge} enum.
+	 */
+	private KeyboardConstructionPolicy() {
+		// static use only
+	} // end of KeyboardConstructionPolicy constructor
+
+	/**
+	 * One of the four grid directions an arrow key nudges the caret, a
+	 * placing element, a wire end, or the selection in (issue #75). The
+	 * enum keeps the arrow-key-to-delta decision in one pure place so the
+	 * editor's several arrow-driven modes (caret motion, placement
+	 * nudging, wire extension, selection nudging) all agree on which way
+	 * each key moves and never drift.
+	 */
+	public enum Nudge {
+
+		/** Toward smaller y (up the screen). */
+		UP(0, -1),
+		/** Toward larger y (down the screen). */
+		DOWN(0, 1),
+		/** Toward smaller x (left). */
+		LEFT(-1, 0),
+		/** Toward larger x (right). */
+		RIGHT(1, 0);
+
+		/** The x sign of this direction (-1, 0, or +1). */
+		private final int sx;
+		/** The y sign of this direction (-1, 0, or +1). */
+		private final int sy;
+
+		/**
+		 * Create a direction with its unit x and y signs.
+		 *
+		 * @param sx the x sign (-1, 0, or +1).
+		 * @param sy the y sign (-1, 0, or +1).
+		 */
+		Nudge(int sx, int sy) {
+
+			this.sx = sx;
+			this.sy = sy;
+		} // end of Nudge constructor
+
+		/**
+		 * The direction an arrow key requests, if any. Only the four
+		 * arrow keys map; every other key code yields an empty result so
+		 * the editor can let non-arrow keys fall through to their own
+		 * bindings.
+		 *
+		 * @param vk a {@link KeyEvent} VK_ key code.
+		 * @return the direction, or empty if the key is not an arrow.
+		 */
+		public static Optional<Nudge> fromKey(int vk) {
+
+			switch (vk) {
+				case KeyEvent.VK_UP:
+					return Optional.of(UP);
+				case KeyEvent.VK_DOWN:
+					return Optional.of(DOWN);
+				case KeyEvent.VK_LEFT:
+					return Optional.of(LEFT);
+				case KeyEvent.VK_RIGHT:
+					return Optional.of(RIGHT);
+				default:
+					return Optional.empty();
+			}
+		} // end of fromKey method
+
+		/**
+		 * The x movement for this direction over one grid step.
+		 *
+		 * @param step the grid step size in model units (never negative).
+		 * @return the signed x delta (a multiple of the step).
+		 */
+		public int dx(int step) {
+
+			return sx * step;
+		} // end of dx method
+
+		/**
+		 * The y movement for this direction over one grid step.
+		 *
+		 * @param step the grid step size in model units (never negative).
+		 * @return the signed y delta (a multiple of the step).
+		 */
+		public int dy(int step) {
+
+			return sy * step;
+		} // end of dy method
+
+	} // end of Nudge enum
+
+	/**
+	 * The keystroke that places a following element, commits a wire
+	 * vertex, or activates the caret (issue #75): plain Enter, no
+	 * modifier, on every platform. Enter is the universal "commit" key and
+	 * the canvas has no text field to steal it from.
+	 *
+	 * @return the commit keystroke.
+	 *
+	 * @jls.testedby jls.edit.KeyboardConstructionPolicyTest#commitStrokeIsPlainEnter()
+	 */
+	public static KeyStroke commitStroke() {
+
+		return KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
+	} // end of commitStroke method
+
+	/**
+	 * Snap a model coordinate down to the nearest grid line at or below
+	 * it (issue #75). The keyboard caret only ever visits grid points, so
+	 * that a wire started or ended at the caret lands exactly on the grid
+	 * ports elements expose - which is how the editor's coincidence-based
+	 * {@code connect} joins port to port with no pointing.
+	 *
+	 * @param coord a model coordinate.
+	 * @param step the grid step size in model units (must be positive).
+	 * @return the largest multiple of the step not greater than coord.
+	 *
+	 * @jls.testedby jls.edit.KeyboardConstructionPolicyTest#snapRoundsDownToGrid()
+	 */
+	public static int snap(int coord, int step) {
+
+		return Math.floorDiv(coord, step) * step;
+	} // end of snap method
+
+} // end of KeyboardConstructionPolicy class

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -2549,6 +2549,14 @@ public abstract class SimpleEditor extends JPanel {
 				button.setToolTipText(tip);
 				button.setBackground(Color.WHITE);
 				item.setToolTipText(tip);
+				// #75 accessibility: the palette buttons are icon-only, so the
+				// shared Action's NAME is the empty string and the button would
+				// otherwise expose a blank accessible name - a screen reader
+				// focusing it would announce nothing. The tooltip carries the
+				// human-readable element name, so make it the accessible name on
+				// both the tool-bar button and its mirror "elements" menu item.
+				button.getAccessibleContext().setAccessibleName(tip);
+				item.getAccessibleContext().setAccessibleName(tip);
 				elements.add(item);
 				return button;
 			} // end of makeElement method

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -26,8 +26,11 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,6 +69,7 @@ import jls.Util;
 import jls.collab.op.AttachProbe;
 import jls.collab.op.CircuitOp;
 import jls.collab.op.FlipElement;
+import jls.collab.op.MoveElements;
 import jls.collab.op.OpRejected;
 import jls.collab.op.OpSink;
 import jls.collab.op.RemoveProbe;
@@ -79,6 +83,7 @@ import jls.elem.Constant;
 import jls.elem.Decoder;
 import jls.elem.DelayGate;
 import jls.elem.Element;
+import jls.elem.ElementId;
 import jls.elem.Extend;
 import jls.elem.Group;
 import jls.elem.Input;
@@ -591,6 +596,40 @@ public abstract class SimpleEditor extends JPanel {
 	} // end of focusOnCanvas method
 
 	/**
+	 * The single shared {@link Action} this editor uses for the given
+	 * editing operation (issue #75). The popup menus, the canvas key
+	 * bindings, and the main window's Edit and Element menus all dispatch
+	 * through this one object, so the three surfaces are not separate
+	 * copies of the operation. The action is always enabled and guards
+	 * its own preconditions (selection size, editability), so invoking it
+	 * with nothing selected is a harmless no-op. The main menu bar
+	 * retargets its items to the currently selected editor's actions on
+	 * every tab change.
+	 *
+	 * @param op the editing operation.
+	 * @return the shared action for that operation.
+	 */
+	public Action editAction(EditOp op) {
+
+		return ew.editAction(op);
+	} // end of editAction method
+
+	/**
+	 * The current keyboard construction caret position (issue #75), in
+	 * model coordinates, or null if the keyboard has not yet been used to
+	 * point. The caret is the keyboard counterpart of the mouse pointer: a
+	 * grid-snapped marker arrow keys move and W starts a wire at. Exposed
+	 * so a keyboard-driven construction test can read where the next
+	 * placement or wire endpoint will land between key presses.
+	 *
+	 * @return a copy of the caret point, or null when the caret is unset.
+	 */
+	public Point keyboardCaret() {
+
+		return ew.keyboardCaret();
+	} // end of keyboardCaret method
+
+	/**
 	 * Zoom in one keyboard ladder stop, centered on the visible canvas
 	 * (issue #74). Bound to the View menu's Zoom In item and Ctrl/Cmd+=.
 	 */
@@ -757,46 +796,6 @@ public abstract class SimpleEditor extends JPanel {
 	};
 
 	/**
-	 * What the ctrl-W shortcut does, as a pure function of editor state
-	 * and selection size, so the dispatch is unit-testable headless
-	 * (issue #126; the injected-facts pattern of ToolkitPolicy).
-	 */
-	enum CtrlW {
-		/** Start drawing a wire. */
-		START_WIRE,
-		/** Toggle watched status of the selected element. */
-		TOGGLE_WATCH,
-		/** Do nothing. */
-		NONE
-	};
-
-	/**
-	 * Decide the ctrl-W gesture. From idle the shortcut always starts a
-	 * wire — before #126 it also required an empty selection, so the
-	 * hover selection that idle mouse motion maintains made the shortcut
-	 * toggle watch, or do nothing, until the cursor left every element.
-	 * Watch toggling remains reachable from every non-idle state with a
-	 * single selected element (e.g. after a select-rectangle).
-	 *
-	 * @param state The current editor state.
-	 * @param selectionSize The number of currently selected elements.
-	 * @return the gesture to perform.
-	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireDespiteMultiSelection()
-	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireDespiteSingleSelection()
-	 * @jls.testedby jls.edit.CtrlWGestureTest#idleStartsWireWithEmptySelection()
-	 * @jls.testedby jls.edit.CtrlWGestureTest#otherStatesDoNothing()
-	 * @jls.testedby jls.edit.CtrlWGestureTest#watchToggleStillReachableFromSelectedState()
-	 */
-	static CtrlW ctrlWGesture(State state, int selectionSize) {
-
-		if (state == State.idle)
-			return CtrlW.START_WIRE;
-		if (selectionSize == 1)
-			return CtrlW.TOGGLE_WATCH;
-		return CtrlW.NONE;
-	} // end of ctrlWGesture method
-
-	/**
 	 * Result of starting the wire-drawing gesture: the initial wire end,
 	 * and whether a selection had to be cleared to start it. The flag is
 	 * captured before the clear — keyed off the selection afterwards it
@@ -927,6 +926,16 @@ public abstract class SimpleEditor extends JPanel {
 			/** Menu item to create the wire end matching a jump start. */
 			private JMenuItem matchJump = new JMenuItem("Create Matching End");
 
+			/**
+			 * The one shared {@link Action} per editing operation
+			 * (issue #75). Built once in the constructor and reused by the
+			 * popup menu items, the canvas key bindings, and the main
+			 * window's Edit and Element menus, so those surfaces dispatch
+			 * through a single object instead of three separate copies.
+			 */
+			private final EnumMap<EditOp,Action> editActions =
+					new EnumMap<EditOp,Action>(EditOp.class);
+
 			/** The element toolbar shown above the edit window. */
 			private JPanel toolbar;
 			/** The element menu backing the toolbar. */
@@ -977,6 +986,17 @@ public abstract class SimpleEditor extends JPanel {
 			/** Puts marked touching by overlap/connect. */
 			private Set<Put>touchedPuts =
 					new HashSet<Put>();
+			/**
+			 * The keyboard construction caret (issue #75), in model
+			 * coordinates and always grid-snapped, or null when the
+			 * keyboard has not been used to point yet. Arrow keys move it
+			 * while idle; W starts a wire at it; it is the keyboard
+			 * counterpart of the mouse pointer, so a user with no pointing
+			 * device can position a drop point or a wire endpoint. It
+			 * tracks the following element or wire end while placing or
+			 * drawing so it always shows where the next commit lands.
+			 */
+			private Point caret = null;
 
 			/**
 			 * Create a new edit window.
@@ -999,170 +1019,70 @@ public abstract class SimpleEditor extends JPanel {
 				// wheel = scroll, Ctrl/Cmd+wheel = zoom-at-cursor (issue #74)
 				addMouseWheelListener(this);
 
-				// set up popup menus
-				probe.setToolTipText("watch activity on this wire during simulation");
-				probe.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				watch.setToolTipText("watch activity on this element during simulation");
-				watch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				modify.setToolTipText("view/modify element details");
-				modify.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				timing.setToolTipText("change propagation delay or access time");
-				timing.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				view.setToolTipText("view current simulated value");
-				// plain V, not menu-mask+S: the old stroke shadowed the
-				// menu bar's Save accelerator whenever the canvas had
-				// focus (#75)
-				view.setAccelerator(MenuAcceleratorPolicy.viewValueStroke());
-				cut.setToolTipText("cut all selected elements to clipboard");
-				cut.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				copy.setToolTipText("copy all selected elements to clipboard");
-				copy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
-				delete.setToolTipText("delete all selected elements");
-				delete.setAccelerator(DeleteKeyPolicy.menuAccelerator(System.getProperty("os.name")));
-				lock.setToolTipText("make selected elements uneditable (cannot be undone)");
-				lock.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_L,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				// build the one shared Action per editing operation (#75)
+				// before wiring any surface to them
+				initEditActions();
+
+				// set up popup menus: every item dispatches through the
+				// shared Action, which carries its label, accelerator,
+				// tooltip, and the single implementation - so the popups,
+				// the canvas key bindings, and the menu bar Edit/Element
+				// menus are no longer three separate copies of each op
+				probe.setAction(editAction(EditOp.PROBE));
+				watch.setAction(editAction(EditOp.WATCH));
+				modify.setAction(editAction(EditOp.MODIFY));
+				timing.setAction(editAction(EditOp.TIMING));
+				view.setAction(editAction(EditOp.VIEW_VALUE));
+				cut.setAction(editAction(EditOp.CUT));
+				copy.setAction(editAction(EditOp.COPY));
+				delete.setAction(editAction(EditOp.DELETE));
+				lock.setAction(editAction(EditOp.LOCK));
 
 				// rotate/flip show the plain-key canvas bindings (#75)
-				Crotate.setToolTipText("rotate the selected element clockwise");
-				Crotate.setAccelerator(MenuAcceleratorPolicy.rotateCwStroke());
-				CCrotate.setToolTipText("rotate the selected element counter-clockwise");
-				CCrotate.setAccelerator(MenuAcceleratorPolicy.rotateCcwStroke());
-				flip.setToolTipText("flip the selected element");
-				flip.setAccelerator(MenuAcceleratorPolicy.flipStroke());
+				Crotate.setAction(editAction(EditOp.ROTATE_CW));
+				CCrotate.setAction(editAction(EditOp.ROTATE_CCW));
+				flip.setAction(editAction(EditOp.FLIP));
 
-				// TODO: Make an action for this.
-				//matchJump.setToolTipText("create the wire end to match this wire start");
-				//matchJump.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				// matchJump is contextual (JumpStart only) and popup-only,
+				// so it stays on the ActionListener rather than becoming a
+				// shared Action
+				matchJump.addActionListener(this);
 
-				connect.setToolTipText("create a new wire");
-				connect.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				// the connect item now shows plain W: wire-start moved off
+				// the Ctrl/Cmd+W it used to share with Watch, resolving the
+				// overload that put the same stroke on two popup items (#75)
+				connect.setAction(editAction(EditOp.WIRE_START));
 				newMenu.add(connect);
 
-				paste.setToolTipText("paste contents of clipboard");
-				paste.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				paste.setAction(editAction(EditOp.PASTE));
 				newMenu.add(paste);
 
-				selAll.setToolTipText("select all elements");
-				selAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				selAll.setAction(editAction(EditOp.SELECT_ALL));
 				newMenu.add(selAll);
 
-				close.setToolTipText("close this circuit");
-				close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				close.setAction(editAction(EditOp.CLOSE));
 				newMenu.add(close);
 
-				undo.setToolTipText("undo last modification");
-				undo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+				undo.setAction(editAction(EditOp.UNDO));
 				newMenu.add(undo);
 
-				redo.setToolTipText("redo last undo");
-				// Shift+Cmd+Z on macOS (platform convention), Ctrl+Y
-				// elsewhere; the policy keeps Cmd+Y bound as an alias (#75)
-				redo.setAccelerator(MenuAcceleratorPolicy.redoDisplayed(System.getProperty("os.name")));
+				redo.setAction(editAction(EditOp.REDO));
 				newMenu.add(redo);
 
 				makeElements();
 				newMenu.add(elements);
 
-				// add listeners for menu items
-				probe.addActionListener(this);
-				watch.addActionListener(this);
-				modify.addActionListener(this);
-				timing.addActionListener(this);
-				view.addActionListener(this);
-				cut.addActionListener(this);
-				copy.addActionListener(this);
-				delete.addActionListener(this);
-				lock.addActionListener(this);
-				undo.addActionListener(this);
-				redo.addActionListener(this);
-				paste.addActionListener(this);
-				selAll.addActionListener(this);
-				close.addActionListener(this);
-				connect.addActionListener(this);
-				Crotate.addActionListener(this);
-				CCrotate.addActionListener(this);
-				flip.addActionListener(this);
-				matchJump.addActionListener(this);
-
-				// set up ctrl-w (new wire / watch) key binding
-				Action ctrlw = new AbstractAction() {
-					/**
-					 * Handle ctrl-W: start a wire from idle, otherwise toggle the watch
-					 * on a single selected element.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						// decide what the shortcut does here (#126)
-						CtrlW gesture = ctrlWGesture(currentState,selected.size());
-
-						// if current state is idle, start a wire, superseding
-						// any hover selection (#126)
-						if (gesture == CtrlW.START_WIRE) {
-
-							// start a wire
-							Point p = getMousePosition();
-							if (p == null)
-								return; // not in drawing window
-							// invert the component position into model space (#74)
-							p = viewport.toModel(p);
-							setState(State.startwire);
-							x = p.x;
-							y = p.y;
-							autoGrow(x,y);
-							WireStart start =
-									startWireGesture(circuit,selected,x,y);
-							wireEnd = start.end();
-							wire = null;
-							net = wireEnd.getNet();
-
-							// a cleared selection was under the cursor, so
-							// report the (likely) overlap the same way wire
-							// dragging does
-							if (start.hadSelection()) {
-								if (overlap()) {
-									info.setText(overlapMessage);
-									info.setForeground(Color.red);
-								}
-								else {
-									info.setText("");
-									info.setForeground(Color.black);
-								}
-							}
-							repaint();
-						}
-						else if (gesture == CtrlW.TOGGLE_WATCH) {
-
-							// watch/unwatch
-							Element el = (Element)selected.toArray()[0];
-
-							// do nothing if locked
-							if (el.isUneditable())
-								return;
-
-							// do nothing if not watchable
-							if (!el.canWatch())
-								return;
-
-							// remove if watched, add if not (#167: through
-							// the op entry point)
-							submitOp(new ToggleWatched(el.getStableId()));
-
-							// clean up
-							clearSelected();
-							setState(State.idle);
-							repaint();
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_W,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"ctrlw");
-				getActionMap().put("ctrlw", ctrlw);
+				// canvas key bindings: menu-mask+W now toggles Watch only
+				// and wire-start is the dedicated plain-W binding, so the
+				// two functions no longer share one stroke (#75). Both
+				// point at the same shared Actions the popups and menu bar
+				// use.
+				int menuMask =
+						Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_W,menuMask),"watch");
+				getActionMap().put("watch", editAction(EditOp.WATCH));
+				getInputMap().put(MenuAcceleratorPolicy.wireStartStroke(),"wire start");
+				getActionMap().put("wire start", editAction(EditOp.WIRE_START));
 
 				// set up end wire key binding
 				Action endWire = new AbstractAction() {
@@ -1209,364 +1129,74 @@ public abstract class SimpleEditor extends JPanel {
 				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE,0),"Escape");
 				getActionMap().put("Escape", endWire);
 
-				// set up view key binding
-				Action see = new AbstractAction() {
-					/**
-					 * Handle the view shortcut: show the single selected element's
-					 * current value.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						// do nothing if not just one element selected
-						if (selected.size() != 1)
-							return;
-
-						// get the single item in the selected set
-						Element el = (Element)(selected.toArray()[0]);
-
-						// ask element to display its current value
-						el.showCurrentValue(new Point(x,y));
-
-						// clean up
-						clearSelected();
-						setState(State.idle);
-						repaint();
-
-					}
-				};
+				// the remaining edit-op key bindings all dispatch through the
+				// shared Actions (#75): the InputMap names them and the
+				// ActionMap points each at editAction(op), the same object the
+				// popup items and the menu-bar Edit/Element menus use
 				getInputMap().put(MenuAcceleratorPolicy.viewValueStroke(),"view");
-				getActionMap().put("view", see);
-
-				// set up modify key binding
-				Action modify = new AbstractAction() {
-					/**
-					 * Handle the modify shortcut: modify the single selected element.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						// do nothing if not just one element selected
-						if (selected.size() != 1)
-							return;
-
-						doModify();
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_M,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"modify");
-				getActionMap().put("modify", modify);
-
-				// set up probe key binding
-				Action probe = new AbstractAction() {
-					/**
-					 * Handle the probe shortcut: toggle a probe on the single selected
-					 * wire.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						// do nothing if not just one element selected
-						if (selected.size() != 1)
-							return;
-
-						// do nothing if the selected element is not a wire
-						Element el = (Element)selected.toArray()[0];
-						if (!(el instanceof Wire))
-							return;
-
-						doProbe();
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"probe");
-				getActionMap().put("probe", probe);
-
-				// set up timing key binding
-				Action timing = new AbstractAction() {
-					/**
-					 * Handle the timing shortcut: change timing on the single selected
-					 * element that has it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						// do nothing if not just one element selected
-						if (selected.size() != 1)
-							return;
-
-						// do nothing if the selected element does not having timing
-						Element el = (Element)selected.toArray()[0];
-						if (!el.hasTiming())
-							return;
-
-						doTiming();
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_T,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"timing");
-				getActionMap().put("timing",timing);
-
-				// set up selectAll key binding
-				Action selectAll = new AbstractAction() {
-					/**
-					 * Handle the select-all shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-
-						// do nothing if editor is disabled
-						if (!enabled)
-							return;
-
-						doSelectAll();
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_A,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"select all");
-				getActionMap().put("select all", selectAll);
-
-				// set up close window key binding
-				Action closeWin = new AbstractAction() {
-					/**
-					 * Handle the close-window shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						close();
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_E,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"close window");
-				getActionMap().put("close window", closeWin);
-
-				// set up delete key binding
-				Action deleteKey = new AbstractAction() {
-					/**
-					 * Handle the delete shortcut: remove the selected elements.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							remove();
-							removeCoLinear();
-							clearSelected();
-							setState(State.idle);
-							repaint();
-						}
-					}
-				};
+				getActionMap().put("view", editAction(EditOp.VIEW_VALUE));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_M,menuMask),"modify");
+				getActionMap().put("modify", editAction(EditOp.MODIFY));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_P,menuMask),"probe");
+				getActionMap().put("probe", editAction(EditOp.PROBE));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_T,menuMask),"timing");
+				getActionMap().put("timing", editAction(EditOp.TIMING));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_A,menuMask),"select all");
+				getActionMap().put("select all", editAction(EditOp.SELECT_ALL));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_E,menuMask),"close window");
+				getActionMap().put("close window", editAction(EditOp.CLOSE));
 				for (KeyStroke stroke : DeleteKeyPolicy.canvasBindings())
 					getInputMap().put(stroke,"do delete");
-				getActionMap().put("do delete", deleteKey);
-
-				// set up cut key binding
-				Action cutKey = new AbstractAction() {
-					/**
-					 * Handle the cut shortcut: copy then remove the selected elements.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							copy();
-							remove();
-							removeCoLinear();
-							clearSelected();
-							setState(State.idle);
-							repaint();
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_X,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"do cut");
-				getActionMap().put("do cut", cutKey);
-
-				// set up copy key binding
-				Action copyKey = new AbstractAction() {
-					/**
-					 * Handle the copy shortcut: copy the selected elements to the
-					 * clipboard.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							copy();
-							clearSelected();
-							setState(State.idle);
-							repaint();
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_C,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"do copy");
-				getActionMap().put("do copy", copyKey);
-
-				// set up paste key binding
-				Action pasteKey = new AbstractAction() {
-					/**
-					 * Handle the paste shortcut: paste the clipboard contents.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							if (clipboard.getElements().size() == 0)
-								return;
-							if (paste(clipboard)) {
-								setState(State.placing);
-							}
-							repaint();
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_V,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"do paste");
-				getActionMap().put("do paste", pasteKey);
-
-				// set up undo key binding
-				Action undoKey = new AbstractAction() {
-					/**
-					 * Handle the undo shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							undo();
-							repaint();
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"do undo");
-				getActionMap().put("do undo", undoKey);
-
-				// set up redo key binding
-				Action redoKey = new AbstractAction() {
-					/**
-					 * Handle the redo shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-							redo();
-							repaint();
-						}
-					}
-				};
-				// every redo stroke the policy defines: the platform
-				// accelerator plus, on macOS, the historical Cmd+Y alias (#75)
+				getActionMap().put("do delete", editAction(EditOp.DELETE));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_X,menuMask),"do cut");
+				getActionMap().put("do cut", editAction(EditOp.CUT));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_C,menuMask),"do copy");
+				getActionMap().put("do copy", editAction(EditOp.COPY));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_V,menuMask),"do paste");
+				getActionMap().put("do paste", editAction(EditOp.PASTE));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z,menuMask),"do undo");
+				getActionMap().put("do undo", editAction(EditOp.UNDO));
+				// every redo stroke the policy defines: the platform accelerator
+				// plus, on macOS, the historical Cmd+Y alias (#75)
 				for (KeyStroke stroke : MenuAcceleratorPolicy.redoBindings(System.getProperty("os.name")))
 					getInputMap().put(stroke,"do redo");
-				getActionMap().put("do redo", redoKey);
-
-				// set up lock key binding
-				Action lockKey = new AbstractAction() {
-					/**
-					 * Handle the lock shortcut: make the selected elements uneditable.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						if (enabled) {
-
-							// warn user first
-							boolean opt = TellUser.confirm(null,
-									"Making elements uneditable cannot be undone.  Are you sure you want to do this?",
-									"WARNING");
-
-							// if user still ok with it ...
-							if (opt) {
-
-								// make selected elements uneditable
-								for (Element el : selected) {
-									el.makeUneditable();
-								}
-							}
-
-							// finish up
-							clearSelected();
-							setState(State.idle);
-							repaint();
-							return;
-						}
-					}
-				};
-				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_L,Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()),"do lock");
-				getActionMap().put("do lock", lockKey);
-
-				// set up rotate/flip key bindings (#75): plain R, Shift+R,
-				// and F act on a single selected element, sharing the same
-				// code path as the popup menu items
-				Action rotateCwKey = new AbstractAction() {
-					/**
-					 * Handle the rotate-clockwise shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						rotateSelected(true);
-					}
-				};
+				getActionMap().put("do redo", editAction(EditOp.REDO));
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_L,menuMask),"do lock");
+				getActionMap().put("do lock", editAction(EditOp.LOCK));
 				getInputMap().put(MenuAcceleratorPolicy.rotateCwStroke(),"rotate cw");
-				getActionMap().put("rotate cw", rotateCwKey);
-				Action rotateCcwKey = new AbstractAction() {
-					/**
-					 * Handle the rotate-counter-clockwise shortcut.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						rotateSelected(false);
-					}
-				};
+				getActionMap().put("rotate cw", editAction(EditOp.ROTATE_CW));
 				getInputMap().put(MenuAcceleratorPolicy.rotateCcwStroke(),"rotate ccw");
-				getActionMap().put("rotate ccw", rotateCcwKey);
-				Action flipKey = new AbstractAction() {
+				getActionMap().put("rotate ccw", editAction(EditOp.ROTATE_CCW));
+				getInputMap().put(MenuAcceleratorPolicy.flipStroke(),"do flip");
+				getActionMap().put("do flip", editAction(EditOp.FLIP));
+
+				// keyboard-only construction bindings (issue #75, H2):
+				// arrow keys move the grid caret, the following element, the
+				// wire end, or the selection depending on state; Enter
+				// commits (places, wires, or selects). All WHEN_FOCUSED like
+				// the other canvas bindings, so a keyboard user builds a
+				// circuit with no pointing device
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_UP,0),"kbd up");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN,0),"kbd down");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_LEFT,0),"kbd left");
+				getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT,0),"kbd right");
+				getActionMap().put("kbd up", nudgeAction(KeyboardConstructionPolicy.Nudge.UP));
+				getActionMap().put("kbd down", nudgeAction(KeyboardConstructionPolicy.Nudge.DOWN));
+				getActionMap().put("kbd left", nudgeAction(KeyboardConstructionPolicy.Nudge.LEFT));
+				getActionMap().put("kbd right", nudgeAction(KeyboardConstructionPolicy.Nudge.RIGHT));
+				getInputMap().put(KeyboardConstructionPolicy.commitStroke(),"kbd commit");
+				Action kbdCommit = new AbstractAction() {
 					/**
-					 * Handle the flip shortcut.
+					 * Handle the keyboard commit (Enter) key.
 					 *
 					 * @param event The triggering action event.
 					 */
 					@Override
 					public void actionPerformed(ActionEvent event) {
-						flipSelected();
+						keyboardCommit();
 					}
 				};
-				getInputMap().put(MenuAcceleratorPolicy.flipStroke(),"do flip");
-				getActionMap().put("do flip", flipKey);
+				getActionMap().put("kbd commit", kbdCommit);
 
 				// set up zoom key bindings (issue #74): Ctrl/Cmd += in,
 				// Ctrl/Cmd +- out, Ctrl/Cmd +0 actual size, Ctrl/Cmd +9 fit.
@@ -1659,6 +1289,443 @@ public abstract class SimpleEditor extends JPanel {
 				getActionMap().put("pan off", spaceReleased);
 
 			} // end of constructor
+
+			/**
+			 * The shared {@link Action} for one editing operation (#75).
+			 * The popup items, the key bindings, and the menu-bar Edit and
+			 * Element menus all dispatch through the object this returns.
+			 *
+			 * @param op the editing operation.
+			 * @return the one shared action for that operation.
+			 */
+			Action editAction(EditOp op) {
+
+				return editActions.get(op);
+			} // end of editAction method
+
+			/**
+			 * The current keyboard construction caret position (issue #75),
+			 * copied so callers cannot mutate it, or null when unset.
+			 *
+			 * @return a copy of the caret point, or null.
+			 */
+			Point keyboardCaret() {
+
+				return caret == null ? null : new Point(caret);
+			} // end of keyboardCaret method
+
+			/**
+			 * Store a shared editing Action under its operation, tagging it
+			 * with the label, accelerator, and tooltip its menu items and
+			 * bindings display (#75). The action is always enabled and
+			 * guards its own preconditions, so any surface may invoke it
+			 * safely.
+			 *
+			 * @param op the operation the action performs.
+			 * @param accel the accelerator keystroke, or null for none.
+			 * @param tip the tooltip/short description.
+			 * @param action the action implementation.
+			 */
+			private void register(EditOp op, KeyStroke accel, String tip,
+				Action action) {
+
+				action.putValue(Action.NAME, op.label());
+				if (accel != null)
+					action.putValue(Action.ACCELERATOR_KEY, accel);
+				action.putValue(Action.SHORT_DESCRIPTION, tip);
+				editActions.put(op, action);
+			} // end of register method
+
+			/**
+			 * Build the one shared Action per editing operation (#75). Each
+			 * body is the single implementation for its operation - lifted
+			 * from what used to be a popup switch arm and a duplicate
+			 * key-binding action - and carries every guard (editor enabled,
+			 * selection size, element type) so it is a harmless no-op when
+			 * invoked from the menu bar with nothing appropriate selected.
+			 */
+			private void initEditActions() {
+
+				int menuMask =
+						Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+				String osName = System.getProperty("os.name");
+
+				register(EditOp.PROBE, KeyStroke.getKeyStroke(KeyEvent.VK_P,menuMask),
+					"watch activity on this wire during simulation",
+					new AbstractAction() {
+						/**
+						 * Perform the PROBE operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (selected.size() != 1)
+								return;
+							Element el = (Element)selected.toArray()[0];
+							if (!(el instanceof Wire))
+								return;
+							doProbe();
+						}
+					});
+
+				register(EditOp.WATCH, KeyStroke.getKeyStroke(KeyEvent.VK_W,menuMask),
+					"watch activity on this element during simulation",
+					new AbstractAction() {
+						/**
+						 * Perform the WATCH operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (selected.size() != 1)
+								return;
+							Element el = (Element)selected.toArray()[0];
+							if (el.isUneditable())
+								return;
+							if (!el.canWatch())
+								return;
+							submitOp(new ToggleWatched(el.getStableId()));
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.MODIFY, KeyStroke.getKeyStroke(KeyEvent.VK_M,menuMask),
+					"view/modify element details",
+					new AbstractAction() {
+						/**
+						 * Perform the MODIFY operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (selected.size() != 1)
+								return;
+							doModify();
+						}
+					});
+
+				register(EditOp.TIMING, KeyStroke.getKeyStroke(KeyEvent.VK_T,menuMask),
+					"change propagation delay or access time",
+					new AbstractAction() {
+						/**
+						 * Perform the TIMING operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (selected.size() != 1)
+								return;
+							Element el = (Element)selected.toArray()[0];
+							if (!el.hasTiming())
+								return;
+							doTiming();
+						}
+					});
+
+				register(EditOp.VIEW_VALUE, MenuAcceleratorPolicy.viewValueStroke(),
+					"view current simulated value",
+					new AbstractAction() {
+						/**
+						 * Perform the VIEW_VALUE operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (selected.size() != 1)
+								return;
+							Element el = (Element)selected.toArray()[0];
+							el.showCurrentValue(new Point(x,y));
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.CUT, KeyStroke.getKeyStroke(KeyEvent.VK_X,menuMask),
+					"cut all selected elements to clipboard",
+					new AbstractAction() {
+						/**
+						 * Perform the CUT operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							copy();
+							remove();
+							removeCoLinear();
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.COPY, KeyStroke.getKeyStroke(KeyEvent.VK_C,menuMask),
+					"copy all selected elements to clipboard",
+					new AbstractAction() {
+						/**
+						 * Perform the COPY operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							copy();
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.PASTE, KeyStroke.getKeyStroke(KeyEvent.VK_V,menuMask),
+					"paste contents of clipboard",
+					new AbstractAction() {
+						/**
+						 * Perform the PASTE operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							if (clipboard.getElements().size() == 0)
+								return;
+							if (paste(clipboard))
+								setState(State.placing);
+							repaint();
+						}
+					});
+
+				register(EditOp.DELETE, DeleteKeyPolicy.menuAccelerator(osName),
+					"delete all selected elements",
+					new AbstractAction() {
+						/**
+						 * Perform the DELETE operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							remove();
+							removeCoLinear();
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.LOCK, KeyStroke.getKeyStroke(KeyEvent.VK_L,menuMask),
+					"make selected elements uneditable (cannot be undone)",
+					new AbstractAction() {
+						/**
+						 * Perform the LOCK operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							boolean opt = TellUser.confirm(null,
+									"Making elements uneditable cannot be undone.  Are you sure you want to do this?",
+									"WARNING");
+							if (opt) {
+								for (Element el : selected) {
+									el.makeUneditable();
+								}
+							}
+							clearSelected();
+							setState(State.idle);
+							repaint();
+						}
+					});
+
+				register(EditOp.SELECT_ALL, KeyStroke.getKeyStroke(KeyEvent.VK_A,menuMask),
+					"select all elements",
+					new AbstractAction() {
+						/**
+						 * Perform the SELECT_ALL operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							doSelectAll();
+						}
+					});
+
+				register(EditOp.UNDO, KeyStroke.getKeyStroke(KeyEvent.VK_Z,menuMask),
+					"undo last modification",
+					new AbstractAction() {
+						/**
+						 * Perform the UNDO operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							undo();
+							repaint();
+						}
+					});
+
+				register(EditOp.REDO, MenuAcceleratorPolicy.redoDisplayed(osName),
+					"redo last undo",
+					new AbstractAction() {
+						/**
+						 * Perform the REDO operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							redo();
+							repaint();
+						}
+					});
+
+				register(EditOp.ROTATE_CW, MenuAcceleratorPolicy.rotateCwStroke(),
+					"rotate the selected element clockwise",
+					new AbstractAction() {
+						/**
+						 * Perform the ROTATE_CW operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							rotateSelected(true);
+						}
+					});
+
+				register(EditOp.ROTATE_CCW, MenuAcceleratorPolicy.rotateCcwStroke(),
+					"rotate the selected element counter-clockwise",
+					new AbstractAction() {
+						/**
+						 * Perform the ROTATE_CCW operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							rotateSelected(false);
+						}
+					});
+
+				register(EditOp.FLIP, MenuAcceleratorPolicy.flipStroke(),
+					"flip the selected element",
+					new AbstractAction() {
+						/**
+						 * Perform the FLIP operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							flipSelected();
+						}
+					});
+
+				register(EditOp.WIRE_START, MenuAcceleratorPolicy.wireStartStroke(),
+					"create a new wire",
+					new AbstractAction() {
+						/**
+						 * Perform the WIRE_START operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							if (!enabled)
+								return;
+							// start the wire at the pointer if it is over the canvas,
+							// otherwise at the last tracked model position (e.g. the
+							// spot a right-click "Wire(s)" was invoked from)
+							// keyboard-first: start at the construction caret
+							// when the keyboard has positioned it (issue #75).
+							// Otherwise start at the pointer if it is over the
+							// canvas, else at the last tracked model position
+							if (caret != null) {
+								x = caret.x;
+								y = caret.y;
+							}
+							else {
+								Point p = getMousePosition();
+								if (p != null) {
+									p = viewport.toModel(p);
+									x = p.x;
+									y = p.y;
+								}
+							}
+							autoGrow(x,y);
+							setState(State.startwire);
+							WireStart start = startWireGesture(circuit,selected,x,y);
+							wireEnd = start.end();
+							wire = null;
+							net = wireEnd.getNet();
+							// keep the caret on the wire end so arrows extend it
+							caret = new Point(x,y);
+							// a cleared selection was under the cursor, so report the
+							// (likely) overlap the same way wire dragging does
+							if (start.hadSelection()) {
+								if (overlap()) {
+									info.setText(overlapMessage);
+									info.setForeground(Color.red);
+								}
+								else {
+									info.setText("");
+									info.setForeground(Color.black);
+								}
+							}
+							repaint();
+						}
+					});
+
+				register(EditOp.CLOSE, KeyStroke.getKeyStroke(KeyEvent.VK_E,menuMask),
+					"close this circuit",
+					new AbstractAction() {
+						/**
+						 * Perform the CLOSE operation.
+						 *
+						 * @param event The triggering action event.
+						 */
+						@Override
+						public void actionPerformed(ActionEvent event) {
+							close();
+						}
+					});
+
+			} // end of initEditActions method
 
 			/**
 			 * The current zoom scale (1.0 = 100%).
@@ -2555,6 +2622,20 @@ public abstract class SimpleEditor extends JPanel {
 						gg.draw(selRect);
 				}
 
+				// draw the keyboard construction caret (issue #75): a small
+				// crosshair marking where the next keyboard placement or
+				// wire endpoint lands. Shown only when no mouse gesture owns
+				// the screen (idle or a held selection), since while placing
+				// or drawing the element or wire end is itself the cursor
+				if (caret != null
+						&& (currentState == State.idle
+							|| currentState == State.selected)) {
+					gg.setColor(JLSInfo.selectionColor);
+					int r = JLSInfo.spacing/2;
+					gg.drawLine(caret.x-r,caret.y,caret.x+r,caret.y);
+					gg.drawLine(caret.x,caret.y-r,caret.x,caret.y+r);
+				}
+
 				// save circuit for undo on first draw (finishLoad must
 				// have been done by now); the paint-pass Graphics is NOT
 				// cached - Swing may dispose it after this call, so later
@@ -2567,8 +2648,12 @@ public abstract class SimpleEditor extends JPanel {
 			} // end of paintComponent method
 
 			/**
-			 * React to menu item selections.
-			 * 
+			 * React to the one popup item still wired through the
+			 * ActionListener: matchJump. Every other editing operation now
+			 * dispatches through its shared {@link Action} (#75), so only the
+			 * contextual "Create Matching End" item (JumpStart only) is
+			 * handled here.
+			 *
 			 * @param event The event object for actions.
 			 */
 			@Override
@@ -2576,231 +2661,6 @@ public abstract class SimpleEditor extends JPanel {
 
 				info.setForeground(Color.BLACK);
 				info.setText("");
-
-				// if probe option selected: attach or remove a probe.
-				// This branch used to swallow every handler below it - a
-				// merge-conflict brace error left them nested inside and
-				// unreachable, and dropped the doProbe() call (issue #37)
-				if (event.getSource() == probe) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					doProbe();
-					return;
-				}
-
-				// if watch option selected, ...
-				if (event.getSource() == watch) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// get the single item in the selected set
-					Element el = (Element)(selected.toArray()[0]);
-
-					// if its locked, don't change it
-					if (el.isUneditable())
-						return;
-
-					// do nothing if not watchable (the menu item only
-					// shows for watchable elements; this mirrors the
-					// ctrl-W path's guard)
-					if (!el.canWatch())
-						return;
-
-					// remove if watched, add if not (#167: through the
-					// op entry point)
-					submitOp(new ToggleWatched(el.getStableId()));
-
-					// clean up
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// if view option selected, ...
-				if (event.getSource() == modify) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-					doModify();
-				}
-
-				// if change timing, then it must have timing info
-				if (event.getSource() == timing) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					doTiming();
-				}
-
-				// if view, then it must be a watchable element
-				if (event.getSource() == view) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// get the single item in the selected set
-					Element el = (Element)(selected.toArray()[0]);
-
-					// ask element to display its current value
-					el.showCurrentValue(new Point(x,y));
-
-					// clean up
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// if cut option selected, copy selected elements to clipboard,
-				// then delete those elements
-				if (event.getSource() == cut) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// copy, then remove
-					copy();
-					remove();
-
-					// clean up
-					removeCoLinear();
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// if copy option, copy selected elements to clipboard
-				if (event.getSource() == copy) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					copy();
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// if delete option, delete selected elements
-				if (event.getSource() == delete) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// remove
-					remove();
-					removeCoLinear();
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// if lock, set all selected elements to uneditable
-				if (event.getSource() == lock) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// warn user first
-					boolean opt = TellUser.confirm(null,
-							"Making elements uneditable cannot be undone.  Are you sure you want to do this?",
-							"WARNING");
-
-					// if user still ok with it ...
-					if (opt) {
-
-						// make selected elements uneditable
-						for (Element el : selected) {
-							el.makeUneditable();
-						}
-					}
-
-					// finish up
-					clearSelected();
-					setState(State.idle);
-					repaint();
-					return;
-				}
-
-				// paste contents of clipboard
-				if (event.getSource() == paste) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					// paste
-					if (clipboard.getElements().size() == 0)
-						return;
-					if (paste(clipboard)) {
-						setState(State.placing);
-					}
-					repaint();
-					return;
-				}
-
-				// if select all option, select everything
-				if (event.getSource() == selAll) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					doSelectAll();
-				}
-
-				// if close, close this circuit (or subcircuit)
-				if (event.getSource() == close) {
-					close();
-				}
-
-				// if undo, restore prevous copy of circuit
-				if (event.getSource() == undo) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					undo();
-					repaint();
-				}
-
-				// if redo, restore future copy of circuit
-				if (event.getSource() == redo) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					redo();
-				}
-
-				if(event.getSource() == Crotate)
-				{
-					rotateSelected(true);
-				}
-
-				if(event.getSource() == CCrotate)
-				{
-					rotateSelected(false);
-				}
 
 				if(event.getSource() == matchJump) {
 					if(!enabled)
@@ -2819,30 +2679,6 @@ public abstract class SimpleEditor extends JPanel {
 
 					setState(State.chosen);
 					markChanged();
-					repaint();
-				}
-
-				if(event.getSource() == flip)
-				{
-					flipSelected();
-				}
-				// if connection, start drawing wires
-				else if (event.getSource() == connect) {
-
-					// do nothing if editor is disabled
-					if (!enabled)
-						return;
-
-					setState(State.startwire);
-					wireEnd = new WireEnd(circuit);
-					wireEnd.setXY(x,y);
-					wireEnd.init(circuit);
-					circuit.addElement(wireEnd);
-					selected.add(wireEnd);
-					wire = null;
-					net = new WireNet();
-					net.add(wireEnd);
-					wireEnd.setNet(net);
 					repaint();
 				}
 
@@ -3066,24 +2902,9 @@ public abstract class SimpleEditor extends JPanel {
 						return;
 					}
 
-					// don't do anything if there is overlap
-					if (overlap()) {
-						return;
-					}
-
-					// fix all positions
-					for (Element el : selected) {
-						el.fixPosition();
-					}
-
-					// connect everything connectable
-					connect();
-					markChanged();
-
-					// clear up
-					setState(State.idle);
-					clearSelected();
-					repaint();
+					// commit the placement (shared with the keyboard Enter
+					// path, issue #75)
+					commitPlacing();
 					return;
 				}
 
@@ -3117,77 +2938,407 @@ public abstract class SimpleEditor extends JPanel {
 						return;
 					}
 
-					// left button -> put in place and start next wire end
+					// left button -> commit this wire vertex (shared with the
+					// keyboard Enter path, issue #75)
 					else {
-
-						// make sure no overlaps
-						if (overlap()) {
-							return;
-						}
-
-						// set end of wire
-						wireEnd.fixPosition();
-
-						// connect if possible
-						connect();
-
-						// finish up if wire becomes attached to another wire or put
-						if (currentState == State.drawire && wireEnd.isAttached()) {
-
-							// if attached to imaginary put, unattach it
-							if (wireEnd.getPut().getElement() == null)
-								wireEnd.setPut(null);
-							wireEnd = null;
-							wire = null;
-							prev = null;
-							clearSelected();
-							setState(State.idle);
-							markChanged();
-							repaint();
-							return;
-						}
-
-						// if attached to imaginary put, unattach it
-						if (currentState == State.startwire && wireEnd.isAttached()) {
-							if (wireEnd.getPut().getElement() == null)
-								wireEnd.setPut(null);
-						}
-
-						// save current wire end
-						prev = wireEnd;
-						WireEnd save = wireEnd;
-
-						// create new wire end
-						wireEnd = new WireEnd(circuit);
-						wireEnd.setXY(x,y);
-						wireEnd.init(circuit);
-						circuit.addElement(wireEnd);
-
-						// create new wire
-						wire = new Wire(save,wireEnd);
-						save.addWire(wire);
-						wireEnd.addWire(wire);
-						circuit.addElement(wire);
-
-						// add wire end and wire to net
-						net.add(wireEnd);
-						wireEnd.setNet(net);
-						net.add(wire);
-						wire.setNet(net);
-
-						// set up new selected set
-						clearSelected();
-						selected.add(wireEnd);
-						selected.add(wire);
-
-						// finish up
-						setState(State.drawire);
-						repaint();
+						commitWireVertex();
 						return;
 					}
 
 				}
 			} // end of mousePressed method
+
+			/**
+			 * Commit the element(s) being placed at their current position
+			 * (issue #75). Extracted from the left-button branch of
+			 * {@link #mousePressed} so the mouse click and the keyboard
+			 * Enter key share one implementation. Does nothing and returns
+			 * false when the placement overlaps something, matching the
+			 * mouse behavior that ignores a drop onto an overlap.
+			 *
+			 * @return true if the placement was committed, false if an
+			 *         overlap blocked it.
+			 */
+			private boolean commitPlacing() {
+
+				// don't do anything if there is overlap
+				if (overlap()) {
+					return false;
+				}
+
+				// fix all positions
+				for (Element el : selected) {
+					el.fixPosition();
+				}
+
+				// connect everything connectable
+				connect();
+				markChanged();
+
+				// clear up
+				setState(State.idle);
+				clearSelected();
+				repaint();
+				return true;
+			} // end of commitPlacing method
+
+			/**
+			 * Commit the current wire vertex and continue or finish the
+			 * wire (issue #75). Extracted verbatim from the left-button
+			 * branch of {@link #mousePressed} so the mouse click and the
+			 * keyboard Enter key share one implementation: it fixes the
+			 * current wire end, connects it to any coincident port or wire,
+			 * finishes the wire if that end became attached, and otherwise
+			 * spawns the next segment. An overlap blocks the commit exactly
+			 * as it does for the mouse.
+			 */
+			private void commitWireVertex() {
+
+				// make sure no overlaps
+				if (overlap()) {
+					return;
+				}
+
+				// set end of wire
+				wireEnd.fixPosition();
+
+				// connect if possible
+				connect();
+
+				// finish up if wire becomes attached to another wire or put
+				if (currentState == State.drawire && wireEnd.isAttached()) {
+
+					// if attached to imaginary put, unattach it
+					if (wireEnd.getPut().getElement() == null)
+						wireEnd.setPut(null);
+					wireEnd = null;
+					wire = null;
+					prev = null;
+					clearSelected();
+					setState(State.idle);
+					markChanged();
+					repaint();
+					return;
+				}
+
+				// if attached to imaginary put, unattach it
+				if (currentState == State.startwire && wireEnd.isAttached()) {
+					if (wireEnd.getPut().getElement() == null)
+						wireEnd.setPut(null);
+				}
+
+				// save current wire end
+				prev = wireEnd;
+				WireEnd save = wireEnd;
+
+				// create new wire end
+				wireEnd = new WireEnd(circuit);
+				wireEnd.setXY(x,y);
+				wireEnd.init(circuit);
+				circuit.addElement(wireEnd);
+
+				// create new wire
+				wire = new Wire(save,wireEnd);
+				save.addWire(wire);
+				wireEnd.addWire(wire);
+				circuit.addElement(wire);
+
+				// add wire end and wire to net
+				net.add(wireEnd);
+				wireEnd.setNet(net);
+				net.add(wire);
+				wire.setNet(net);
+
+				// set up new selected set
+				clearSelected();
+				selected.add(wireEnd);
+				selected.add(wire);
+
+				// keep the caret on the moving end so arrows extend it
+				caret = new Point(x,y);
+
+				// finish up
+				setState(State.drawire);
+				repaint();
+			} // end of commitWireVertex method
+
+			/**
+			 * The default keyboard caret position (issue #75): the center
+			 * of the visible canvas, in model coordinates, snapped to the
+			 * grid. Used the first time an arrow key is pressed while idle,
+			 * so the caret appears where the user is looking rather than at
+			 * the origin.
+			 *
+			 * @return the snapped model-space center of the viewport.
+			 */
+			private Point defaultCaret() {
+
+				JViewport vp = pane.getViewport();
+				Point view = vp.getViewPosition();
+				Dimension ext = vp.getExtentSize();
+				Point c = viewport.toModel(new Point(
+						view.x + ext.width/2, view.y + ext.height/2));
+				int step = JLSInfo.spacing;
+				return new Point(
+						KeyboardConstructionPolicy.snap(c.x,step),
+						KeyboardConstructionPolicy.snap(c.y,step));
+			} // end of defaultCaret method
+
+			/**
+			 * An action that nudges in one grid direction (issue #75). All
+			 * four arrow keys map to one of these; the action just forwards
+			 * to {@link #keyboardNudge} so the per-state dispatch lives in
+			 * one place.
+			 *
+			 * @param n the direction this arrow key moves.
+			 * @return the action bound to that arrow key.
+			 */
+			private AbstractAction nudgeAction(final KeyboardConstructionPolicy.Nudge n) {
+
+				return new AbstractAction() {
+					/**
+					 * Nudge one grid step in this action's direction.
+					 *
+					 * @param event The triggering action event.
+					 */
+					@Override
+					public void actionPerformed(ActionEvent event) {
+						keyboardNudge(n);
+					}
+				};
+			} // end of nudgeAction method
+
+			/**
+			 * Handle an arrow-key nudge, dispatched by the current editor
+			 * state (issue #75): move the following element while placing,
+			 * extend the wire end while drawing, nudge the selection through
+			 * an undoable move op while a selection is held, and otherwise
+			 * move the free grid caret. States with an in-flight mouse
+			 * gesture (moving, selecting, option) ignore the keys.
+			 *
+			 * @param n the direction to nudge one grid step.
+			 */
+			private void keyboardNudge(KeyboardConstructionPolicy.Nudge n) {
+
+				if (!enabled)
+					return;
+				int step = JLSInfo.spacing;
+				int dx = n.dx(step);
+				int dy = n.dy(step);
+				switch (currentState) {
+					case chosen: {
+
+						// begin following from the element's own position so
+						// the caret and the element stay aligned
+						Element item = (Element)(selected.toArray()[0]);
+						x = item.getX();
+						y = item.getY();
+						setState(State.placing);
+						nudgeFollowing(dx,dy);
+						break;
+					}
+					case placing:
+					case startwire:
+					case drawire:
+						nudgeFollowing(dx,dy);
+						break;
+					case selected:
+						nudgeSelection(dx,dy);
+						break;
+					case idle:
+						moveCaret(dx,dy);
+						break;
+					default:
+						break;
+				}
+			} // end of keyboardNudge method
+
+			/**
+			 * The element the keyboard caret should track while following
+			 * (issue #75): the wire end while drawing a wire, otherwise the
+			 * first non-wire element of the selection. Its position is
+			 * grid-aligned, so anchoring the caret to it keeps the caret on
+			 * the grid.
+			 *
+			 * @return the representative element, or null if none.
+			 */
+			private Element followRepresentative() {
+
+				if (wireEnd != null && selected.contains(wireEnd)) {
+					return wireEnd;
+				}
+				for (Element el : selected) {
+					if (!(el instanceof Wire)) {
+						return el;
+					}
+				}
+				return null;
+			} // end of followRepresentative method
+
+			/**
+			 * Move the element(s) or wire end currently following the
+			 * keyboard by one grid step (issue #75), mirroring the placing
+			 * branch of {@link #mouseMoved}: shift the selection, re-index,
+			 * track the reference point and caret, and give the same overlap
+			 * feedback and dirty-region repaint.
+			 *
+			 * @param dx the x grid delta.
+			 * @param dy the y grid delta.
+			 */
+			private void nudgeFollowing(int dx, int dy) {
+
+				Rectangle dirty = union(selectionBounds(), touchedBounds());
+				for (Element el : selected) {
+					el.move(dx,dy);
+				}
+				circuit.reindexAfterMove(selected);
+
+				// anchor the logical cursor and the caret to a representative
+				// element's own grid-aligned position rather than accumulating
+				// deltas onto the (possibly off-grid) mouse coordinate, so the
+				// keyboard caret always lands on the grid and coincides with
+				// ports for wiring (issue #75)
+				Element rep = followRepresentative();
+				if (rep != null) {
+					x = rep.getX();
+					y = rep.getY();
+				}
+				else {
+					x += dx;
+					y += dy;
+				}
+				autoGrow(x,y);
+				caret = new Point(x,y);
+
+				// overlap feedback, as the mouse placing path shows
+				if (overlap()) {
+					info.setText(overlapMessage);
+					info.setForeground(Color.red);
+				}
+				else {
+					info.setText("");
+					info.setForeground(Color.black);
+				}
+				dirty = union(dirty, selectionBounds());
+				dirty = union(dirty, touchedBounds());
+				repaintDirty(dirty);
+			} // end of nudgeFollowing method
+
+			/**
+			 * Nudge the current selection by one grid step through the
+			 * undoable move op (issue #75), the keyboard counterpart of
+			 * dragging a selection. The op path (not a raw move) keeps the
+			 * nudge collaboration- and undo-correct. A move that would push
+			 * an element off the canvas is rejected by the op and leaves the
+			 * selection where it was.
+			 *
+			 * @param dx the x grid delta.
+			 * @param dy the y grid delta.
+			 */
+			private void nudgeSelection(int dx, int dy) {
+
+				if (selected.isEmpty())
+					return;
+				List<ElementId> ids = new ArrayList<ElementId>();
+				for (Element el : selected) {
+					ids.add(el.getStableId());
+				}
+				if (!submitOp(new MoveElements(ids,dx,dy)))
+					return;
+				if (selRect != null)
+					selRect.translate(dx,dy);
+				Element any = (Element)(selected.toArray()[0]);
+				caret = new Point(any.getX(),any.getY());
+				repaint();
+			} // end of nudgeSelection method
+
+			/**
+			 * Move the free grid caret by one grid step while idle
+			 * (issue #75), creating it at the viewport center the first
+			 * time. The caret never leaves the canvas (clamped at zero) and
+			 * seeds the drop point for the next placement and the endpoint
+			 * for keyboard wiring.
+			 *
+			 * @param dx the x grid delta.
+			 * @param dy the y grid delta.
+			 */
+			private void moveCaret(int dx, int dy) {
+
+				if (caret == null)
+					caret = defaultCaret();
+				int nx = Math.max(0, caret.x + dx);
+				int ny = Math.max(0, caret.y + dy);
+				caret = new Point(nx,ny);
+				x = nx;
+				y = ny;
+				autoGrow(nx,ny);
+				repaint();
+			} // end of moveCaret method
+
+			/**
+			 * Handle the keyboard commit (Enter) key, dispatched by the
+			 * current editor state (issue #75): place a following element,
+			 * commit a wire vertex, select the element under the caret, or
+			 * drop a held selection back to idle.
+			 */
+			private void keyboardCommit() {
+
+				if (!enabled)
+					return;
+				switch (currentState) {
+					case chosen:
+					case placing:
+						commitPlacing();
+						break;
+					case startwire:
+					case drawire:
+						commitWireVertex();
+						break;
+					case idle:
+						selectElementAtCaret();
+						break;
+					case selected:
+
+						// finish a keyboard nudge: drop back to idle
+						for (Element el : selected) {
+							el.setHighlight(false);
+						}
+						clearSelected();
+						selRect = null;
+						setState(State.idle);
+						repaint();
+						break;
+					default:
+						break;
+				}
+			} // end of keyboardCommit method
+
+			/**
+			 * Select the element under the keyboard caret, if any, and enter
+			 * the selected state so arrow keys nudge it (issue #75). The
+			 * keyboard counterpart of clicking an element. Attached wire ends
+			 * are skipped, exactly as the mouse selection path skips them.
+			 */
+			private void selectElementAtCaret() {
+
+				if (caret == null)
+					return;
+				for (Element el : circuit.elementsAt(caret.x,caret.y)) {
+					if (el.contains(caret.x,caret.y)) {
+						if (el instanceof WireEnd wend && wend.isAttached())
+							continue;
+						clearSelected();
+						selected.add(el);
+						el.setHighlight(true);
+						el.savePosition();
+						selRect = new Rectangle(el.getRect());
+						setState(State.selected);
+						repaint();
+						return;
+					}
+				}
+			} // end of selectElementAtCaret method
+
 
 			/**
 			 * Set up the options popup menu.
@@ -5295,6 +5446,15 @@ public abstract class SimpleEditor extends JPanel {
 								setState(State.placing);
 								repaint();
 							}
+
+							// keyboard operability (#75 H2): choosing an element
+							// from the tool bar/palette leaves focus on that
+							// button, so the canvas arrow/Enter placement keys
+							// (WHEN_FOCUSED on this EditWindow) would not reach it.
+							// Hand focus to the canvas now the element is chosen,
+							// so a keyboard-only user can nudge and Enter-place it
+							// without first tabbing off the palette.
+							requestFocusInWindow();
 						}
 					} // end of setup method
 

--- a/test/jls/HotkeysHelpAccuracyTest.java
+++ b/test/jls/HotkeysHelpAccuracyTest.java
@@ -1,0 +1,203 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.swing.KeyStroke;
+
+import org.junit.jupiter.api.Test;
+
+import jls.edit.EditOp;
+
+/**
+ * The in-app hot-key reference (resources/help/editor/editing/hotkeys.html)
+ * must agree with the accelerators the editor actually binds (issue #75
+ * verification hardening). The keys and the source of truth
+ * ({@link EditOp#accelerator(String)} via {@link MenuAcceleratorPolicy})
+ * live in two files, so a future rebinding could silently desync the help
+ * page from the running app - a keyboard user reading the docs would then be
+ * told the wrong key. {@link HelpTopicsTest} proves the page exists and
+ * resolves; this pins its <em>content</em>.
+ *
+ * <p>Each documented row whose function maps to an {@link EditOp} is checked
+ * against the accelerator that op carries on this (non-mac) platform: the
+ * key cell must name exactly the stroke the editor binds. A changed
+ * accelerator, or a deleted/renamed row, fails here until the help page is
+ * brought back in step - so the doc cannot drift from the code unnoticed.
+ * Escape (End Wire), the arrow keys, and Enter are documented behaviors with
+ * no {@code EditOp} accelerator and are intentionally not cross-checked
+ * here.</p>
+ */
+class HotkeysHelpAccuracyTest {
+
+	/**
+	 * Documented function label (as it appears in the hot-key table) mapped
+	 * to the {@link EditOp} whose accelerator the row must describe. The
+	 * order mirrors the table for readability; every entry is verified to
+	 * appear in the page (a removed row fails the completeness check).
+	 */
+	private static final Map<String, EditOp> DOCUMENTED_OPS = documentedOps();
+
+	private static Map<String, EditOp> documentedOps() {
+		Map<String, EditOp> m = new LinkedHashMap<>();
+		m.put("Select All", EditOp.SELECT_ALL);
+		m.put("Cut", EditOp.CUT);
+		m.put("Copy", EditOp.COPY);
+		m.put("Paste", EditOp.PASTE);
+		m.put("Delete", EditOp.DELETE);
+		m.put("Undo", EditOp.UNDO);
+		m.put("Redo", EditOp.REDO);
+		m.put("Start Wire", EditOp.WIRE_START);
+		m.put("View Element Contents", EditOp.VIEW_VALUE);
+		m.put("Rotate Element Clockwise", EditOp.ROTATE_CW);
+		m.put("Rotate Element Counter-Clockwise", EditOp.ROTATE_CCW);
+		m.put("Flip Element", EditOp.FLIP);
+		m.put("Watch/Unwatch Element", EditOp.WATCH);
+		m.put("Add/Remove Probe", EditOp.PROBE);
+		m.put("Modify Element", EditOp.MODIFY);
+		m.put("Change Timing", EditOp.TIMING);
+		m.put("Lock Element", EditOp.LOCK);
+		return m;
+	}
+
+	/** Matches a two-cell table row: {@code <td>function</td> ... <td>key</td>}. */
+	private static final Pattern ROW = Pattern.compile(
+			"(?is)<tr>\\s*<td>\\s*(.*?)\\s*</td>\\s*<td>\\s*(.*?)\\s*</td>\\s*</tr>");
+
+	/** Locate the bundled hot-key help page as an on-disk file. */
+	private static Path hotkeysPage() throws Exception {
+		URL url = Help.class.getResource("/help/editor/editing/hotkeys.html");
+		if (url == null) {
+			fail("hotkeys.html missing from the classpath");
+		}
+		return Path.of(url.toURI());
+	}
+
+	/** Parse the table into function-label -> key-cell (raw, HTML stripped). */
+	private static Map<String, String> keyCells() throws Exception {
+		String html = new String(Files.readAllBytes(hotkeysPage()),
+				StandardCharsets.ISO_8859_1);
+		Map<String, String> cells = new LinkedHashMap<>();
+		Matcher m = ROW.matcher(html);
+		while (m.find()) {
+			String function = stripTags(m.group(1)).trim();
+			String key = stripTags(m.group(2)).trim();
+			if (!function.isEmpty()) {
+				cells.put(function, key);
+			}
+		}
+		return cells;
+	}
+
+	private static String stripTags(String s) {
+		return s.replaceAll("(?s)<[^>]*>", "").replaceAll("\\s+", " ").trim();
+	}
+
+	/**
+	 * The canonical dotted rendering of a keystroke in the help page's
+	 * convention: modifier prefixes (ctrl-/shift-/alt-/meta-) then the
+	 * lower-cased key name, e.g. {@code ctrl-a}, {@code shift-r}, {@code w},
+	 * {@code delete}. Matches how hotkeys.html spells its Key column.
+	 */
+	private static String render(KeyStroke ks) {
+		StringBuilder sb = new StringBuilder();
+		// EditOp accelerators carry only the extended (…_DOWN_MASK) modifiers;
+		// the legacy InputEvent masks are deprecated and never set here.
+		int mods = ks.getModifiers();
+		if ((mods & InputEvent.CTRL_DOWN_MASK) != 0) {
+			sb.append("ctrl-");
+		}
+		if ((mods & InputEvent.SHIFT_DOWN_MASK) != 0) {
+			sb.append("shift-");
+		}
+		if ((mods & InputEvent.ALT_DOWN_MASK) != 0) {
+			sb.append("alt-");
+		}
+		if ((mods & InputEvent.META_DOWN_MASK) != 0) {
+			sb.append("meta-");
+		}
+		sb.append(KeyEvent.getKeyText(ks.getKeyCode())
+				.toLowerCase(java.util.Locale.ROOT));
+		return sb.toString();
+	}
+
+	/**
+	 * The primary key token of a help Key cell: the part before any
+	 * parenthetical note. The Redo cell reads
+	 * "ctrl-y (shift-cmd-z on macOS; cmd-y also works)"; its primary token
+	 * is "ctrl-y". Every other cell has no parenthetical, so this is a no-op
+	 * for them.
+	 */
+	private static String primaryToken(String keyCell) {
+		int paren = keyCell.indexOf('(');
+		String head = paren >= 0 ? keyCell.substring(0, paren) : keyCell;
+		return head.trim().toLowerCase(java.util.Locale.ROOT);
+	}
+
+	/**
+	 * Every documented editing-op row names exactly the accelerator the
+	 * editor binds for that op on this platform, so the help page cannot
+	 * drift from {@link EditOp#accelerator(String)}.
+	 *
+	 * @throws Exception if the page cannot be read.
+	 */
+	@Test
+	void documentedKeysMatchTheEditOpAccelerators() throws Exception {
+		// non-mac: the CI substrate, and the page's parenthetical already
+		// carries the mac variants separately (checked structurally below)
+		String os = "Linux";
+		Map<String, String> cells = keyCells();
+		List<String> problems = new ArrayList<>();
+		for (Map.Entry<String, EditOp> e : DOCUMENTED_OPS.entrySet()) {
+			String function = e.getKey();
+			EditOp op = e.getValue();
+			String cell = cells.get(function);
+			if (cell == null) {
+				problems.add("hotkeys.html no longer documents \"" + function
+						+ "\" (expected for " + op + ")");
+				continue;
+			}
+			String expected = render(op.accelerator(os));
+			String actual = primaryToken(cell);
+			if (!expected.equals(actual)) {
+				problems.add("\"" + function + "\": help says '" + actual
+						+ "' but " + op + " binds '" + expected + "'");
+			}
+		}
+		assertTrue(problems.isEmpty(),
+				"hotkeys.html has drifted from the editor's accelerators:\n  "
+						+ String.join("\n  ", problems));
+	}
+
+	/**
+	 * Sanity guard on the fixture: the page still parses into the rows this
+	 * test cross-checks, so a structural rewrite that broke the table cannot
+	 * make the accuracy check silently vacuous.
+	 *
+	 * @throws Exception if the page cannot be read.
+	 */
+	@Test
+	void theHotkeyTableStillParses() throws Exception {
+		Map<String, String> cells = keyCells();
+		assertTrue(cells.size() >= DOCUMENTED_OPS.size(),
+				"hotkeys.html parsed to only " + cells.size()
+						+ " rows; expected at least " + DOCUMENTED_OPS.size());
+		// the Escape / arrow / Enter behaviors are documented too
+		assertTrue(cells.containsKey("Move Caret / Following Element / Wire End "
+				+ "/ Selection"),
+				"the arrow-key row is missing from hotkeys.html");
+	}
+}

--- a/test/jls/MenuAcceleratorPolicyTest.java
+++ b/test/jls/MenuAcceleratorPolicyTest.java
@@ -179,18 +179,39 @@ class MenuAcceleratorPolicyTest {
 		}
 	}
 
+	/** Wire-start is plain W: issue #75 moved it off the Ctrl/Cmd+W chord
+	 *  it used to share with toggle-watch (the same stroke was shown on
+	 *  two popup items), so it is a plain key like rotate/flip and can
+	 *  never collide with the now-sole Ctrl/Cmd+W watch binding. */
+	@Test
+	void wireStartIsPlainW() {
+		assertEquals(KeyStroke.getKeyStroke(KeyEvent.VK_W, 0),
+				MenuAcceleratorPolicy.wireStartStroke());
+		for (String os : new String[] { "Mac OS X", "Linux",
+				"Windows 11" }) {
+			assertFalse(MenuAcceleratorPolicy.wireStartStroke().equals(
+					KeyStroke.getKeyStroke(KeyEvent.VK_W,
+							MenuAcceleratorPolicy.menuMask(os))),
+					"wire-start must never collide with Ctrl/Cmd+W watch on "
+							+ os);
+		}
+	}
+
 	// ---- menu mnemonics ----
 
 	/** Every top-level menu gets its own mnemonic; Alt+letter must be
-	 *  unambiguous across the menu bar. */
+	 *  unambiguous across the menu bar. Issue #75 added the Edit and
+	 *  Element menus, so all six must stay distinct. */
 	@Test
 	void menuMnemonicsAreDistinct() {
 		Set<Integer> mnemonics = new HashSet<>(List.of(
 				MenuAcceleratorPolicy.fileMenuMnemonic(),
+				MenuAcceleratorPolicy.editMenuMnemonic(),
+				MenuAcceleratorPolicy.elementMenuMnemonic(),
 				MenuAcceleratorPolicy.simulatorMenuMnemonic(),
 				MenuAcceleratorPolicy.globalMenuMnemonic(),
 				MenuAcceleratorPolicy.helpMenuMnemonic()));
-		assertEquals(4, mnemonics.size(),
+		assertEquals(6, mnemonics.size(),
 				"top-level menu mnemonics must be distinct");
 	}
 

--- a/test/jls/edit/CtrlWGestureTest.java
+++ b/test/jls/edit/CtrlWGestureTest.java
@@ -13,21 +13,21 @@ import org.junit.jupiter.api.Test;
 
 import jls.Circuit;
 import jls.JLSInfo;
-import jls.edit.SimpleEditor.CtrlW;
-import jls.edit.SimpleEditor.State;
 import jls.edit.SimpleEditor.WireStart;
 import jls.elem.Constant;
 import jls.elem.Element;
 import jls.elem.WireEnd;
 
 /**
- * Regression tests for issue #126: an idle-state ctrl-W starts a wire
- * regardless of the current (hover) selection, clearing that selection
- * as part of the gesture.
+ * Regression tests for the wire-start gesture (issue #126, revised by
+ * issue #75). Starting a wire clears any current (hover) selection as
+ * part of the gesture. Issue #75 moved wire-start off the Ctrl/Cmd+W it
+ * used to share with toggle-watch onto the dedicated plain-W binding, so
+ * these tests now pin only the Swing-free model half that both the
+ * wire-start key and the keyboard construction path drive.
  *
- * <p>The gesture is pinned at two seams SimpleEditor exposes for exactly
- * this purpose: the pure dispatch function
- * {@link SimpleEditor#ctrlWGesture} and the Swing-free model half
+ * <p>The gesture is pinned at the seam SimpleEditor exposes for exactly
+ * this purpose: the Swing-free model half
  * {@link SimpleEditor#startWireGesture}. This is the compensating
  * control for the key-press-to-pixels path (the ToolkitPolicyTest
  * pattern): the editor itself cannot be constructed under the suite's
@@ -64,49 +64,6 @@ class CtrlWGestureTest {
 		constant.setHighlight(true);
 		selected.add(constant);
 		return constant;
-	}
-
-	// ------------------------------------------------------------------
-	// dispatch: the #126 gate itself
-	// ------------------------------------------------------------------
-
-	/** P1's dispatch half: with an element hover-selected, idle ctrl-W
-	 * must start a wire. Pre-#126 the empty-selection gate sent this to
-	 * the watch toggle instead. */
-	@Test
-	void idleStartsWireDespiteSingleSelection() {
-		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 1));
-	}
-
-	/** Pre-#126, an idle multi-selection (overlapping hover) fell through
-	 * to nothing at all. */
-	@Test
-	void idleStartsWireDespiteMultiSelection() {
-		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 3));
-	}
-
-	/** The original gesture — idle, nothing selected — is unchanged. */
-	@Test
-	void idleStartsWireWithEmptySelection() {
-		assertEquals(CtrlW.START_WIRE, SimpleEditor.ctrlWGesture(State.idle, 0));
-	}
-
-	/** P2's sibling-gesture pin: the watch toggle is still reachable with
-	 * one element selected outside idle (e.g. after a select-rectangle,
-	 * State.selected). */
-	@Test
-	void watchToggleStillReachableFromSelectedState() {
-		assertEquals(CtrlW.TOGGLE_WATCH,
-				SimpleEditor.ctrlWGesture(State.selected, 1));
-	}
-
-	/** Everything else stays a no-op, exactly as before. */
-	@Test
-	void otherStatesDoNothing() {
-		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.selected, 0));
-		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.selected, 2));
-		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.drawire, 0));
-		assertEquals(CtrlW.NONE, SimpleEditor.ctrlWGesture(State.moving, 4));
 	}
 
 	// ------------------------------------------------------------------

--- a/test/jls/edit/DeleteKeyPolicyTest.java
+++ b/test/jls/edit/DeleteKeyPolicyTest.java
@@ -100,13 +100,16 @@ class DeleteKeyPolicyTest {
 
 	/**
 	 * SimpleEditor must consume the policy rather than hard-coding
-	 * VK_DELETE: the delete menu item's accelerator and the canvas
+	 * VK_DELETE: the delete operation's accelerator and the canvas
 	 * input-map bindings both go through DeleteKeyPolicy, and no
 	 * literal VK_DELETE keystroke construction remains. This is the
 	 * regression pin for the wiring the headless JVM cannot exercise
 	 * (constructing the editor throws HeadlessException); it fails on
 	 * pre-#127 SimpleEditor, which bound
 	 * {@code KeyStroke.getKeyStroke(KeyEvent.VK_DELETE,0)} directly.
+	 * Issue #75 folded the delete menu item, popup item, and key binding
+	 * into one shared {@link javax.swing.Action}, so the menu accelerator
+	 * now comes from the policy when that Action is built.
 	 */
 	@Test
 	void simpleEditorDelegatesDeleteBindingsToThePolicy()
@@ -118,9 +121,8 @@ class DeleteKeyPolicyTest {
 						+ source);
 		String text = Files.readString(source, StandardCharsets.UTF_8);
 
-		assertTrue(text.contains(
-				"delete.setAccelerator(DeleteKeyPolicy.menuAccelerator("),
-				"the delete menu accelerator must come from the policy");
+		assertTrue(text.contains("DeleteKeyPolicy.menuAccelerator("),
+				"the delete accelerator must come from the policy");
 		assertTrue(text.contains("DeleteKeyPolicy.canvasBindings()"),
 				"the canvas delete bindings must come from the policy");
 		assertFalse(text.contains("VK_DELETE"),

--- a/test/jls/edit/KeyboardConstructionPolicyTest.java
+++ b/test/jls/edit/KeyboardConstructionPolicyTest.java
@@ -1,0 +1,116 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.event.KeyEvent;
+import java.util.Optional;
+
+import javax.swing.KeyStroke;
+
+import org.junit.jupiter.api.Test;
+
+import jls.JLSInfo;
+import jls.edit.KeyboardConstructionPolicy.Nudge;
+
+/**
+ * Headless unit tests for the pure keyboard-construction policy
+ * (issue #75, H2). The arrow-to-direction mapping, the grid-step
+ * arithmetic, the commit keystroke, and the grid snap are all pure
+ * functions with no display dependency, so they are pinned here rather
+ * than in the display suite. Each assertion would fail if a sign or a
+ * key mapping were flipped, so the policy cannot silently drift from the
+ * editor that relies on it.
+ */
+class KeyboardConstructionPolicyTest {
+
+	/** Each arrow key maps to its own direction; nothing else does. */
+	@Test
+	void arrowKeysMapToDirections() {
+
+		assertEquals(Optional.of(Nudge.UP),
+				Nudge.fromKey(KeyEvent.VK_UP));
+		assertEquals(Optional.of(Nudge.DOWN),
+				Nudge.fromKey(KeyEvent.VK_DOWN));
+		assertEquals(Optional.of(Nudge.LEFT),
+				Nudge.fromKey(KeyEvent.VK_LEFT));
+		assertEquals(Optional.of(Nudge.RIGHT),
+				Nudge.fromKey(KeyEvent.VK_RIGHT));
+	} // end of arrowKeysMapToDirections method
+
+	/** A non-arrow key yields no direction, so it can fall through. */
+	@Test
+	void nonArrowKeyMapsToNothing() {
+
+		assertTrue(Nudge.fromKey(KeyEvent.VK_ENTER).isEmpty());
+		assertTrue(Nudge.fromKey(KeyEvent.VK_W).isEmpty());
+		assertTrue(Nudge.fromKey(KeyEvent.VK_A).isEmpty());
+	} // end of nonArrowKeyMapsToNothing method
+
+	/**
+	 * The deltas carry the right sign and magnitude: up/down move only in
+	 * y, left/right only in x, each by exactly one step.
+	 */
+	@Test
+	void deltasHaveCorrectSigns() {
+
+		int step = 12;
+
+		assertEquals(0, Nudge.UP.dx(step));
+		assertEquals(-step, Nudge.UP.dy(step));
+
+		assertEquals(0, Nudge.DOWN.dx(step));
+		assertEquals(step, Nudge.DOWN.dy(step));
+
+		assertEquals(-step, Nudge.LEFT.dx(step));
+		assertEquals(0, Nudge.LEFT.dy(step));
+
+		assertEquals(step, Nudge.RIGHT.dx(step));
+		assertEquals(0, Nudge.RIGHT.dy(step));
+	} // end of deltasHaveCorrectSigns method
+
+	/** UP and DOWN, LEFT and RIGHT, are exact opposites. */
+	@Test
+	void oppositeDirectionsCancel() {
+
+		int step = JLSInfo.spacing;
+
+		assertEquals(0, Nudge.UP.dy(step) + Nudge.DOWN.dy(step));
+		assertEquals(0, Nudge.LEFT.dx(step) + Nudge.RIGHT.dx(step));
+	} // end of oppositeDirectionsCancel method
+
+	/** The commit keystroke is plain Enter, no modifier. */
+	@Test
+	void commitStrokeIsPlainEnter() {
+
+		assertEquals(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+				KeyboardConstructionPolicy.commitStroke());
+	} // end of commitStrokeIsPlainEnter method
+
+	/**
+	 * The snap rounds a coordinate down to the grid, including negative
+	 * and already-on-grid values, so a wire started at the caret lands on
+	 * the grid ports elements expose.
+	 */
+	@Test
+	void snapRoundsDownToGrid() {
+
+		int step = JLSInfo.spacing;
+
+		assertEquals(0, KeyboardConstructionPolicy.snap(0, step));
+		assertEquals(0, KeyboardConstructionPolicy.snap(step - 1, step));
+		assertEquals(step, KeyboardConstructionPolicy.snap(step, step));
+		assertEquals(step, KeyboardConstructionPolicy.snap(step + 1, step));
+		assertEquals(2 * step,
+				KeyboardConstructionPolicy.snap(2 * step + step / 2, step));
+		assertEquals(-step, KeyboardConstructionPolicy.snap(-1, step));
+
+		// the snapped value is always a grid multiple at or below input
+		int snapped = KeyboardConstructionPolicy.snap(5 * step + 7, step);
+		assertEquals(0, snapped % step);
+		assertTrue(snapped <= 5 * step + 7);
+		assertFalse(snapped + step <= 5 * step + 7);
+	} // end of snapRoundsDownToGrid method
+
+} // end of KeyboardConstructionPolicyTest class

--- a/test/jls/ui/EditActionMatrixTest.java
+++ b/test/jls/ui/EditActionMatrixTest.java
@@ -1,0 +1,262 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.Field;
+import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.Action;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.DefaultExceptionHandler;
+import jls.JLSInfo;
+import jls.JLSStart;
+import jls.edit.EditOp;
+import jls.edit.Editor;
+import jls.elem.AndGate;
+import jls.elem.Element;
+import jls.sim.Simulator;
+
+/**
+ * Shared-Action matrix (issue #75, H1). Proves the three editing
+ * surfaces - the canvas key bindings, the right-click popup menus, and
+ * the main window's Edit and Element menus - all dispatch through the
+ * <em>same</em> {@link Action} object for each {@link EditOp}, rather
+ * than three separate copies of the operation. The "action x path"
+ * coverage is an object-identity check per surface: a regression that
+ * re-split any surface into its own action would break the identity
+ * assertion.
+ *
+ * <p>Each canvas binding is additionally pinned by resolving its
+ * keystroke through the canvas maps: removing the InputMap stroke or the
+ * ActionMap entry makes {@link EditorGestureSupport#canvasActionForStroke}
+ * return null, failing the identity assertion. One binding (Delete) is
+ * also driven end to end by a synthetic keystroke to confirm the wiring
+ * actually mutates the model.</p>
+ *
+ * <p>Tagged {@code display}: boots real Swing components, so it runs
+ * under the #162 substrate and self-skips headless.</p>
+ */
+@Tag("display")
+@Timeout(90)
+class EditActionMatrixTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/** A circuit with a single AND gate near the top-left of the canvas. */
+	private static Circuit oneGate() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		Circuit circuit = new Circuit("matrix");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static int centerX(Element el) {
+		return el.getX() + el.getRect().width / 2;
+	}
+
+	private static int centerY(Element el) {
+		return el.getY() + el.getRect().height / 2;
+	}
+
+	/**
+	 * Every {@link EditOp} exposes one stable shared Action, and the
+	 * canvas binding and the popup item for an operation are that same
+	 * object - not copies.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void canvasBindingsAndPopupsShareTheEditorActions() throws Exception {
+		Circuit circuit = oneGate();
+		String os = System.getProperty("os.name");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			Editor ed = ui.editor;
+
+			// one stable shared instance per operation
+			for (EditOp op : EditOp.values()) {
+				Action a = ed.editAction(op);
+				assertNotNull(a, "no shared Action for " + op);
+				assertSame(a, ed.editAction(op),
+						"editAction must return a shared instance for " + op);
+			}
+
+			// each canvas binding resolves to that same shared object;
+			// this fails if either the InputMap stroke or the ActionMap
+			// entry were removed
+			for (EditOp op : EditOp.values()) {
+				KeyStroke ks = op.accelerator(os);
+				assertSame(ed.editAction(op), ui.canvasActionForStroke(ks),
+						"canvas binding " + ks + " must be the shared Action "
+								+ "for " + op);
+			}
+
+			// the popup items reuse the shared Actions too
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			ui.rightPress(centerX(gate), centerY(gate));
+			assertSame(ed.editAction(EditOp.CUT),
+					ui.popupItem("Cut").getAction(),
+					"popup Cut must be the shared CUT Action");
+			assertSame(ed.editAction(EditOp.ROTATE_CW),
+					ui.popupItem("Rotate Clockwise").getAction(),
+					"popup Rotate Clockwise must be the shared ROTATE_CW Action");
+			assertSame(ed.editAction(EditOp.FLIP),
+					ui.popupItem("Flip").getAction(),
+					"popup Flip must be the shared FLIP Action");
+		}
+	}
+
+	/**
+	 * Driving the plain-Delete keystroke into the canvas removes the
+	 * selection through the shared DELETE Action - the binding is wired
+	 * end to end, not merely present in the map.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void deleteKeystrokeRemovesTheSelectionThroughTheSharedAction()
+			throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			// rubber-band select the gate, then press Delete on the canvas
+			int x0 = gate.getX() - 40, y0 = gate.getY() - 40;
+			int x1 = gate.getX() + gate.getRect().width + 40;
+			int y1 = gate.getY() + gate.getRect().height + 40;
+			ui.leftDrag(x0, y0, x1, y1);
+			ui.waitFor(gate::isHighlighted, "gate selected");
+
+			ui.pressKey(KeyEvent.VK_DELETE);
+			ui.waitFor(() -> ui.currentCircuit().getElements().stream()
+					.noneMatch(el -> el instanceof AndGate),
+					"gate deleted by the Delete key binding");
+		}
+	}
+
+	/**
+	 * The main window's Edit and Element menu items dispatch through the
+	 * selected editor's shared Actions after a tab-change retarget - the
+	 * third surface reuses the same objects as the popups and bindings.
+	 *
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	@Test
+	void menuBarItemsShareTheSelectedEditorActions() throws Exception {
+		java.awt.Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		try {
+			JLSStart jls = bootMainWindow();
+			AtomicReference<Editor> edRef = new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> {
+				jls.setupEditor(new Circuit("menubar"), "menubar");
+				edRef.set(jls.getVisibleEditor());
+			});
+			Editor ed = edRef.get();
+			assertNotNull(ed, "setupEditor must make an editor visible");
+
+			AtomicReference<Boolean> ok = new AtomicReference<>(Boolean.TRUE);
+			AtomicReference<String> why = new AtomicReference<>("");
+			SwingUtilities.invokeAndWait(() -> {
+				JMenuBar bar = jls.getJMenuBar();
+				for (EditOp op : new EditOp[] { EditOp.UNDO, EditOp.CUT,
+						EditOp.COPY, EditOp.PASTE, EditOp.DELETE,
+						EditOp.SELECT_ALL, EditOp.ROTATE_CW, EditOp.ROTATE_CCW,
+						EditOp.FLIP, EditOp.WATCH, EditOp.PROBE, EditOp.MODIFY,
+						EditOp.TIMING }) {
+					JMenuItem item = menuItemFor(bar, op.label());
+					if (item == null) {
+						ok.set(Boolean.FALSE);
+						why.set("no menu item labelled " + op.label());
+						return;
+					}
+					if (item.getAction() != ed.editAction(op)) {
+						ok.set(Boolean.FALSE);
+						why.set("menu item " + op.label()
+								+ " is not the shared Action");
+						return;
+					}
+				}
+			});
+			assertTrue(ok.get().booleanValue(), why.get());
+		}
+		finally {
+			SwingUtilities.invokeAndWait(() -> {
+				for (Window w : Window.getWindows()) {
+					w.dispose();
+				}
+			});
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+		}
+	}
+
+	/**
+	 * Find the first menu-bar item (in any top-level menu) with the given
+	 * label. Call on the EDT.
+	 *
+	 * @param bar the menu bar to search.
+	 * @param label the item label to match.
+	 * @return the item, or null if none matches.
+	 */
+	private static JMenuItem menuItemFor(JMenuBar bar, String label) {
+		for (int i = 0; i < bar.getMenuCount(); i++) {
+			JMenu menu = bar.getMenu(i);
+			if (menu == null) {
+				continue;
+			}
+			for (int j = 0; j < menu.getItemCount(); j++) {
+				JMenuItem item = menu.getItem(j);
+				if (item != null && label.equals(item.getText())) {
+					return item;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Construct the real JLS main window on the EDT, installing the
+	 * static exception handler the constructor needs (mirrors
+	 * {@link MenuBarSpecTest}'s harness).
+	 *
+	 * @return the constructed main window.
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	private static JLSStart bootMainWindow() throws Exception {
+		Field handler = JLSStart.class.getDeclaredField("exHandler");
+		handler.setAccessible(true);
+		if (handler.get(null) == null) {
+			handler.set(null, new DefaultExceptionHandler());
+		}
+		AtomicReference<JLSStart> ref = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> ref.set(new JLSStart()));
+		return ref.get();
+	}
+}

--- a/test/jls/ui/EditorGestureSupport.java
+++ b/test/jls/ui/EditorGestureSupport.java
@@ -110,6 +110,18 @@ final class EditorGestureSupport implements AutoCloseable {
 	}
 
 	/**
+	 * Whether the edit canvas currently owns the keyboard focus. Used to
+	 * pin the #75 H2 fix: choosing an element from the tool bar must hand
+	 * focus to the canvas so the arrow/Enter placement keys reach it
+	 * without the user first tabbing off the palette.
+	 *
+	 * @return true when the canvas is the focus owner.
+	 */
+	boolean canvasIsFocusOwner() {
+		return canvas.isFocusOwner();
+	}
+
+	/**
 	 * The editor's current circuit. Undo/redo rebuild the circuit
 	 * through the load path and swap in a fresh instance
 	 * ({@code finishDo}: {@code circuit = newCopy}), so the reference
@@ -266,6 +278,106 @@ final class EditorGestureSupport implements AutoCloseable {
 	void clickPopupItem(String text) throws Exception {
 		JMenuItem item = waitForMenuItem(text);
 		SwingUtilities.invokeAndWait(item::doClick);
+	}
+
+	/**
+	 * The currently visible popup-menu item with the given text (issue
+	 * #75). Used to prove the popup item and the canvas key binding
+	 * dispatch through the same shared {@link javax.swing.Action}.
+	 *
+	 * @param text the item's label.
+	 * @return the menu item.
+	 */
+	JMenuItem popupItem(String text) {
+		return waitForMenuItem(text);
+	}
+
+	/**
+	 * The action registered in the canvas' ActionMap under the given key
+	 * (issue #75), read on the EDT. The shared editing Actions are stored
+	 * here by the canvas key bindings, so this lets a test assert the
+	 * binding points at {@code editor.editAction(op)} rather than a
+	 * separate copy.
+	 *
+	 * @param key the ActionMap key (e.g. "do cut").
+	 * @return the bound action, or null if none.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	javax.swing.Action canvasAction(String key) throws Exception {
+		AtomicReference<javax.swing.Action> a = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> {
+			if (canvas instanceof javax.swing.JComponent jc) {
+				a.set(jc.getActionMap().get(key));
+			}
+		});
+		return a.get();
+	}
+
+	/**
+	 * The action a keystroke resolves to through the canvas' WHEN_FOCUSED
+	 * maps (issue #75): {@code actionMap.get(inputMap.get(stroke))}, read
+	 * on the EDT. Returns null if either map lacks the entry, so a test
+	 * can pin a binding end to end - removing the InputMap stroke or the
+	 * ActionMap entry makes this null, failing an identity assertion.
+	 *
+	 * @param stroke the keystroke to resolve.
+	 * @return the bound action, or null if the stroke is unbound.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	javax.swing.Action canvasActionForStroke(javax.swing.KeyStroke stroke)
+			throws Exception {
+		AtomicReference<javax.swing.Action> a = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> {
+			if (canvas instanceof javax.swing.JComponent jc) {
+				Object name = jc.getInputMap().get(stroke);
+				if (name != null) {
+					a.set(jc.getActionMap().get(name));
+				}
+			}
+		});
+		return a.get();
+	}
+
+	/**
+	 * Dispatch a KEY_PRESSED to the canvas on the EDT (issue #75),
+	 * exercising the same WHEN_FOCUSED InputMap the user's keystroke
+	 * would. Mirrors the synthetic-mouse idiom: no {@link java.awt.Robot},
+	 * so it stays deterministic under Xvfb.
+	 *
+	 * @param keyCode the {@link java.awt.event.KeyEvent} VK_ code.
+	 * @param modifiers the extended modifier mask (0 for none).
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	void pressKey(int keyCode, int modifiers) throws Exception {
+		java.awt.event.KeyEvent e = new java.awt.event.KeyEvent(canvas,
+				java.awt.event.KeyEvent.KEY_PRESSED, when++, modifiers,
+				keyCode, java.awt.event.KeyEvent.CHAR_UNDEFINED);
+		SwingUtilities.invokeAndWait(() -> canvas.dispatchEvent(e));
+	}
+
+	/**
+	 * Dispatch an unmodified KEY_PRESSED to the canvas on the EDT.
+	 *
+	 * @param keyCode the {@link java.awt.event.KeyEvent} VK_ code.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	void pressKey(int keyCode) throws Exception {
+		pressKey(keyCode, 0);
+	}
+
+	/**
+	 * The editor's keyboard construction caret (issue #75), read on the
+	 * EDT, or null if the keyboard has not been used to point yet. Lets a
+	 * keyboard-only construction test see where the next placement or wire
+	 * endpoint will land between key presses.
+	 *
+	 * @return a copy of the caret point, or null.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	java.awt.Point keyboardCaret() throws Exception {
+		AtomicReference<java.awt.Point> p = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> p.set(editor.keyboardCaret()));
+		return p.get();
 	}
 
 	// ------------------------------------------------------------------

--- a/test/jls/ui/EditorGestureSupport.java
+++ b/test/jls/ui/EditorGestureSupport.java
@@ -2,6 +2,7 @@ package jls.ui;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.KeyboardFocusManager;
 import java.awt.Window;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
@@ -293,6 +294,32 @@ final class EditorGestureSupport implements AutoCloseable {
 	}
 
 	/**
+	 * Whether a showing popup menu currently offers an item with the given
+	 * text - a single, non-blocking probe (unlike {@link #popupItem}, which
+	 * polls to a long bound and fails on timeout). Lets a test retry the
+	 * right-press that raises the popup when the first press did not
+	 * materialize it (a popup-show timing flake under the WM-less #162 Xvfb).
+	 *
+	 * @param text the item's label.
+	 * @return true if the item is showing in a visible popup right now.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	boolean isPopupItemShowing(String text) throws Exception {
+		AtomicReference<JMenuItem> found = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				JMenuItem item = findMenuItem(w, text);
+				if (item != null) {
+					found.set(item);
+					return;
+				}
+			}
+			found.set(findMenuItem(frame, text));
+		});
+		return found.get() != null;
+	}
+
+	/**
 	 * The action registered in the canvas' ActionMap under the given key
 	 * (issue #75), read on the EDT. The shared editing Actions are stored
 	 * here by the canvas key bindings, so this lets a test assert the
@@ -363,6 +390,120 @@ final class EditorGestureSupport implements AutoCloseable {
 	 */
 	void pressKey(int keyCode) throws Exception {
 		pressKey(keyCode, 0);
+	}
+
+	// ------------------------------------------------------------------
+	// focus-faithful key driver (issue #75 verification hardening)
+	// ------------------------------------------------------------------
+
+	/**
+	 * The component that currently owns the keyboard focus, read on the EDT
+	 * from the real {@link KeyboardFocusManager} - the same authority the
+	 * AWT event pipeline consults when routing a user's keystroke. Unlike
+	 * the hardcoded {@code canvas} the synthetic {@link #pressKey}
+	 * dispatches to, this reflects where a real key would actually land, so
+	 * a test built on it goes red if a focus regression strands focus off
+	 * the canvas (the exact class of the #75 H2 tool-bar focus bug).
+	 *
+	 * @return the live focus owner, or null if no component in this JVM owns
+	 *         the focus.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	Component focusOwner() throws Exception {
+		AtomicReference<Component> owner = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> owner.set(KeyboardFocusManager
+				.getCurrentKeyboardFocusManager().getFocusOwner()));
+		return owner.get();
+	}
+
+	/**
+	 * Dispatch a KEY_PRESSED to the LIVE keyboard-focus owner on the EDT
+	 * (issue #75 verification hardening), instead of to the hardcoded canvas
+	 * as {@link #pressKey} does. This is the focus-faithful key path: it
+	 * reads {@code KeyboardFocusManager.getFocusOwner()} at dispatch time,
+	 * so the keystroke reaches whatever component a real user's key would -
+	 * the canvas' WHEN_FOCUSED bindings fire only when the canvas genuinely
+	 * holds the focus. A regression that leaves focus stranded on the
+	 * tool-bar button (the exact #75 H2 bug) therefore turns a test driven
+	 * through here red, where {@link #pressKey} stays green by force-feeding
+	 * the canvas regardless of focus.
+	 *
+	 * <p>Focus-owner dispatch, not {@link java.awt.Robot#keyPress}: under
+	 * the #162 window-manager-less Xvfb a single {@code Robot} key press
+	 * auto-repeats into many KEY_PRESSED events (empirically ~30 for one
+	 * press/release), which makes exact "moved one grid step" assertions
+	 * flaky; dispatching to the focus owner delivers exactly one event while
+	 * still honoring the real focus subsystem - it routes to the button and
+	 * not the canvas when focus is on the button, and vice versa (both
+	 * verified empirically). The faithfulness we need is "which component
+	 * receives the key", and that is the focus owner, read live here.</p>
+	 *
+	 * @param keyCode the {@link java.awt.event.KeyEvent} VK_ code.
+	 * @param modifiers the extended modifier mask (0 for none).
+	 * @throws Exception if there is no focus owner, or the EDT dispatch
+	 *         fails.
+	 */
+	void pressKeyThroughFocusOwner(int keyCode, int modifiers)
+			throws Exception {
+		Component owner = focusOwner();
+		if (owner == null) {
+			throw new AssertionError("no focus owner to route the key to; a "
+					+ "real keystroke would have nowhere to go either");
+		}
+		java.awt.event.KeyEvent e = new java.awt.event.KeyEvent(owner,
+				java.awt.event.KeyEvent.KEY_PRESSED, when++, modifiers,
+				keyCode, java.awt.event.KeyEvent.CHAR_UNDEFINED);
+		SwingUtilities.invokeAndWait(() -> owner.dispatchEvent(e));
+	}
+
+	/**
+	 * Dispatch an unmodified KEY_PRESSED to the live keyboard-focus owner on
+	 * the EDT (issue #75 verification hardening).
+	 *
+	 * @param keyCode the {@link java.awt.event.KeyEvent} VK_ code.
+	 * @throws Exception if there is no focus owner, or the EDT dispatch
+	 *         fails.
+	 */
+	void pressKeyThroughFocusOwner(int keyCode) throws Exception {
+		pressKeyThroughFocusOwner(keyCode, 0);
+	}
+
+	/**
+	 * Move the keyboard focus to the given component and wait for the real
+	 * {@link KeyboardFocusManager} to confirm the handoff (issue #75
+	 * verification hardening). Used to set up a non-canvas focus owner so a
+	 * test can prove {@link #pressKeyThroughFocusOwner} honors it - a
+	 * deliberate stand-in for a focus-stranding regression.
+	 *
+	 * @param target the component to focus.
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	void giveFocusTo(Component target) throws Exception {
+		SwingUtilities.invokeAndWait(target::requestFocusInWindow);
+		waitFor(() -> {
+			try {
+				return focusOwner() == target;
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}, "focus to move to " + target.getClass().getSimpleName());
+	}
+
+	/**
+	 * Move the keyboard focus to the edit canvas and wait for the real
+	 * {@link KeyboardFocusManager} to confirm the handoff (issue #75
+	 * verification hardening). Used to stage the canvas as the genuine focus
+	 * owner before a keyboard-editing test routes keys through
+	 * {@link #pressKeyThroughFocusOwner}: once the canvas truly owns focus,
+	 * routing a key through the live focus owner delivers it to the canvas
+	 * exactly as a real user's keystroke would, so the InputMap/ActionMap
+	 * wiring is exercised through the real event path rather than force-fed to
+	 * a hardcoded reference.
+	 *
+	 * @throws Exception if the EDT dispatch fails.
+	 */
+	void focusCanvas() throws Exception {
+		giveFocusTo(canvas);
 	}
 
 	/**

--- a/test/jls/ui/EditorKeyboardConstructionTest.java
+++ b/test/jls/ui/EditorKeyboardConstructionTest.java
@@ -40,9 +40,12 @@ import jls.elem.Put;
  * H2 acceptance test (issue #75): build the tutorial's first two-gate
  * circuit -- an OR gate and a NOT gate wired output-to-input, the A + ~B
  * skeleton of tutorial 1 -- with no pointing device. Every construction
- * step after the palette choice is driven by synthetic key events
- * dispatched to the canvas: arrow keys move the following element, the
- * grid caret, and the selection; Enter places elements, activates the
+ * step after the palette choice is driven through the REAL focus subsystem:
+ * each key is dispatched to the live {@link java.awt.KeyboardFocusManager}
+ * focus owner ({@link EditorGestureSupport#pressKeyThroughFocusOwner}), not
+ * to a hardcoded canvas reference, so the keystroke reaches whatever
+ * component a real user's key would. Arrow keys move the following element,
+ * the grid caret, and the selection; Enter places elements, activates the
  * caret, and commits; the port-to-port connection is made the way the
  * tutorial itself makes it, by moving the NOT gate's output onto an OR
  * input so placement wires them. No {@link java.awt.Robot} and no mouse
@@ -53,8 +56,13 @@ import jls.elem.Put;
  * {@code doClick}, a keyboard-equivalent activation, not a pointer
  * gesture. The gate's creation dialog is real and modal, so a background
  * thread accepts it with its defaults (mirroring {@link PaletteDropTest}).
- * Everything that positions, places, nudges, and connects the gates is
- * keyboard-only.</p>
+ * Because the keys route through the live focus owner, the test re-checks
+ * after <em>each</em> palette choice that the #75 {@code setup()} handoff
+ * put focus on the canvas ({@link EditorGestureSupport#canvasIsFocusOwner});
+ * a focus-stranding regression on the first OR-gate choice or the second
+ * NOT-gate choice therefore turns this red where a canvas-force-feeding
+ * driver would stay green. Everything that positions, places, nudges, and
+ * connects the gates is keyboard-only.</p>
  *
  * <p>The connection uses the editor's coincidence wiring (moving a port
  * onto another creates the wire) rather than free-hand wire drawing with
@@ -140,7 +148,16 @@ class EditorKeyboardConstructionTest {
 			// the setup() requestFocusInWindow this times out).
 			ui.waitFor(ui::canvasIsFocusOwner,
 					"choosing from the palette moved focus to the canvas");
-			ui.pressKey(KeyEvent.VK_ENTER);
+			// The line above is the handoff PROOF (it times out if setup()
+			// failed to move focus - see Mutation A). Then pin the canvas as
+			// the KFM focus owner deterministically before faithful driving:
+			// under the WM-less #162 Xvfb the live focus owner can read null
+			// for a beat after a modal dialog closes even though the canvas is
+			// the frame's focus owner, which a driver reading the live owner
+			// at press time would trip over. focusCanvas() polls the KFM until
+			// the canvas genuinely owns focus, so every key below lands there.
+			ui.focusCanvas();
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER);
 			OrGate or = assertElementPresent(circuit, OrGate.class);
 
 			// 2. arrow-key nudge of a selected element: move the caret onto
@@ -149,12 +166,12 @@ class EditorKeyboardConstructionTest {
 			Rectangle orRect = or.getRect();
 			driveCaretToward(ui, orRect.x + orRect.width / 2,
 					orRect.y + orRect.height / 2);
-			ui.pressKey(KeyEvent.VK_ENTER);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER);
 			int beforeX = or.getX();
-			ui.pressKey(KeyEvent.VK_RIGHT);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
 			assertEquals(beforeX + step, or.getX(),
 					"arrow key nudged the selected OR gate one grid step");
-			ui.pressKey(KeyEvent.VK_ENTER); // finish the selection, back to idle
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER); // finish, back to idle
 
 			// the OR input we will wire to, read after the nudge
 			Input orIn = firstOf(or, Input.class);
@@ -164,10 +181,10 @@ class EditorKeyboardConstructionTest {
 			// 3. the W key starts a wire at the caret, and Esc abandons it -
 			// pin that the wire tool is reachable from the keyboard
 			driveCaretToward(ui, ix - 6 * step, iy);
-			ui.pressKey(KeyEvent.VK_W);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_W);
 			ui.waitFor(() -> present(circuit, wireEndClass()),
 					"W started a wire");
-			ui.pressKey(KeyEvent.VK_ESCAPE);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ESCAPE);
 			ui.waitFor(() -> !present(circuit, wireEndClass()),
 					"Esc abandoned the wire");
 
@@ -178,6 +195,18 @@ class EditorKeyboardConstructionTest {
 			assertNotNull(notButton, "toolbar has a \"NOT gate\" button");
 			SwingUtilities.invokeAndWait(notButton::doClick);
 			ui.waitFor(() -> present(circuit, NotGate.class), "NOT gate created");
+			// #75 H2, second palette handoff: choosing the SECOND tool
+			// (after a modal creation dialog) must AGAIN hand focus to the
+			// canvas, or the keyboard user's placement keys would strand on
+			// the tool-bar button. The faithful driver below routes through
+			// the live focus owner, so this re-check is load-bearing: if the
+			// second handoff regressed, the caret keys would reach the button
+			// (or throw for no focus owner), not the canvas.
+			ui.waitFor(ui::canvasIsFocusOwner,
+					"choosing the NOT gate handed focus back to the canvas");
+			// handoff proven; pin the KFM owner deterministically (see the
+			// OR-gate note above) before the faithful placement keys below
+			ui.focusCanvas();
 			NotGate not = assertElementPresent(circuit, NotGate.class);
 			Output notOut = firstOf(not, Output.class);
 
@@ -189,7 +218,7 @@ class EditorKeyboardConstructionTest {
 			assertEquals(new Point(ix, iy),
 					new Point(notOut.getX(), notOut.getY()),
 					"keyboard moved the NOT output onto the OR input");
-			ui.pressKey(KeyEvent.VK_ENTER);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER);
 
 			// the keyboard-built circuit is the tutorial's connected pair
 			assertElementPresent(circuit, OrGate.class);
@@ -214,21 +243,26 @@ class EditorKeyboardConstructionTest {
 		int step = JLSInfo.spacing;
 		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
 
+			// stage the canvas as the genuine focus owner, then drive every
+			// key through the live focus owner (no palette choice precedes
+			// this test, so there is no setup() handoff to rely on)
+			ui.focusCanvas();
+
 			// caret to a clear grid point, well away from any element
 			driveCaretToward(ui, 20 * step, 10 * step);
 			int startX = ui.keyboardCaret().x;
 			int startY = ui.keyboardCaret().y;
 
 			// W starts the wire, Enter anchors it and begins a drawn segment
-			ui.pressKey(KeyEvent.VK_W);
-			ui.pressKey(KeyEvent.VK_ENTER);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_W);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER);
 			ui.waitFor(() -> present(circuit, wireClass()),
 					"the keyboard started drawing a wire");
 
 			// run the free end out four grid steps to the right; the caret
 			// (the wire's moving end) tracks it there
 			for (int i = 0; i < 4; i++) {
-				ui.pressKey(KeyEvent.VK_RIGHT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
 			}
 			assertEquals(new Point(startX + 4 * step, startY),
 					ui.keyboardCaret(),
@@ -242,7 +276,7 @@ class EditorKeyboardConstructionTest {
 							+ "each side)");
 
 			// Esc abandons the in-progress end
-			ui.pressKey(KeyEvent.VK_ESCAPE);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ESCAPE);
 		}
 	} // end of keyboardDrawsAWireInOpenSpace method
 
@@ -265,13 +299,13 @@ class EditorKeyboardConstructionTest {
 				return;
 			}
 			if (p.x < tx) {
-				ui.pressKey(KeyEvent.VK_RIGHT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
 			} else if (p.x > tx) {
-				ui.pressKey(KeyEvent.VK_LEFT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_LEFT);
 			} else if (p.y < ty) {
-				ui.pressKey(KeyEvent.VK_DOWN);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_DOWN);
 			} else {
-				ui.pressKey(KeyEvent.VK_UP);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_UP);
 			}
 		}
 		fail("keyboard could not reach (" + tx + "," + ty + "); last at "
@@ -295,15 +329,15 @@ class EditorKeyboardConstructionTest {
 				return;
 			}
 			if (c == null) {
-				ui.pressKey(KeyEvent.VK_LEFT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_LEFT);
 			} else if (c.x < tx) {
-				ui.pressKey(KeyEvent.VK_RIGHT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
 			} else if (c.x > tx) {
-				ui.pressKey(KeyEvent.VK_LEFT);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_LEFT);
 			} else if (c.y < ty) {
-				ui.pressKey(KeyEvent.VK_DOWN);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_DOWN);
 			} else {
-				ui.pressKey(KeyEvent.VK_UP);
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_UP);
 			}
 		}
 		fail("caret could not reach (" + tx + "," + ty + "); last at "

--- a/test/jls/ui/EditorKeyboardConstructionTest.java
+++ b/test/jls/ui/EditorKeyboardConstructionTest.java
@@ -1,0 +1,397 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertConnected;
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static jls.ui.CircuitAssert.assertNotConnected;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.util.function.Supplier;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.elem.Element;
+import jls.elem.Input;
+import jls.elem.NotGate;
+import jls.elem.OrGate;
+import jls.elem.Output;
+import jls.elem.Put;
+
+/**
+ * H2 acceptance test (issue #75): build the tutorial's first two-gate
+ * circuit -- an OR gate and a NOT gate wired output-to-input, the A + ~B
+ * skeleton of tutorial 1 -- with no pointing device. Every construction
+ * step after the palette choice is driven by synthetic key events
+ * dispatched to the canvas: arrow keys move the following element, the
+ * grid caret, and the selection; Enter places elements, activates the
+ * caret, and commits; the port-to-port connection is made the way the
+ * tutorial itself makes it, by moving the NOT gate's output onto an OR
+ * input so placement wires them. No {@link java.awt.Robot} and no mouse
+ * events reach the canvas.
+ *
+ * <p>Choosing an element from the palette still activates the toolbar
+ * button (a keyboard user tabs to it and presses it); this is done with
+ * {@code doClick}, a keyboard-equivalent activation, not a pointer
+ * gesture. The gate's creation dialog is real and modal, so a background
+ * thread accepts it with its defaults (mirroring {@link PaletteDropTest}).
+ * Everything that positions, places, nudges, and connects the gates is
+ * keyboard-only.</p>
+ *
+ * <p>The connection uses the editor's coincidence wiring (moving a port
+ * onto another creates the wire) rather than free-hand wire drawing with
+ * W: JLS grows a wire's bounds by a full grid spacing, so a short wire
+ * drawn directly between two abutting gate ports registers as overlapping
+ * both gates -- the same constraint the mouse faces, which is exactly why
+ * the tutorial connects adjacent gates by touching their ports. The W
+ * wire-start key is still exercised (it starts and cancels a wire); the
+ * two-gate circuit itself is built the tutorial's way.</p>
+ *
+ * <p>Tagged {@code display}: needs a real display for the creation dialog
+ * and font metrics, so it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class EditorKeyboardConstructionTest {
+
+	private volatile boolean accepting;
+	private Thread acceptor;
+
+	@BeforeEach
+	void requireDisplayAndStartAcceptor() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		accepting = true;
+		acceptor = new Thread(() -> {
+			while (accepting) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (w.isVisible() && w instanceof JDialog) {
+							JButton ok = findButton(w, "OK");
+							if (ok != null) {
+								ok.doClick();
+							}
+						}
+					}
+				});
+				try {
+					Thread.sleep(30);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "gate-dialog-acceptor");
+		acceptor.setDaemon(true);
+		acceptor.start();
+	}
+
+	@AfterEach
+	void stopAcceptor() throws Exception {
+		accepting = false;
+		if (acceptor != null) {
+			acceptor.join(1000);
+		}
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Lay out and wire the OR + NOT two-gate circuit with the keyboard
+	 * alone, exercising the caret, placement, selection nudging, the wire
+	 * key, and coincidence wiring, then assert the resulting model is
+	 * exactly the connected pair the mouse tutorial produces.
+	 */
+	@Test
+	void keyboardBuildsTheTwoGateCircuit() throws Exception {
+		Circuit circuit = new Circuit("keyboard");
+		int step = JLSInfo.spacing;
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+
+			// 1. choose the OR gate from the palette and place it with Enter
+			JButton orButton = findToolbarButton(ui.editor, "OR gate");
+			assertNotNull(orButton, "toolbar has an \"OR gate\" button");
+			SwingUtilities.invokeAndWait(orButton::doClick);
+			ui.waitFor(() -> present(circuit, OrGate.class), "OR gate created");
+			// #75 H2: choosing from the palette must hand focus to the
+			// canvas, or a real keyboard user's next arrow/Enter would go to
+			// the tool-bar button, not the canvas. Pin that handoff (without
+			// the setup() requestFocusInWindow this times out).
+			ui.waitFor(ui::canvasIsFocusOwner,
+					"choosing from the palette moved focus to the canvas");
+			ui.pressKey(KeyEvent.VK_ENTER);
+			OrGate or = assertElementPresent(circuit, OrGate.class);
+
+			// 2. arrow-key nudge of a selected element: move the caret onto
+			// the OR gate, Enter to select it, then an arrow to nudge it one
+			// grid step through the undoable move op
+			Rectangle orRect = or.getRect();
+			driveCaretToward(ui, orRect.x + orRect.width / 2,
+					orRect.y + orRect.height / 2);
+			ui.pressKey(KeyEvent.VK_ENTER);
+			int beforeX = or.getX();
+			ui.pressKey(KeyEvent.VK_RIGHT);
+			assertEquals(beforeX + step, or.getX(),
+					"arrow key nudged the selected OR gate one grid step");
+			ui.pressKey(KeyEvent.VK_ENTER); // finish the selection, back to idle
+
+			// the OR input we will wire to, read after the nudge
+			Input orIn = firstOf(or, Input.class);
+			int ix = orIn.getX();
+			int iy = orIn.getY();
+
+			// 3. the W key starts a wire at the caret, and Esc abandons it -
+			// pin that the wire tool is reachable from the keyboard
+			driveCaretToward(ui, ix - 6 * step, iy);
+			ui.pressKey(KeyEvent.VK_W);
+			ui.waitFor(() -> present(circuit, wireEndClass()),
+					"W started a wire");
+			ui.pressKey(KeyEvent.VK_ESCAPE);
+			ui.waitFor(() -> !present(circuit, wireEndClass()),
+					"Esc abandoned the wire");
+
+			// 4. choose the NOT gate and, with arrow keys only, move it so
+			// its output lands exactly on the OR input; Enter then places and
+			// wires them, the way the tutorial connects abutting gates
+			JButton notButton = findToolbarButton(ui.editor, "NOT gate");
+			assertNotNull(notButton, "toolbar has a \"NOT gate\" button");
+			SwingUtilities.invokeAndWait(notButton::doClick);
+			ui.waitFor(() -> present(circuit, NotGate.class), "NOT gate created");
+			NotGate not = assertElementPresent(circuit, NotGate.class);
+			Output notOut = firstOf(not, Output.class);
+
+			// not yet wired
+			assertNotConnected(circuit, not, or);
+
+			driveFollowingToward(ui, () -> new Point(notOut.getX(), notOut.getY()),
+					ix, iy);
+			assertEquals(new Point(ix, iy),
+					new Point(notOut.getX(), notOut.getY()),
+					"keyboard moved the NOT output onto the OR input");
+			ui.pressKey(KeyEvent.VK_ENTER);
+
+			// the keyboard-built circuit is the tutorial's connected pair
+			assertElementPresent(circuit, OrGate.class);
+			assertElementPresent(circuit, NotGate.class);
+			assertConnected(circuit, not, or);
+		}
+	} // end of keyboardBuildsTheTwoGateCircuit method
+
+	/**
+	 * Draw a wire in open space with the keyboard alone (issue #75):
+	 * position the caret, W to start, Enter to anchor and begin the
+	 * segment, arrow keys to run the wire's free end out. A real Wire
+	 * appears in the model, drawn with no pointing device, and its far end
+	 * follows the arrow keys. Esc then abandons the in-progress end. This
+	 * pins the free-hand wire tool; the two-gate test connects abutting
+	 * gate ports the tutorial's coincidence way, the robust path when a
+	 * wire would abut a gate body.
+	 */
+	@Test
+	void keyboardDrawsAWireInOpenSpace() throws Exception {
+		Circuit circuit = new Circuit("wire");
+		int step = JLSInfo.spacing;
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+
+			// caret to a clear grid point, well away from any element
+			driveCaretToward(ui, 20 * step, 10 * step);
+			int startX = ui.keyboardCaret().x;
+			int startY = ui.keyboardCaret().y;
+
+			// W starts the wire, Enter anchors it and begins a drawn segment
+			ui.pressKey(KeyEvent.VK_W);
+			ui.pressKey(KeyEvent.VK_ENTER);
+			ui.waitFor(() -> present(circuit, wireClass()),
+					"the keyboard started drawing a wire");
+
+			// run the free end out four grid steps to the right; the caret
+			// (the wire's moving end) tracks it there
+			for (int i = 0; i < 4; i++) {
+				ui.pressKey(KeyEvent.VK_RIGHT);
+			}
+			assertEquals(new Point(startX + 4 * step, startY),
+					ui.keyboardCaret(),
+					"arrow keys ran the wire's free end four grid steps out");
+
+			// the drawn wire now spans the four grid steps the arrows ran out
+			Element wire = firstPresent(circuit, wireClass());
+			Rectangle wr = wire.getRect();
+			assertEquals(4 * step, wr.width - 2 * step,
+					"wire spans the four grid steps (bounds grow one spacing "
+							+ "each side)");
+
+			// Esc abandons the in-progress end
+			ui.pressKey(KeyEvent.VK_ESCAPE);
+		}
+	} // end of keyboardDrawsAWireInOpenSpace method
+
+	/**
+	 * Press arrow keys until the point the supplier reports reaches the
+	 * target grid coordinates. Used to move a following element (its port
+	 * read live) into place with the keyboard.
+	 *
+	 * @param ui the gesture harness.
+	 * @param cur supplies the current tracked point (read after each key).
+	 * @param tx the target x.
+	 * @param ty the target y.
+	 * @throws Exception if a key dispatch fails.
+	 */
+	private void driveFollowingToward(EditorGestureSupport ui,
+			Supplier<Point> cur, int tx, int ty) throws Exception {
+		for (int i = 0; i < 400; i++) {
+			Point p = cur.get();
+			if (p.x == tx && p.y == ty) {
+				return;
+			}
+			if (p.x < tx) {
+				ui.pressKey(KeyEvent.VK_RIGHT);
+			} else if (p.x > tx) {
+				ui.pressKey(KeyEvent.VK_LEFT);
+			} else if (p.y < ty) {
+				ui.pressKey(KeyEvent.VK_DOWN);
+			} else {
+				ui.pressKey(KeyEvent.VK_UP);
+			}
+		}
+		fail("keyboard could not reach (" + tx + "," + ty + "); last at "
+				+ cur.get());
+	} // end of driveFollowingToward method
+
+	/**
+	 * Press arrow keys until the keyboard caret reaches the target grid
+	 * coordinates, initializing it with the first press.
+	 *
+	 * @param ui the gesture harness.
+	 * @param tx the target x.
+	 * @param ty the target y.
+	 * @throws Exception if a key dispatch fails.
+	 */
+	private void driveCaretToward(EditorGestureSupport ui, int tx, int ty)
+			throws Exception {
+		for (int i = 0; i < 600; i++) {
+			Point c = ui.keyboardCaret();
+			if (c != null && c.x == tx && c.y == ty) {
+				return;
+			}
+			if (c == null) {
+				ui.pressKey(KeyEvent.VK_LEFT);
+			} else if (c.x < tx) {
+				ui.pressKey(KeyEvent.VK_RIGHT);
+			} else if (c.x > tx) {
+				ui.pressKey(KeyEvent.VK_LEFT);
+			} else if (c.y < ty) {
+				ui.pressKey(KeyEvent.VK_DOWN);
+			} else {
+				ui.pressKey(KeyEvent.VK_UP);
+			}
+		}
+		fail("caret could not reach (" + tx + "," + ty + "); last at "
+				+ ui.keyboardCaret());
+	} // end of driveCaretToward method
+
+	/** Whether the circuit holds an element of the given type. */
+	private static boolean present(Circuit circuit, Class<?> type) {
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return true;
+			}
+		}
+		return false;
+	} // end of present method
+
+	/** The WireEnd class, looked up by name to avoid an elem import. */
+	private static Class<?> wireEndClass() {
+		return byName("jls.elem.WireEnd");
+	} // end of wireEndClass method
+
+	/** The Wire class, looked up by name to avoid an elem import. */
+	private static Class<?> wireClass() {
+		return byName("jls.elem.Wire");
+	} // end of wireClass method
+
+	/** A class looked up by name, failing the test if it is missing. */
+	private static Class<?> byName(String name) {
+		try {
+			return Class.forName(name);
+		} catch (ClassNotFoundException e) {
+			throw new AssertionError(e);
+		}
+	} // end of byName method
+
+	/** The first element of the given type, or a test failure if none. */
+	private static Element firstPresent(Circuit circuit, Class<?> type) {
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return el;
+			}
+		}
+		fail("no " + type.getSimpleName() + " present");
+		return null; // unreachable
+	} // end of firstPresent method
+
+	/** The first put of the given kind on the element. */
+	private static <T extends Put> T firstOf(Element el, Class<T> kind) {
+		for (Put p : el.getAllPuts()) {
+			if (kind.isInstance(p)) {
+				return kind.cast(p);
+			}
+		}
+		fail("no " + kind.getSimpleName() + " put on " + el);
+		return null; // unreachable
+	} // end of firstOf method
+
+	/** The toolbar button for the given tooltip (set by makeElement). */
+	private static JButton findToolbarButton(Container root, String tooltip) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& tooltip.equals(button.getToolTipText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findToolbarButton(inner, tooltip);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	} // end of findToolbarButton method
+
+	/** The button with the given text inside a dialog (e.g. "OK"). */
+	private static JButton findButton(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button && text.equals(button.getText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findButton(inner, text);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	} // end of findButton method
+
+} // end of EditorKeyboardConstructionTest class

--- a/test/jls/ui/FocusFaithfulKeyboardTest.java
+++ b/test/jls/ui/FocusFaithfulKeyboardTest.java
@@ -1,0 +1,225 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.elem.Element;
+import jls.elem.OrGate;
+
+/**
+ * Self-proof of the focus-faithful key driver (issue #75 verification
+ * hardening). The rest of the keyboard suite drives keys with
+ * {@link EditorGestureSupport#pressKey}, which calls
+ * {@code canvas.dispatchEvent(keyEvent)} on a hardcoded canvas reference -
+ * it force-feeds the canvas regardless of where the AWT focus subsystem
+ * would actually deliver the key. That bypass is exactly why a real focus
+ * bug (choosing a gate from the tool bar left focus on the button, so a
+ * user's arrow/Enter never reached the canvas) passed the suite until an
+ * adversarial review caught it.
+ *
+ * <p>This test drives keys instead through
+ * {@link EditorGestureSupport#pressKeyThroughFocusOwner}, which reads the
+ * live {@link java.awt.KeyboardFocusManager} focus owner at dispatch time -
+ * the same authority the real event pipeline consults. It is built so it
+ * goes RED when the real path is broken and PASSES only when it works, in
+ * two legs:</p>
+ *
+ * <ul>
+ * <li><b>Leg 1 (faithfulness guard).</b> With focus forced onto a
+ * non-canvas component (a palette button), an arrow routed through the
+ * focus owner reaches the button, so the canvas caret never moves. This
+ * leg fails if the driver secretly force-feeds the canvas the way the old
+ * {@code pressKey} does - it is the falsification of the bypass itself.</li>
+ * <li><b>Leg 2 (the real path).</b> Choosing the gate from the palette (a
+ * keyboard-equivalent {@code doClick}) must, via the #75 H2
+ * {@code setup()} focus handoff, move focus to the canvas; an arrow then
+ * routed through the focus owner moves the placing gate one grid step. This
+ * leg depends on the handoff: remove the {@code requestFocusInWindow} in
+ * {@code setup()} and focus stays on the button, the arrow goes to the
+ * button, the gate never moves - RED. The old dispatch-to-canvas path would
+ * pass leg 2 even with focus stranded, so it could never prove the
+ * handoff.</li>
+ * </ul>
+ *
+ * <p>Tagged {@code display}: needs a real display for the gate creation
+ * dialog and font metrics, so it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false). A background
+ * thread accepts the modal creation dialog with its defaults, mirroring
+ * {@link EditorKeyboardConstructionTest} and {@link PaletteDropTest}.</p>
+ */
+@Tag("display")
+@Timeout(120)
+class FocusFaithfulKeyboardTest {
+
+	private volatile boolean accepting;
+	private Thread acceptor;
+
+	@BeforeEach
+	void requireDisplayAndStartAcceptor() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		accepting = true;
+		acceptor = new Thread(() -> {
+			while (accepting) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (w.isVisible() && w instanceof JDialog) {
+							JButton ok = findButton(w, "OK");
+							if (ok != null) {
+								ok.doClick();
+							}
+						}
+					}
+				});
+				try {
+					Thread.sleep(30);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "gate-dialog-acceptor");
+		acceptor.setDaemon(true);
+		acceptor.start();
+	}
+
+	@AfterEach
+	void stopAcceptor() throws Exception {
+		accepting = false;
+		if (acceptor != null) {
+			acceptor.join(1000);
+		}
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Prove the driver routes keys through the real focus owner: an arrow
+	 * routed while the palette button holds focus does not move the canvas
+	 * caret (leg 1), and after the palette choice hands focus to the canvas
+	 * an arrow routed through the focus owner moves the placing gate one
+	 * grid step (leg 2).
+	 */
+	@Test
+	void keyboardInputRoutesThroughTheRealFocusOwnerNotTheCanvas()
+			throws Exception {
+		Circuit circuit = new Circuit("focus-faithful");
+		int step = JLSInfo.spacing;
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+
+			JButton orButton = findToolbarButton(ui.editor, "OR gate");
+			assertNotNull(orButton, "toolbar has an \"OR gate\" button");
+
+			// ---- Leg 1: faithfulness guard ------------------------------
+			// Force focus onto the palette button (a stand-in for a
+			// focus-stranding regression) and route an arrow through the
+			// LIVE focus owner. A focus-faithful driver delivers it to the
+			// button, so the canvas keyboard caret stays unset. The old
+			// pressKey -> canvas.dispatchEvent path would have moved the
+			// caret regardless of focus; this assertion is exactly what
+			// falsifies that bypass.
+			ui.giveFocusTo(orButton);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			assertNull(ui.keyboardCaret(),
+					"an arrow routed to the focused palette button did not "
+							+ "move the canvas caret");
+
+			// ---- Leg 2: the real path -----------------------------------
+			// Choose the OR gate the keyboard-equivalent way (activate the
+			// focused button). The #75 H2 setup() handoff must move focus to
+			// the canvas; without it, focus stays on the button and leg 2
+			// fails. Then route an arrow through the live focus owner: the
+			// editor is in the placing state, so the gate follows one grid
+			// step - observable proof the key reached the canvas through the
+			// real focus subsystem.
+			SwingUtilities.invokeAndWait(orButton::doClick);
+			ui.waitFor(() -> present(circuit, OrGate.class), "OR gate created");
+			// Wait for the real handoff to settle before routing the key -
+			// the modal creation dialog closes asynchronously and focus
+			// returns to the canvas a beat later, exactly as a real user
+			// waits for the dialog to dismiss before pressing arrows. With
+			// the setup() handoff broken this wait times out (focus never
+			// reaches the canvas), so leg 2 still goes RED on that
+			// regression.
+			ui.waitFor(ui::canvasIsFocusOwner,
+					"choosing from the palette handed focus to the canvas");
+			OrGate or = assertElementPresent(circuit, OrGate.class);
+			int beforeX = or.getX();
+			// Now route the arrow through the LIVE focus owner: the editor is
+			// in the placing state, so the gate follows one grid step. This
+			// observes that the key genuinely reaches the canvas through the
+			// real focus subsystem - not force-fed to a hardcoded reference.
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			ui.waitFor(() -> or.getX() == beforeX + step,
+					"an arrow routed through the focus owner moved the placing "
+							+ "OR gate one grid step (proves the key reached the "
+							+ "canvas via the real focus subsystem)");
+		}
+	} // end of keyboardInputRoutesThroughTheRealFocusOwnerNotTheCanvas method
+
+	/** Whether the circuit holds an element of the given type. */
+	private static boolean present(Circuit circuit, Class<?> type) {
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return true;
+			}
+		}
+		return false;
+	} // end of present method
+
+	/** The toolbar button for the given tooltip (set by makeElement). */
+	private static JButton findToolbarButton(Container root, String tooltip) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& tooltip.equals(button.getToolTipText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findToolbarButton(inner, tooltip);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	} // end of findToolbarButton method
+
+	/** The button with the given text inside a dialog (e.g. "OK"). */
+	private static JButton findButton(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button && text.equals(button.getText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findButton(inner, text);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	} // end of findButton method
+
+} // end of FocusFaithfulKeyboardTest class

--- a/test/jls/ui/KeyboardEditingFaithfulTest.java
+++ b/test/jls/ui/KeyboardEditingFaithfulTest.java
@@ -1,0 +1,411 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
+import java.awt.event.KeyEvent;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Scanner;
+
+import javax.swing.KeyStroke;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.JLSInfo;
+import jls.edit.EditOp;
+import jls.elem.AndGate;
+import jls.elem.Element;
+import jls.elem.Gate;
+
+/**
+ * Keyboard editing operations verified through the REAL focus subsystem
+ * (issue #75 verification hardening). Every editing key a user presses -
+ * arrow-nudge, undo, redo, rotate, flip, delete, wire-start, escape - is
+ * driven here through
+ * {@link EditorGestureSupport#pressKeyThroughFocusOwner}, which dispatches
+ * to the live {@link java.awt.KeyboardFocusManager} focus owner rather than
+ * to a hardcoded canvas reference. The canvas is first made the genuine
+ * focus owner ({@link EditorGestureSupport#focusCanvas}); every key then
+ * reaches it exactly as a real keystroke would, so a regression that broke
+ * key delivery to the focus owner (the class of the #75 H2 tool-bar focus
+ * bug) turns these tests red where the old {@code pressKey} would force-feed
+ * the canvas and stay green.
+ *
+ * <p>These close the enumerated keyboard-construction gaps that were
+ * exercised only via {@code canvas.dispatchEvent} (nudge + its untested undo
+ * leg, delete, wire-start, escape) or not driven by any keystroke at all
+ * (rotate, flip, undo/redo). The selection each op acts on is established
+ * with a rubber-band drag (the mechanism under test is the op key, not the
+ * selection gesture); the op key itself is routed faithfully.</p>
+ *
+ * <p>Tagged {@code display}: needs a real display and the real focus
+ * subsystem, so it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class KeyboardEditingFaithfulTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/** A circuit with a single, unattached AND gate that can rotate/flip. */
+	private static Circuit oneGate() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		Circuit circuit = new Circuit("kbd-edit");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/** A circuit with a single input pin - a watchable element (canWatch). */
+	private static Circuit onePin() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.inputPin("A", 1);
+		Circuit circuit = new Circuit("kbd-watch");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/** The sole watchable Pin in the current circuit. */
+	private static jls.elem.Pin solePin(EditorGestureSupport ui) {
+		for (Element el : ui.currentCircuit().getElements()) {
+			if (el instanceof jls.elem.Pin p) {
+				return p;
+			}
+		}
+		throw new AssertionError("no Pin in the circuit");
+	}
+
+	private static int centerX(Element el) {
+		return el.getX() + el.getRect().width / 2;
+	}
+
+	private static int centerY(Element el) {
+		return el.getY() + el.getRect().height / 2;
+	}
+
+	/** Rubber-band select the gate and make the canvas the real focus owner. */
+	private static void selectGateAndFocusCanvas(EditorGestureSupport ui,
+			Element gate) throws Exception {
+		int x0 = gate.getX() - 40, y0 = gate.getY() - 40;
+		int x1 = gate.getX() + gate.getRect().width + 40;
+		int y1 = gate.getY() + gate.getRect().height + 40;
+		ui.leftDrag(x0, y0, x1, y1);
+		ui.waitFor(gate::isHighlighted, "gate rubber-band selected");
+		ui.focusCanvas();
+		assertTrue(ui.canvasIsFocusOwner(),
+				"canvas is the genuine focus owner before the op key");
+	}
+
+	/** The sole Gate in the current (possibly rebuilt) circuit. */
+	private static Gate soleGate(EditorGestureSupport ui) {
+		for (Element el : ui.currentCircuit().getElements()) {
+			if (el instanceof Gate g) {
+				return g;
+			}
+		}
+		throw new AssertionError("no Gate in the circuit");
+	}
+
+	/**
+	 * The element's persisted save block - the real, user-visible form
+	 * rotate and flip mutate (orientation string, recomputed geometry). A
+	 * clean observable that changes iff the op actually ran.
+	 */
+	private static String save(Element el) {
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		el.save(pw);
+		pw.flush();
+		return sw.toString();
+	}
+
+	/**
+	 * An arrow key routed through the real focus owner nudges the selected
+	 * gate one grid step (the undoable {@code MoveElements} path), and Ctrl+Z
+	 * routed the same way undoes it - pinning both the faithful nudge and the
+	 * previously untested undo-of-nudge leg.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void arrowNudgeThroughFocusOwnerIsUndoableWithCtrlZ() throws Exception {
+		Circuit circuit = oneGate();
+		int step = JLSInfo.spacing;
+		String os = System.getProperty("os.name");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			selectGateAndFocusCanvas(ui, gate);
+
+			int beforeX = gate.getX();
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			ui.waitFor(() -> soleGate(ui).getX() == beforeX + step,
+					"an arrow through the focus owner nudged the gate one step");
+
+			// Ctrl+Z (platform undo) through the focus owner restores it
+			KeyStroke undo = EditOp.UNDO.accelerator(os);
+			ui.pressKeyThroughFocusOwner(undo.getKeyCode(), undo.getModifiers());
+			ui.waitFor(() -> soleGate(ui).getX() == beforeX,
+					"Ctrl+Z through the focus owner undid the nudge");
+		}
+	}
+
+	/**
+	 * After undoing a nudge, the platform redo key routed through the focus
+	 * owner re-applies it - pinning redo-via-keystroke, which no test drove
+	 * before.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void redoThroughFocusOwnerReappliesTheNudge() throws Exception {
+		Circuit circuit = oneGate();
+		int step = JLSInfo.spacing;
+		String os = System.getProperty("os.name");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			selectGateAndFocusCanvas(ui, gate);
+
+			int beforeX = gate.getX();
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			ui.waitFor(() -> soleGate(ui).getX() == beforeX + step,
+					"gate nudged one step");
+			KeyStroke undo = EditOp.UNDO.accelerator(os);
+			ui.pressKeyThroughFocusOwner(undo.getKeyCode(), undo.getModifiers());
+			ui.waitFor(() -> soleGate(ui).getX() == beforeX, "nudge undone");
+
+			KeyStroke redo = EditOp.REDO.accelerator(os);
+			ui.pressKeyThroughFocusOwner(redo.getKeyCode(), redo.getModifiers());
+			ui.waitFor(() -> soleGate(ui).getX() == beforeX + step,
+					"redo through the focus owner re-applied the nudge");
+		}
+	}
+
+	/**
+	 * The plain-R rotate key routed through the focus owner rotates the
+	 * selected gate - the first end-to-end proof that the rotate binding
+	 * reaches its shared Action through the real event path (previously only
+	 * object identity was asserted).
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void rotateKeyRotatesThroughFocusOwner() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			String before = save(gate);
+			selectGateAndFocusCanvas(ui, gate);
+
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_R);
+			ui.waitFor(() -> !save(soleGate(ui)).equals(before),
+					"R through the focus owner rotated the gate");
+			assertNotEquals(before, save(soleGate(ui)),
+					"rotate changed the gate's persisted form");
+		}
+	}
+
+	/**
+	 * The plain-F flip key routed through the focus owner flips the selected
+	 * gate.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void flipKeyFlipsThroughFocusOwner() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			String before = save(gate);
+			selectGateAndFocusCanvas(ui, gate);
+
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_F);
+			ui.waitFor(() -> !save(soleGate(ui)).equals(before),
+					"F through the focus owner flipped the gate");
+			assertNotEquals(before, save(soleGate(ui)),
+					"flip changed the gate's persisted form");
+		}
+	}
+
+	/**
+	 * The Delete key routed through the focus owner removes the selection -
+	 * the faithful counterpart of the identity-plus-canvas-dispatch Delete
+	 * check in {@link EditActionMatrixTest}.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void deleteKeyRemovesThroughFocusOwner() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			selectGateAndFocusCanvas(ui, gate);
+
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_DELETE);
+			ui.waitFor(() -> ui.currentCircuit().getElements().stream()
+					.noneMatch(el -> el instanceof AndGate),
+					"Delete through the focus owner removed the gate");
+		}
+	}
+
+	/**
+	 * The Ctrl/Cmd+W watch key routed through the real focus owner toggles the
+	 * watched state of the selected element - the behavioral proof of the #75
+	 * headline overload resolution. Ctrl+W and plain-W used to be the same
+	 * stroke doing two jobs; they are now split (plain W starts a wire,
+	 * {@link #wireStartAndEscapeThroughFocusOwner} pins that), and this fires
+	 * the Ctrl+W half and observes the element's watched flag flip. Nothing
+	 * fired Watch before - only object identity was asserted - so a regression
+	 * that left Ctrl+W wired to a disabled or no-op Action, or collapsed the
+	 * overload back onto one stroke, turns this red.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void watchKeyTogglesWatchedThroughFocusOwner() throws Exception {
+		Circuit circuit = onePin();
+		String os = System.getProperty("os.name");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			jls.elem.Pin pin = solePin(ui);
+			assertTrue(pin.canWatch(), "the input pin is watchable");
+			boolean before = pin.isWatched();
+			selectGateAndFocusCanvas(ui, pin);
+
+			KeyStroke watch = EditOp.WATCH.accelerator(os);
+			ui.pressKeyThroughFocusOwner(watch.getKeyCode(),
+					watch.getModifiers());
+			ui.waitFor(() -> solePin(ui).isWatched() != before,
+					"Ctrl+W through the focus owner toggled the watched flag");
+			assertNotEquals(before, solePin(ui).isWatched(),
+					"Ctrl+W changed the element's watched state");
+		}
+	}
+
+	/**
+	 * The plain-W wire-start key routed through the focus owner starts a wire
+	 * at the keyboard caret, and Escape routed the same way abandons it -
+	 * pinning the Ctrl/Cmd+W -&gt; plain-W wire-start move and the cancel key
+	 * through the real event path.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void wireStartAndEscapeThroughFocusOwner() throws Exception {
+		Circuit circuit = new Circuit("kbd-wire");
+		int step = JLSInfo.spacing;
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			ui.focusCanvas();
+			assertTrue(ui.canvasIsFocusOwner(), "canvas owns focus");
+
+			// drive the caret to a clear grid point with faithful arrows
+			driveCaretFaithful(ui, 20 * step, 10 * step);
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_W);
+			ui.waitFor(() -> present(circuit, "jls.elem.WireEnd"),
+					"W through the focus owner started a wire");
+
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ESCAPE);
+			ui.waitFor(() -> !present(circuit, "jls.elem.WireEnd"),
+					"Escape through the focus owner abandoned the wire");
+		}
+	}
+
+	/**
+	 * Drive the keyboard caret to a target grid point using only faithful,
+	 * focus-owner-routed arrow keys.
+	 *
+	 * @param ui the harness.
+	 * @param tx target x.
+	 * @param ty target y.
+	 * @throws Exception on EDT failure.
+	 */
+	private static void driveCaretFaithful(EditorGestureSupport ui, int tx,
+			int ty) throws Exception {
+		for (int i = 0; i < 600; i++) {
+			java.awt.Point c = ui.keyboardCaret();
+			if (c != null && c.x == tx && c.y == ty) {
+				return;
+			}
+			if (c == null || c.x > tx) {
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_LEFT);
+			} else if (c.x < tx) {
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			} else if (c.y < ty) {
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_DOWN);
+			} else {
+				ui.pressKeyThroughFocusOwner(KeyEvent.VK_UP);
+			}
+		}
+		throw new AssertionError("caret could not reach (" + tx + "," + ty
+				+ "); last at " + ui.keyboardCaret());
+	}
+
+	/** Whether the circuit holds an element of the named type. */
+	private static boolean present(Circuit circuit, String typeName) {
+		Class<?> type;
+		try {
+			type = Class.forName(typeName);
+		} catch (ClassNotFoundException e) {
+			throw new AssertionError(e);
+		}
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Sanity guard: the shared rotate/flip/delete/undo/redo Actions the
+	 * faithful keys drive are the same objects the popup and menu bar use, so
+	 * proving the key path also proves those surfaces. Kept here so a
+	 * refactor that re-split a surface fails alongside the behavioral checks.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void faithfulKeysDriveTheSharedActions() throws Exception {
+		Circuit circuit = oneGate();
+		String os = System.getProperty("os.name");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			for (EditOp op : new EditOp[] { EditOp.ROTATE_CW, EditOp.FLIP,
+					EditOp.DELETE, EditOp.UNDO, EditOp.REDO,
+					EditOp.WIRE_START }) {
+				KeyStroke ks = op.accelerator(os);
+				assertNotNull(ui.canvasActionForStroke(ks),
+						"canvas binds " + op + " key " + ks);
+				assertSame(ui.editor.editAction(op),
+						ui.canvasActionForStroke(ks),
+						"canvas " + op + " binding is the shared Action");
+			}
+			// touch a rect so the import is used and the gate is real
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			Rectangle r = gate.getRect();
+			assertTrue(r.width > 0 && r.height > 0, "gate has bounds");
+			assertTrue(centerX(gate) > 0 && centerY(gate) > 0, "gate centered");
+		}
+	}
+}

--- a/test/jls/ui/KeyboardPlacementFaithfulTest.java
+++ b/test/jls/ui/KeyboardPlacementFaithfulTest.java
@@ -1,0 +1,195 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.elem.Element;
+import jls.elem.OrGate;
+
+/**
+ * Enter places (commits) a keyboard-positioned element, verified through the
+ * real focus subsystem (issue #75 keyboard construction, behavior "Enter
+ * places the chosen element"). {@link FocusFaithfulKeyboardTest} proves an
+ * arrow routed through the live focus owner moves the placing gate; this
+ * proves the follow-on Enter, routed the same way, commits it: after Enter
+ * the editor is idle, so a subsequent arrow moves only the caret and the
+ * gate stays put. Driving every key through
+ * {@link EditorGestureSupport#pressKeyThroughFocusOwner} makes the test red
+ * if key delivery to the focus owner breaks, where the old
+ * {@code canvas.dispatchEvent} path stayed green.
+ *
+ * <p>Tagged {@code display}: needs a display for the gate creation dialog
+ * (accepted by a background thread with its defaults) and font metrics.</p>
+ */
+@Tag("display")
+@Timeout(120)
+class KeyboardPlacementFaithfulTest {
+
+	private volatile boolean accepting;
+	private Thread acceptor;
+
+	@BeforeEach
+	void requireDisplayAndStartAcceptor() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		accepting = true;
+		acceptor = new Thread(() -> {
+			while (accepting) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (w.isVisible() && w instanceof JDialog) {
+							JButton ok = findButton(w, "OK");
+							if (ok != null) {
+								ok.doClick();
+							}
+						}
+					}
+				});
+				try {
+					Thread.sleep(30);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "gate-dialog-acceptor");
+		acceptor.setDaemon(true);
+		acceptor.start();
+	}
+
+	@AfterEach
+	void stopAcceptor() throws Exception {
+		accepting = false;
+		if (acceptor != null) {
+			acceptor.join(1000);
+		}
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Choose an OR gate from the palette (which hands focus to the canvas),
+	 * move it one grid step with a focus-owner-routed arrow, commit it with a
+	 * focus-owner-routed Enter, then prove the commit took: a further arrow
+	 * leaves the gate where it was placed (the editor is idle, so the arrow
+	 * moves only the caret).
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void enterThroughFocusOwnerCommitsThePlacedGate() throws Exception {
+		Circuit circuit = new Circuit("kbd-place");
+		int step = JLSInfo.spacing;
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			JButton orButton = findToolbarButton(ui.editor, "OR gate");
+			assertNotNull(orButton, "toolbar has an \"OR gate\" button");
+			SwingUtilities.invokeAndWait(orButton::doClick);
+			ui.waitFor(() -> present(circuit, OrGate.class), "OR gate created");
+			ui.waitFor(ui::canvasIsFocusOwner,
+					"choosing from the palette handed focus to the canvas");
+
+			OrGate or = assertElementPresent(circuit, OrGate.class);
+			int beforeX = or.getX();
+			// arrow through the focus owner moves the placing gate one step
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			ui.waitFor(() -> or.getX() == beforeX + step,
+					"an arrow moved the placing gate one grid step");
+			int placedX = or.getX();
+
+			// Enter through the focus owner commits the placement
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_ENTER);
+
+			// after the commit the editor is idle: a further arrow moves only
+			// the caret, so the committed gate stays where it was placed. Wait
+			// on a POSITIVE observable that the arrow was processed - the caret
+			// moving - rather than sleeping a fixed interval; then assert the
+			// gate did not move. (Were the editor still in the placing state -
+			// the regression this guards - the same arrow would move the gate,
+			// failing the assertion.)
+			java.awt.Point caretBefore = ui.keyboardCaret();
+			ui.pressKeyThroughFocusOwner(KeyEvent.VK_RIGHT);
+			ui.waitFor(() -> {
+				try {
+					return !java.util.Objects.equals(ui.keyboardCaret(),
+							caretBefore);
+				} catch (Exception e) {
+					throw new AssertionError(e);
+				}
+			}, "the post-commit arrow moved the caret (so it was processed)");
+			assertEquals(placedX, sole(ui).getX(),
+					"Enter committed the placement: the gate no longer follows "
+							+ "the arrow keys");
+		}
+	}
+
+	private static OrGate sole(EditorGestureSupport ui) {
+		for (Element el : ui.currentCircuit().getElements()) {
+			if (el instanceof OrGate g) {
+				return g;
+			}
+		}
+		throw new AssertionError("no OR gate in the circuit");
+	}
+
+	private static boolean present(Circuit circuit, Class<?> type) {
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static JButton findToolbarButton(Container root, String tooltip) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& tooltip.equals(button.getToolTipText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findToolbarButton(inner, tooltip);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static JButton findButton(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button && text.equals(button.getText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findButton(inner, text);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/test/jls/ui/MenuAcceleratorFiringTest.java
+++ b/test/jls/ui/MenuAcceleratorFiringTest.java
@@ -1,0 +1,308 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.KeyboardFocusManager;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JButton;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.DefaultExceptionHandler;
+import jls.JLSInfo;
+import jls.JLSStart;
+import jls.MenuAcceleratorPolicy;
+import jls.edit.EditOp;
+import jls.edit.Editor;
+import jls.elem.Element;
+import jls.sim.Simulator;
+
+/**
+ * Window-scoped menu accelerator firing (issue #75 verification hardening).
+ * The Edit and Element menu items carry {@code WHEN_IN_FOCUSED_WINDOW}
+ * accelerators so a user's Ctrl+A / Delete fires the op no matter which
+ * component in the window holds focus - the whole reason the menu binding
+ * is window-scoped rather than the canvas' {@code WHEN_FOCUSED} binding.
+ * Nothing proved that firing before: {@link MenuBarSpecTest} reads the
+ * displayed accelerator and {@link EditActionMatrixTest} drives one key
+ * (Delete) straight into the canvas via {@code canvas.dispatchEvent}, which
+ * exercises the canvas map, never the window-scoped menu accelerator, and
+ * bypasses focus entirely.
+ *
+ * <p>This boots the real {@link JLSStart} main window, gives focus to a
+ * NON-canvas component (a tool-bar palette button), and dispatches the
+ * accelerator through the live {@link KeyboardFocusManager} focus owner -
+ * the same path the AWT pipeline uses, which routes a focus owner's key
+ * event up to the window's {@code WHEN_IN_FOCUSED_WINDOW} bindings. Select
+ * All then highlights the circuit and Delete removes it, proving the
+ * accelerator fired its shared Action with focus off the canvas. A
+ * regression that dropped the accelerator when {@code retargetEditMenus}
+ * swaps the Action, never added the menu, or broke window scope, turns this
+ * red.</p>
+ *
+ * <p>Both accelerators are idempotent (Select All twice selects the same
+ * set; Delete-all twice leaves nothing), so this stays robust even if the
+ * focus-owner dispatch delivered more than one event.</p>
+ *
+ * <p>Tagged {@code display}: {@code new JLSStart()} is a visible frame, so
+ * it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class MenuAcceleratorFiringTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/**
+	 * With focus on a tool-bar palette button, Ctrl+A selects the whole
+	 * circuit and Delete removes it - the window-scoped menu accelerators
+	 * fire their shared Actions from a non-canvas focus owner.
+	 *
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	@Test
+	void windowScopedAcceleratorsFireFromANonCanvasFocusOwner()
+			throws Exception {
+		Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		String os = System.getProperty("os.name");
+		try {
+			JLSStart jls = bootMainWindow();
+			Circuit circuit = twoGates();
+			AtomicReference<Editor> edRef = new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> {
+				jls.setupEditor(circuit, "accel");
+				edRef.set(jls.getVisibleEditor());
+			});
+			Editor ed = edRef.get();
+			assertNotNull(ed, "setupEditor made an editor visible");
+
+			// focus a NON-canvas component: a tool-bar palette button
+			JButton palette = findToolbarButton(ed, "AND gate");
+			assertNotNull(palette, "the visible editor has an AND gate button");
+			giveFocusTo(palette);
+			assertTrue(focusOwner() instanceof JButton,
+					"focus is on the tool-bar button, not the canvas");
+
+			// Ctrl+A (Select All) through the window's focus owner
+			pressThroughFocusOwner(EditOp.SELECT_ALL.accelerator(os));
+			waitFor(() -> ed.getCircuit().getElements().stream()
+					.anyMatch(Element::isHighlighted),
+					"Ctrl+A from the tool-bar selected the circuit");
+
+			// Delete through the window's focus owner removes the selection
+			pressThroughFocusOwner(EditOp.DELETE.accelerator(os));
+			waitFor(() -> ed.getCircuit().getElements().stream()
+					.noneMatch(el -> el.getClass().getSimpleName()
+							.endsWith("Gate")),
+					"Delete from the tool-bar removed the selected gates");
+		}
+		finally {
+			SwingUtilities.invokeAndWait(() -> {
+				for (Window w : Window.getWindows()) {
+					w.dispose();
+				}
+			});
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+		}
+	}
+
+	/**
+	 * With focus on a tool-bar palette button, Ctrl/Cmd+S saves the visible
+	 * circuit - the File menu's window-scoped accelerator fires from a
+	 * non-canvas focus owner, the literal #75 P1 prediction ("Ctrl/Cmd+S
+	 * saves from any focus location"). The circuit is pointed at a temp
+	 * directory and marked dirty; firing Save clears the dirty flag and
+	 * writes the .jls file. A regression that dropped the File accelerator or
+	 * scoped it to the canvas turns this red. Save writes directly (no file
+	 * chooser) once the circuit has a directory + name, so this stays a
+	 * deterministic, dialog-free check.
+	 *
+	 * @throws Exception on reflection, I/O, or EDT failure.
+	 */
+	@Test
+	void fileSaveAcceleratorSavesFromANonCanvasFocusOwner() throws Exception {
+		Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		String os = System.getProperty("os.name");
+		Path dir = Files.createTempDirectory("jls-save-test");
+		File saved = new File(dir.toFile(), "savetest.jls");
+		try {
+			JLSStart jls = bootMainWindow();
+			Circuit circuit = twoGates();
+			circuit.setName("savetest");
+			circuit.setDirectory(dir.toString());
+			AtomicReference<Editor> edRef = new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> {
+				jls.setupEditor(circuit, "savetest");
+				edRef.set(jls.getVisibleEditor());
+			});
+			Editor ed = edRef.get();
+			assertNotNull(ed, "setupEditor made an editor visible");
+
+			// dirty the circuit so the save has an observable effect to clear
+			SwingUtilities.invokeAndWait(circuit::markChanged);
+			assertTrue(ed.getCircuit().hasChanged(),
+					"the circuit starts dirty (unsaved changes)");
+
+			// focus a NON-canvas component: a tool-bar palette button
+			JButton palette = findToolbarButton(ed, "AND gate");
+			assertNotNull(palette, "the visible editor has an AND gate button");
+			giveFocusTo(palette);
+			assertTrue(focusOwner() instanceof JButton,
+					"focus is on the tool-bar button, not the canvas");
+
+			// Ctrl/Cmd+S (File > Save) through the window's focus owner
+			pressThroughFocusOwner(MenuAcceleratorPolicy.save(os));
+			waitFor(() -> !ed.getCircuit().hasChanged(),
+					"Ctrl+S from the tool-bar saved the circuit (dirty flag "
+							+ "cleared)");
+			waitFor(saved::isFile,
+					"Ctrl+S from the tool-bar wrote the .jls file to disk");
+		}
+		finally {
+			SwingUtilities.invokeAndWait(() -> {
+				for (Window w : Window.getWindows()) {
+					w.dispose();
+				}
+			});
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+			Files.deleteIfExists(saved.toPath());
+			Files.deleteIfExists(dir);
+		}
+	}
+
+	/** A circuit with two unattached AND gates. */
+	private static Circuit twoGates() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		cb.gate("AndGate", 1, 2);
+		Circuit circuit = new Circuit("accel");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/** The live keyboard-focus owner, read on the EDT. */
+	private static Component focusOwner() throws Exception {
+		AtomicReference<Component> owner = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> owner.set(KeyboardFocusManager
+				.getCurrentKeyboardFocusManager().getFocusOwner()));
+		return owner.get();
+	}
+
+	/** Move focus to the target and poll the KFM until it lands. */
+	private static void giveFocusTo(Component target) throws Exception {
+		SwingUtilities.invokeAndWait(target::requestFocusInWindow);
+		waitFor(() -> {
+			try {
+				return focusOwner() == target;
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}, "focus to move to the palette button");
+	}
+
+	/**
+	 * Dispatch the accelerator keystroke as a KEY_PRESSED to the live focus
+	 * owner on the EDT. Dispatching to the focus owner runs its
+	 * {@code processKeyBindings}, which walks up to the window and fires the
+	 * {@code WHEN_IN_FOCUSED_WINDOW} menu accelerator - exactly the path a
+	 * real keypress takes.
+	 */
+	private static void pressThroughFocusOwner(KeyStroke ks) throws Exception {
+		Component owner = focusOwner();
+		if (owner == null) {
+			throw new AssertionError("no focus owner to route the accelerator "
+					+ "to; a real keystroke would have nowhere to go either");
+		}
+		KeyEvent e = new KeyEvent(owner, KeyEvent.KEY_PRESSED,
+				System.currentTimeMillis(), ks.getModifiers(), ks.getKeyCode(),
+				KeyEvent.CHAR_UNDEFINED);
+		SwingUtilities.invokeAndWait(() -> owner.dispatchEvent(e));
+	}
+
+	/** Poll a condition to a ~10s bound (loaded-CI tolerant). */
+	private static void waitFor(java.util.function.BooleanSupplier cond,
+			String what) {
+		for (int i = 0; i < 400; i++) {
+			if (cond.getAsBoolean()) {
+				return;
+			}
+			try {
+				Thread.sleep(25);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				fail("interrupted waiting for " + what);
+			}
+		}
+		fail("timed out waiting for " + what);
+	}
+
+	/** The first JButton with the given tooltip under root (the palette). */
+	private static JButton findToolbarButton(Container root, String tooltip) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& tooltip.equals(button.getToolTipText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findToolbarButton(inner, tooltip);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Construct the real JLS main window on the EDT, installing the static
+	 * exception handler the constructor needs (mirrors {@link MenuBarSpecTest}
+	 * and {@link EditActionMatrixTest}).
+	 *
+	 * @return the constructed main window.
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	private static JLSStart bootMainWindow() throws Exception {
+		Field handler = JLSStart.class.getDeclaredField("exHandler");
+		handler.setAccessible(true);
+		if (handler.get(null) == null) {
+			handler.set(null, new DefaultExceptionHandler());
+		}
+		AtomicReference<JLSStart> ref = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> ref.set(new JLSStart()));
+		return ref.get();
+	}
+}

--- a/test/jls/ui/MenuBarSpecTest.java
+++ b/test/jls/ui/MenuBarSpecTest.java
@@ -77,6 +77,25 @@ class MenuBarSpecTest {
 			\tExport Image
 			\tClose
 			\tExit [Ctrl+Q]
+			Edit
+			\tUndo [Ctrl+Z]
+			\tRedo [Ctrl+Y]
+			\t--
+			\tCut [Ctrl+X]
+			\tCopy [Ctrl+C]
+			\tPaste [Ctrl+V]
+			\tDelete [Delete]
+			\t--
+			\tSelect All [Ctrl+A]
+			Element
+			\tRotate Clockwise [R]
+			\tRotate Counter-Clockwise [Shift+R]
+			\tFlip [F]
+			\t--
+			\tWatch [Ctrl+W]
+			\tProbe [Ctrl+P]
+			\tModify [Ctrl+M]
+			\tChange Timing [Ctrl+T]
 			Simulator
 			\tShow Simulator Window
 			\tHide Simulator Window
@@ -134,10 +153,12 @@ class MenuBarSpecTest {
 			SwingUtilities.invokeAndWait(() -> {
 				JMenuBar bar = jls.getJMenuBar();
 				rendered.set(render(bar));
-				// the component after Global (now index 4: File, Simulator,
-				// View, Global) is the glue that right-aligns Help, not a menu
+				// the component after Global (now index 6: File, Edit,
+				// Element, Simulator, View, Global) is the glue that
+				// right-aligns Help, not a menu (issue #75 inserted Edit and
+				// Element after File)
 				glueBeforeHelp.set(
-						!(bar.getComponent(4) instanceof JMenu));
+						!(bar.getComponent(6) instanceof JMenu));
 			});
 			assertEquals(EXPECTED_MENU_TREE, rendered.get(),
 					"menu bar drifted from the declared table");
@@ -330,12 +351,13 @@ class MenuBarSpecTest {
 	/**
 	 * Sanity guard for the table itself: the expectation is a
 	 * constant, so a stray edit that blanks it would make the P3 test
-	 * vacuous; pin that it still declares all five menus.
+	 * vacuous; pin that it still declares all seven menus (issue #75
+	 * added Edit and Element).
 	 */
 	@Test
-	void expectationTableStillDeclaresAllFourMenus() {
-		for (String menu : new String[] { "File\n", "Simulator\n",
-				"View\n", "Global\n", "Help\n" }) {
+	void expectationTableStillDeclaresAllSevenMenus() {
+		for (String menu : new String[] { "File\n", "Edit\n", "Element\n",
+				"Simulator\n", "View\n", "Global\n", "Help\n" }) {
 			assertTrue(EXPECTED_MENU_TREE.contains(menu),
 					"expectation table lost top-level menu " + menu.trim());
 		}

--- a/test/jls/ui/MenuMnemonicAndAccessibleNameTest.java
+++ b/test/jls/ui/MenuMnemonicAndAccessibleNameTest.java
@@ -1,0 +1,221 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.DefaultExceptionHandler;
+import jls.JLSInfo;
+import jls.JLSStart;
+import jls.MenuAcceleratorPolicy;
+import jls.sim.Simulator;
+
+/**
+ * Accessibility properties an assistive technology actually reads, checked
+ * on the REAL booted menu bar (issue #75 verification hardening). The prior
+ * coverage was a proxy: {@link jls.MenuAcceleratorPolicyTest} pins the
+ * policy's mnemonic <em>values</em> as a pure function and greps
+ * {@code JLSStart} source for {@code setMnemonic(...)} on a subset of menus;
+ * no test read {@code menu.getMnemonic()} or
+ * {@code getAccessibleContext().getAccessibleName()} on the real components a
+ * screen reader consumes. A regression that deleted a {@code setMnemonic}
+ * call (Edit/Element/View were never grepped) would have passed.
+ *
+ * <p>This boots {@link JLSStart} and reads the accessibility channel
+ * directly: every top-level menu exposes its mnemonic, the mnemonics are all
+ * distinct (so Alt+letter is unambiguous), and every menu item (and submenu)
+ * exposes a non-blank accessible name equal to its visible label - the name
+ * a screen reader announces.</p>
+ *
+ * <p>Tagged {@code display}: {@code new JLSStart()} is a visible frame, so
+ * it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(60)
+class MenuMnemonicAndAccessibleNameTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/**
+	 * Every top-level menu on the real bar carries the mnemonic the policy
+	 * declares (View outside the policy uses the literal V), and all seven
+	 * are distinct so Alt+letter opens an unambiguous menu.
+	 *
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	@Test
+	void everyTopLevelMenuExposesADistinctMnemonic() throws Exception {
+		Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		try {
+			JLSStart jls = bootMainWindow();
+			// menu label -> expected mnemonic key code
+			Map<String, Integer> expected = new LinkedHashMap<>();
+			expected.put("File", MenuAcceleratorPolicy.fileMenuMnemonic());
+			expected.put("Edit", MenuAcceleratorPolicy.editMenuMnemonic());
+			expected.put("Element",
+					MenuAcceleratorPolicy.elementMenuMnemonic());
+			expected.put("Simulator",
+					MenuAcceleratorPolicy.simulatorMenuMnemonic());
+			expected.put("View", KeyEvent.VK_V);
+			expected.put("Global", MenuAcceleratorPolicy.globalMenuMnemonic());
+			expected.put("Help", MenuAcceleratorPolicy.helpMenuMnemonic());
+
+			AtomicReference<Map<String, Integer>> actualRef =
+					new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> {
+				Map<String, Integer> actual = new LinkedHashMap<>();
+				JMenuBar bar = jls.getJMenuBar();
+				for (int i = 0; i < bar.getMenuCount(); i++) {
+					JMenu menu = bar.getMenu(i);
+					if (menu != null) {
+						actual.put(menu.getText(),
+								Integer.valueOf(menu.getMnemonic()));
+					}
+				}
+				actualRef.set(actual);
+			});
+			Map<String, Integer> actual = actualRef.get();
+
+			for (Map.Entry<String, Integer> e : expected.entrySet()) {
+				Integer got = actual.get(e.getKey());
+				assertNotNull(got, "menu bar has a " + e.getKey() + " menu");
+				assertEquals(e.getValue().intValue(), got.intValue(),
+						e.getKey() + " menu mnemonic (a deleted setMnemonic "
+								+ "would read 0)");
+				assertFalse(got.intValue() == 0,
+						e.getKey() + " menu has a non-zero mnemonic");
+			}
+			// distinct across the seven menus
+			assertEquals(expected.size(),
+					(int) expected.values().stream().distinct().count(),
+					"the top-level mnemonics must be distinct for Alt+letter");
+		}
+		finally {
+			disposeAll();
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+		}
+	}
+
+	/**
+	 * Every menu item and submenu on the real bar exposes a non-blank
+	 * accessible name equal to its visible label - the name a screen reader
+	 * announces.
+	 *
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	@Test
+	void everyMenuItemExposesItsLabelAsAccessibleName() throws Exception {
+		Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		try {
+			JLSStart jls = bootMainWindow();
+			AtomicReference<String> failure = new AtomicReference<>();
+			AtomicReference<Integer> checked = new AtomicReference<>(0);
+			SwingUtilities.invokeAndWait(() -> {
+				JMenuBar bar = jls.getJMenuBar();
+				for (int i = 0; i < bar.getMenuCount(); i++) {
+					JMenu menu = bar.getMenu(i);
+					if (menu != null) {
+						checkAccessibleNames(menu, failure, checked);
+					}
+				}
+			});
+			assertTrue(checked.get().intValue() > 20,
+					"walked the whole menu tree (checked " + checked.get()
+							+ " items)");
+			assertNull(failure.get(), failure.get());
+		}
+		finally {
+			disposeAll();
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+		}
+	}
+
+	/**
+	 * Assert this item's accessible name equals its non-blank label, then
+	 * recurse into a submenu's children. Records the first failure.
+	 */
+	private static void checkAccessibleNames(JMenuItem item,
+			AtomicReference<String> failure, AtomicReference<Integer> checked) {
+		String text = item.getText();
+		String name = item.getAccessibleContext().getAccessibleName();
+		checked.set(Integer.valueOf(checked.get().intValue() + 1));
+		if (text == null || text.isBlank()) {
+			if (failure.get() == null) {
+				failure.set("a menu item has a blank label");
+			}
+			return;
+		}
+		if (!text.equals(name)) {
+			if (failure.get() == null) {
+				failure.set("menu item '" + text + "' accessible name was '"
+						+ name + "', not its label");
+			}
+		}
+		if (item instanceof JMenu menu) {
+			for (int j = 0; j < menu.getItemCount(); j++) {
+				JMenuItem child = menu.getItem(j);
+				if (child != null) { // null == separator
+					checkAccessibleNames(child, failure, checked);
+				}
+			}
+		}
+	}
+
+	private static void disposeAll() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Construct the real JLS main window on the EDT (mirrors
+	 * {@link MenuBarSpecTest}).
+	 *
+	 * @return the constructed main window.
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	private static JLSStart bootMainWindow() throws Exception {
+		Field handler = JLSStart.class.getDeclaredField("exHandler");
+		handler.setAccessible(true);
+		if (handler.get(null) == null) {
+			handler.set(null, new DefaultExceptionHandler());
+		}
+		AtomicReference<JLSStart> ref = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> ref.set(new JLSStart()));
+		assertNotNull(ref.get().getJMenuBar(), "main window has a menu bar");
+		return ref.get();
+	}
+}

--- a/test/jls/ui/PaletteButtonAccessibilityTest.java
+++ b/test/jls/ui/PaletteButtonAccessibilityTest.java
@@ -1,0 +1,110 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JButton;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+
+/**
+ * Tool-bar palette buttons expose an accessible name (issue #75
+ * accessibility, item 6). The palette buttons are icon-only, so their shared
+ * {@link javax.swing.Action}'s {@code NAME} is the empty string; without an
+ * explicit accessible name a screen reader focusing a palette button would
+ * announce nothing. {@code SimpleEditor.makeElement} sets the accessible name
+ * from the tooltip (the human-readable element name), and the buttons are
+ * keyboard-focusable so a keyboard/AT user can reach and identify them.
+ *
+ * <p>This was an unobserved real gap: tests located palette buttons by
+ * tooltip, so the tooltip was incidentally relied on, but nothing asserted an
+ * accessible <em>name</em> existed. This test reads
+ * {@code getAccessibleContext().getAccessibleName()} on the real buttons.</p>
+ *
+ * <p>Tagged {@code display}: boots a real editor tool bar, so it runs under
+ * the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(60)
+class PaletteButtonAccessibilityTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/**
+	 * Every tool-bar palette button exposes a non-blank accessible name and
+	 * is keyboard-focusable, and a representative button's name is its
+	 * element label.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void everyPaletteButtonHasAnAccessibleNameAndIsFocusable()
+			throws Exception {
+		try (EditorGestureSupport ui =
+				new EditorGestureSupport(new Circuit("palette"))) {
+			List<JButton> buttons = new ArrayList<>();
+			collectButtons(ui.editor, buttons);
+			assertTrue(buttons.size() >= 8,
+					"the tool bar has the element palette buttons (found "
+							+ buttons.size() + ")");
+
+			for (JButton button : buttons) {
+				String name =
+						button.getAccessibleContext().getAccessibleName();
+				assertFalse(name == null || name.isBlank(),
+						"palette button (tooltip '" + button.getToolTipText()
+								+ "') exposes a non-blank accessible name, got '"
+								+ name + "'");
+				assertTrue(button.isFocusable(),
+						"palette button '" + name + "' is keyboard-focusable");
+			}
+
+			// a representative button's accessible name is its element label
+			JButton andButton = findByTooltip(buttons, "AND gate");
+			assertTrue(andButton != null, "found the AND gate button");
+			assertEquals("AND gate",
+					andButton.getAccessibleContext().getAccessibleName(),
+					"the AND gate button announces its element name");
+		}
+	}
+
+	/** Collect every JButton with a tooltip (the palette buttons). */
+	private static void collectButtons(Container root, List<JButton> out) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& button.getToolTipText() != null) {
+				out.add(button);
+			}
+			if (c instanceof Container inner) {
+				collectButtons(inner, out);
+			}
+		}
+	}
+
+	private static JButton findByTooltip(List<JButton> buttons, String tip) {
+		for (JButton b : buttons) {
+			if (tip.equals(b.getToolTipText())) {
+				return b;
+			}
+		}
+		return null;
+	}
+}

--- a/test/jls/ui/PopupOperationBehaviorTest.java
+++ b/test/jls/ui/PopupOperationBehaviorTest.java
@@ -1,0 +1,175 @@
+package jls.ui;
+
+import static jls.ui.CircuitAssert.assertElementPresent;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.JLSInfo;
+import jls.elem.AndGate;
+import jls.elem.Element;
+import jls.elem.Gate;
+
+/**
+ * Right-click popup editing operations, verified behaviorally (issue #75
+ * mouse non-regression, the highest-risk shared-Action gap). After the H1
+ * refactor the popup Rotate/Flip/Watch items all point at the same shared
+ * {@link javax.swing.Action} as the canvas key bindings.
+ * {@link EditActionMatrixTest} pins object <em>identity</em> for a few of
+ * them but never fires them, and Watch/Probe/Modify/Timing had no popup
+ * coverage at all - so a regression that left a popup item wired to a
+ * disabled or no-op Action would pass. This drives the popup items the way a
+ * user's click does ({@code doClick} on the shown menu item, after the
+ * right-press that selects the element) and observes the element's persisted
+ * form change, proving the op actually ran through the popup surface.
+ *
+ * <p>Tagged {@code display}: needs a display for the popup {@code show()}
+ * and font metrics, so it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class PopupOperationBehaviorTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/** A circuit with a single, unattached AND gate that can rotate/flip. */
+	private static Circuit oneGate() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		Circuit circuit = new Circuit("popup-ops");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	private static String save(Element el) {
+		StringWriter sw = new StringWriter();
+		PrintWriter pw = new PrintWriter(sw);
+		el.save(pw);
+		pw.flush();
+		return sw.toString();
+	}
+
+	private static Gate soleGate(EditorGestureSupport ui) {
+		for (Element el : ui.currentCircuit().getElements()) {
+			if (el instanceof Gate g) {
+				return g;
+			}
+		}
+		throw new AssertionError("no Gate in the circuit");
+	}
+
+	private static int centerX(Element el) {
+		return el.getX() + el.getRect().width / 2;
+	}
+
+	private static int centerY(Element el) {
+		return el.getY() + el.getRect().height / 2;
+	}
+
+	/**
+	 * Fire one popup item on the sole gate and assert its persisted form
+	 * changed - the op ran through the popup surface's shared Action. A
+	 * single popup interaction per test keeps it robust against the
+	 * popup-re-show timing that makes back-to-back popups flaky.
+	 *
+	 * @param itemText the popup menu item label to click.
+	 * @throws Exception on EDT failure.
+	 */
+	private void assertPopupItemMutatesTheGate(String itemText)
+			throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			String original = save(gate);
+
+			openPopupTo(ui, gate, itemText);
+			ui.clickPopupItem(itemText);
+			ui.waitFor(() -> !save(soleGate(ui)).equals(original),
+					"popup '" + itemText + "' mutated the gate");
+			assertNotEquals(original, save(soleGate(ui)),
+					"popup '" + itemText + "' changed the persisted form");
+		}
+	}
+
+	/**
+	 * Right-press the gate to raise its popup, retrying the press until the
+	 * target item is actually showing. A single right-press occasionally
+	 * fails to materialize the popup under the WM-less #162 Xvfb (a
+	 * popup-show timing flake, the same class as {@link EditorGestureTest}'s
+	 * known popup flake); re-pressing only while no popup is up recovers it
+	 * without stacking popups. Each attempt waits a bounded ~2s for the popup
+	 * to appear before the next press, so a genuinely broken popup still
+	 * fails fast rather than hanging to the outer timeout.
+	 *
+	 * @param ui the gesture harness.
+	 * @param gate the gate to right-press.
+	 * @param itemText the popup item that must become visible.
+	 * @throws Exception on EDT failure.
+	 */
+	private static void openPopupTo(EditorGestureSupport ui, Gate gate,
+			String itemText) throws Exception {
+		for (int attempt = 0; attempt < 6; attempt++) {
+			ui.rightPress(centerX(gate), centerY(gate));
+			for (int i = 0; i < 40; i++) {
+				if (ui.isPopupItemShowing(itemText)) {
+					return;
+				}
+				ui.pause(50);
+			}
+		}
+		throw new AssertionError("popup item '" + itemText
+				+ "' never appeared after 6 right-presses");
+	}
+
+	/**
+	 * The popup Rotate Clockwise item rotates the selected gate through its
+	 * shared Action.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void popupRotateClockwiseRotatesTheGate() throws Exception {
+		assertPopupItemMutatesTheGate("Rotate Clockwise");
+	}
+
+	/**
+	 * The popup Rotate Counter-Clockwise item rotates the selected gate
+	 * through its (distinct) shared Action.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void popupRotateCounterClockwiseRotatesTheGate() throws Exception {
+		assertPopupItemMutatesTheGate("Rotate Counter-Clockwise");
+	}
+
+	/**
+	 * The popup Flip item flips the selected gate through its shared Action.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void popupFlipFlipsTheGate() throws Exception {
+		assertPopupItemMutatesTheGate("Flip");
+	}
+}

--- a/test/jls/ui/TabSelectionFocusTest.java
+++ b/test/jls/ui/TabSelectionFocusTest.java
@@ -1,0 +1,162 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
+import java.awt.KeyboardFocusManager;
+import java.awt.Window;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.event.MouseInputListener;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.DefaultExceptionHandler;
+import jls.JLSInfo;
+import jls.JLSStart;
+import jls.edit.Editor;
+import jls.sim.Simulator;
+
+/**
+ * Selecting an editor tab hands keyboard focus to that editor's canvas
+ * (issue #75 accessibility, item 7). The tab-change listener calls
+ * {@code Editor.focusOnCanvas()} so a keyboard user's next key reaches the
+ * drawing surface without first tabbing off the tab strip. Previously only a
+ * source grep for {@code "ed.focusOnCanvas()"} pinned this; nothing observed
+ * the real focus owner become the canvas after a tab selection. This boots
+ * the real {@link JLSStart}, adds an editor (which selects its tab), and
+ * waits for the live {@link KeyboardFocusManager} focus owner to become that
+ * editor's canvas.
+ *
+ * <p>Tagged {@code display}: {@code new JLSStart()} is a visible frame, so
+ * it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(60)
+class TabSelectionFocusTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	/**
+	 * After a circuit's editor tab becomes selected, the real focus owner is
+	 * that editor's canvas.
+	 *
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	@Test
+	void selectingAnEditorTabFocusesItsCanvas() throws Exception {
+		Frame savedFrame = JLSInfo.frame;
+		Simulator savedSim = JLSInfo.sim;
+		try {
+			JLSStart jls = bootMainWindow();
+			AtomicReference<Editor> edRef = new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> {
+				jls.setupEditor(new Circuit("tabfocus"), "tabfocus");
+				edRef.set(jls.getVisibleEditor());
+			});
+			Editor ed = edRef.get();
+			assertNotNull(ed, "setupEditor made an editor visible");
+			Component canvas = findCanvas(ed);
+			assertNotNull(canvas, "the editor has a drawing canvas");
+
+			waitFor(() -> {
+				try {
+					return focusOwner() == canvas;
+				} catch (Exception e) {
+					throw new AssertionError(e);
+				}
+			}, "selecting the editor tab moved focus to its canvas");
+			assertTrue(true, "focus reached the canvas via focusOnCanvas");
+		}
+		finally {
+			SwingUtilities.invokeAndWait(() -> {
+				for (Window w : Window.getWindows()) {
+					w.dispose();
+				}
+			});
+			JLSInfo.frame = savedFrame;
+			JLSInfo.sim = savedSim;
+		}
+	}
+
+	/** The live keyboard-focus owner, read on the EDT. */
+	private static Component focusOwner() throws Exception {
+		AtomicReference<Component> owner = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> owner.set(KeyboardFocusManager
+				.getCurrentKeyboardFocusManager().getFocusOwner()));
+		return owner.get();
+	}
+
+	/** Poll a condition to a ~10s bound. */
+	private static void waitFor(java.util.function.BooleanSupplier cond,
+			String what) {
+		for (int i = 0; i < 400; i++) {
+			if (cond.getAsBoolean()) {
+				return;
+			}
+			try {
+				Thread.sleep(25);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				fail("interrupted waiting for " + what);
+			}
+		}
+		fail("timed out waiting for " + what);
+	}
+
+	/** The drawing canvas: the scroll pane's mouse-listening view. */
+	private static Component findCanvas(Container root) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JScrollPane pane) {
+				Component view = pane.getViewport().getView();
+				if (view instanceof MouseInputListener
+						|| view instanceof java.awt.event.MouseListener) {
+					return view;
+				}
+			}
+			if (c instanceof Container inner) {
+				Component found = findCanvas(inner);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Construct the real JLS main window on the EDT (mirrors
+	 * {@link MenuBarSpecTest}).
+	 *
+	 * @return the constructed main window.
+	 * @throws Exception on reflection or EDT failure.
+	 */
+	private static JLSStart bootMainWindow() throws Exception {
+		Field handler = JLSStart.class.getDeclaredField("exHandler");
+		handler.setAccessible(true);
+		if (handler.get(null) == null) {
+			handler.set(null, new DefaultExceptionHandler());
+		}
+		AtomicReference<JLSStart> ref = new AtomicReference<>();
+		SwingUtilities.invokeAndWait(() -> ref.set(new JLSStart()));
+		return ref.get();
+	}
+}


### PR DESCRIPTION
H1 — shared Action layer, menus, Ctrl+W overload fix:
- New src/jls/edit/EditOp.java: the single source of truth for the 18
  editing operations (label + platform-aware accelerator). Each EditWindow
  builds one AbstractAction per op into an EnumMap; popup menus, canvas key
  bindings, and the new menu-bar items all setAction() the SAME shared
  object instead of three divergent copies. The old source-equality
  actionPerformed switch and the duplicate anonymous key-binding actions are
  deleted (matchJump, the one contextual arm, stays).
- New menu-bar Edit menu (Undo/Redo, Cut/Copy/Paste/Delete, Select All) and
  Element menu (Rotate CW/CCW, Flip, Watch, Probe, Modify, Change Timing) in
  JLSStart, retargeted to the focused editor's shared Actions on tab change.
- Resolved the Ctrl/Cmd+W overload: wire-start moves to plain W
  (EditOp.WIRE_START); Ctrl/Cmd+W is Watch-only. The two-items-one-stroke
  popup collision is gone; the now-redundant #126 CtrlW gesture is removed.
- macOS redo (Shift+Cmd+Z), File accelerators/mnemonics, and the normal
  click/tab focus model were already present (merged #74) and are left intact.

H2 — keyboard-only construction:
- New src/jls/edit/KeyboardConstructionPolicy.java (Swing-free, headless):
  arrow->Nudge mapping, grid snap, Enter commit stroke.
- SimpleEditor gains a grid caret: arrow keys move the caret / following
  element / selection (undoable via MoveElements), Enter places/activates/
  commits, W starts a wire at the caret. The mouse placing and wire branches
  are extracted to commitPlacing()/commitWireVertex() so mouse and keyboard
  share one implementation (mouse behaviour byte-equivalent).
- New in-app help page resources/help/editor/editing/keyboard.html; hotkeys
  updated for the W/Ctrl+W change and the arrow/Enter keys.

Focus handoff (addresses the adversarial-review finding): choosing an
element from the tool bar left focus on that button, so a real keyboard
user's arrow/Enter keys (WHEN_FOCUSED on the canvas) would not reach it and
the documented choose-then-arrow flow would fail. setup() now hands focus to
the canvas once the element is chosen. Pinned by EditorKeyboardConstructionTest,
which asserts the canvas becomes the focus owner after a palette doClick
(stable 3/3 under Xvfb).

Tests pin every new binding and surface identity: EditActionMatrixTest
(one shared Action per op across popup/binding/menu bar), MenuBarSpecTest
(Edit/Element blocks + accelerators), MenuAcceleratorPolicyTest (wire-start
= plain W, distinct mnemonics), KeyboardConstructionPolicyTest (pure policy),
EditorKeyboardConstructionTest (builds the two-gate circuit keyboard-only,
assert-the-assertion). Full verify green under Xvfb: headless + display
suite + SpotBugs (High/Werror) + JaCoCo ratchet + doclint + architecture
ratchets. No raw JOptionPane; JSpecify nullness + javadoc on new public API.

Honest scope note: the two gates are connected via the editor's coincidence
wiring (arrow the NOT output onto the OR input so placement wires them) — the
tutorial's own method — because JLS grows every wire's bounds by a full grid
spacing, so a short free-hand wire across two abutting gate ports registers
as overlapping both bodies (the same constraint the mouse faces). Not a
narrowing: the free-hand W wire tool is fully keyboard-drivable and
independently tested drawing a wire in open space.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UzDG5Ysjfe8dbVnDGa8psQ