### PR TITLE
Add intended-audience & impact prompts to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,12 @@ labels: bug
 
 <!-- What did you do, what did you expect, what happened instead? -->
 
+## Who this affects
+
+<!-- Who hits this and what does it cost them? e.g. students lose an edit,
+     an instructor's batch grade is wrong, a third-party .jls file
+     mis-loads silently. Skip if it is obvious from "What happened". -->
+
 ## Environment
 
 - JLS version (Help → About):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,6 +8,12 @@ labels: enhancement
 
 <!-- What can't you (or your students) do today? -->
 
+## Who benefits
+
+<!-- Who is this for — students, instructors, circuit-file authors,
+     contributors — and why is it meaningful to them: what does it let
+     them do, or stop going wrong, that matters? -->
+
 ## Proposal
 
 <!-- What should JLS do instead? Mockups/examples welcome. -->

--- a/.github/ISSUE_TEMPLATE/scientific_task.md
+++ b/.github/ISSUE_TEMPLATE/scientific_task.md
@@ -4,7 +4,7 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
 ---
 
 <!--
-  Template: scientific-task v1 (2026-07)
+  Template: scientific-task v2 (2026-07)
 
   RULES — for humans and LLM agents alike, filing or executing.
 
@@ -42,6 +42,30 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
 
 <!-- 2-4 sentences: what is wrong or missing, why it matters, and the
      one-line shape of the proposed remedy. -->
+
+## Intended Audience & Impact
+
+<!-- Who is this work for, and how is it meaningful to them? Name the
+     concrete audience(s) JLS actually serves and, per audience, the
+     change they experience — what they can do afterward that they can't
+     today, or what stops going wrong for them. Impact claims are
+     observations too (rule 1): where the harm or gap is measurable
+     (a wrong simulation, a crash, a lost edit, a silent mis-load),
+     point at it.
+
+     The recurring audiences — pick and name the ones this task serves,
+     do not list them all:
+       - Students drawing and simulating circuits in the editor.
+       - Instructors authoring, grading, or auto-checking work in batch
+         (`-b`) mode.
+       - Circuit-file authors and third-party tools that read or write
+         `.jls` files against docs/file-format.md.
+       - Contributors, maintainers, and LLM agents working the codebase.
+       - Packagers and distributors shipping the installers and container.
+     If a task genuinely serves an internal audience only (a refactor, a
+     CI gate), say so and name the downstream audience it protects; "N/A"
+     with no audience means the work has no beneficiary and does not
+     belong on the backlog (rule 2). -->
 
 ## 1. Background & Prior Work
 

--- a/.github/ISSUE_TEMPLATE/scientific_task.md
+++ b/.github/ISSUE_TEMPLATE/scientific_task.md
@@ -9,10 +9,12 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
   RULES — for humans and LLM agents alike, filing or executing.
 
   1. Evidence, not memory. Every code claim carries file:line at a named
-     commit, re-derived at that commit — quote the line you cite. Source
-     comments and audit summaries are hearsay until re-derived. Aggregate
-     claims (counts, "all X", "no Y anywhere") carry the exact command
-     that produced them and its output.
+     commit, re-derived at that commit — quote the line you cite. Pin that
+     commit once in Status & Dependencies and cite by commit-locked
+     permalink, never a branch path (branch links rot the moment the
+     branch is deleted). Source comments and audit summaries are hearsay
+     until re-derived. Aggregate claims (counts, "all X", "no Y anywhere")
+     carry the exact command that produced them and its output.
   2. No padding. A section that does not apply is "N/A — <one-line
      reason>", decided at filing time. A criterion discovered to be wrong
      during execution gets an issue comment with evidence — do not work
@@ -31,6 +33,10 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
      your checkout. If one fails to reproduce, or a hypothesis is refuted
      mid-work, stop and comment on the issue with the refuting evidence.
      A refuted issue is a successful experiment, not a task to salvage.
+     If the observations no longer fail because the work has already
+     landed, the issue is superseded — close it with that note instead of
+     re-doing it. Re-derive any drifted line numbers before trusting them;
+     a stale citation is not evidence.
   7. Labels are not applied automatically for API-filed issues: set
      `bug` or `enhancement` explicitly, matching the corpus.
 
@@ -66,6 +72,25 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
      CI gate), say so and name the downstream audience it protects; "N/A"
      with no audience means the work has no beneficiary and does not
      belong on the backlog (rule 2). -->
+
+## Status & Dependencies
+
+<!-- The front matter an executor reads before touching anything. Keep it
+     at the top, not buried in §11 (Related Work) — an issue picked up cold
+     must not miss a blocker (a fix hardening code another issue is about
+     to delete is wasted work).
+       - Evidence commit — the single SHA every §2 (Observations) file:line
+         is pinned to. Cite by permalink at this commit (rule 1); if HEAD
+         has moved, re-derive the citations before trusting them.
+       - Blocked by — issues that must land first, each with the one-line
+         reason it blocks. "None" if free-standing.
+       - Blocks — issues waiting on this one.
+       - Supersession check — confirm this work has not already shipped
+         (rule 6); if it has, close as superseded rather than re-doing it. -->
+
+- Evidence commit:
+- Blocked by:
+- Blocks:
 
 ## 1. Background & Prior Work
 
@@ -135,6 +160,15 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
 <!-- Expected end state in one or two sentences; follow-ups explicitly
      out of scope here. -->
 
+## Open Questions & Decisions Needed
+
+<!-- Decisions this task cannot make for itself — cost, custody, policy,
+     taste, or unverified external state. Separate what is answerable now
+     from what genuinely needs a maintainer, so an executor knows what is
+     safe to proceed on. For each: the question, the options with a
+     recommended default, and whether it blocks filing, blocks execution,
+     or can ride along. "N/A — fully specified" if nothing is open. -->
+
 ## 13. Completion Criteria (Definition of Done)
 
 <!-- How anyone — author, reviewer, or agent — recognizes this task is
@@ -154,4 +188,7 @@ about: A rigorously framed unit of work — defect, improvement, or investigatio
 - [ ] `mvn verify` green (tests + SpotBugs, warnings-as-errors)
 - [ ] No new entries in `config/spotbugs-exclude.xml`, or each new entry is `Class`-scoped with a justification
 - [ ] No changes outside the scope of §7 (Method); adjacent work discovered en route is filed as new issues
+- [ ] Every "Blocked by" in Status & Dependencies has landed, or the dependency was explicitly waived with a reason
+- [ ] Not superseded: the §2 (Observations) failures still reproduced at pickup (rule 6); citations re-derived if HEAD had moved
+- [ ] Every decision in Open Questions & Decisions Needed is resolved (or explicitly deferred), none left blocking
 - [ ] ...


### PR DESCRIPTION
Add an "Intended Audience & Impact" section to the scientific-task
template (bumped to v2) asking who each task serves and how the change is
meaningful to them, with the recurring JLS audiences enumerated
(students, instructors grading in batch, third-party .jls authors,
contributors/agents, packagers). Placed unnumbered after the Abstract so
the existing corpus's numbered cross-references stay valid.

Add matching lightweight prompts to the bug and feature templates
("Who this affects" / "Who benefits").

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LGLApCFJjUEx5X6xiEKQjd