### PR TITLE
Grand-architecture determination + module-program planning tooling

### DIFF
--- a/docs/architecture-project-setup.md
+++ b/docs/architecture-project-setup.md
@@ -1,0 +1,156 @@
+# Setting up the grand-architecture project, milestones, and labels
+
+The grand-architecture module program was planned from a remote session
+where the GitHub surface was an MCP server with **no milestone/label
+creation and no `gh`**. So the tracking issue (#224) and its sub-issues
+exist, but the *repo-level scaffolding* — Milestone objects, a label
+taxonomy, and a Projects v2 board — does not. This page is the runbook to
+create it from a machine where `gh` is available (e.g. running `claude`
+locally).
+
+Everything here is captured as one idempotent script,
+[`scripts/setup-architecture-project.sh`](../scripts/setup-architecture-project.sh);
+this document explains what it does, the mappings it encodes, and the
+manual `gh` commands if you prefer to run steps piecemeal.
+
+## Prerequisites
+
+```sh
+gh --version          # >= 2.40
+gh auth status        # authenticated against github.com
+# Projects v2 needs an extra scope the default login may lack:
+gh auth refresh -s project,read:project
+```
+
+## Run it
+
+```sh
+# from the repo root, on the architecture branch or master
+DRY_RUN=1 scripts/setup-architecture-project.sh   # preview every mutation
+scripts/setup-architecture-project.sh             # do it (safe to re-run)
+
+# variants
+SKIP_PROJECT=1 scripts/setup-architecture-project.sh   # milestones + labels only
+OWNER=anadon REPO=JLS scripts/setup-architecture-project.sh
+```
+
+The script is **idempotent**: milestones are created only if a milestone
+of that exact title is absent, labels are `--force`d (create-or-update),
+and issue milestone/label assignments are naturally idempotent. Re-running
+after new issues are added simply extends the assignments.
+
+If you are driving this with `claude` locally, a one-line prompt is
+enough, e.g. *"run scripts/setup-architecture-project.sh; if the Projects
+step is skipped for scope, refresh the `project` scope and re-run just
+that step."*
+
+## What it creates
+
+### 1. Milestones (M0–M4)
+
+Titles and issue membership mirror the phase checklists in #224. The
+script assigns each issue to its milestone via
+`PATCH /repos/:owner/:repo/issues/:n`.
+
+| Milestone | Issues |
+|---|---|
+| **M0 — Boundary seed & type-safety** | #78, #167 (shipped) · #93, #94, #95 |
+| **M1 — Headless kernel (keystone)** | #77 |
+| **M2 — Module runtime & extension points** | #220, #223, #222 |
+| **M3 — Consumer modules** | #84, #59, #61, #62, #63, #213, #215, #163, #168, #169, #170, #171, #200, #214, #76 |
+| **M4 — External providers & scale** | #212, #221 |
+
+The umbrella tracker #224 is intentionally left milestone-less.
+
+Manual equivalent for one milestone + assignment:
+
+```sh
+num=$(gh api -X POST repos/anadon/JLS/milestones \
+        -f title="M1 — Headless kernel (keystone)" \
+        -f description="Extract the enforced-headless jls.core (#77)." --jq '.number')
+gh api -X PATCH repos/anadon/JLS/issues/77 -F milestone="$num"
+```
+
+### 2. Labels
+
+A small, orthogonal taxonomy — a program label, a decision kind, phase
+labels, and area labels:
+
+| Label | Purpose |
+|---|---|
+| `architecture` | the whole module program (tracking #224) |
+| `kind:decision` | a decision-and-record issue (#221, #222) |
+| `phase:M0`…`phase:M4` | mirror the milestones for filtering without the milestone dropdown |
+| `area:core` / `area:module` / `area:gui` / `area:hdl` / `area:collab` / `area:batch` / `area:distribution` | subsystem |
+
+`phase:*` labels are applied to exactly the issues in each milestone.
+`area:*`/`kind:*`/`architecture` are **seeded on the core program issues**
+(#77/#78/#167/#212/#220–#224 and a few consumers) so the taxonomy exists
+and is correct where it is applied; extend the `LABEL_ISSUES` map in the
+script to cover the rest of the backlog as you triage — the script does
+not attempt to auto-classify all ~50 open issues by area, on purpose.
+
+Manual equivalent:
+
+```sh
+gh label create "phase:M1" --color 7fdbca --description "Program phase M1" --force
+gh issue edit 77 --add-label "area:core,phase:M1,architecture"
+```
+
+### 3. Projects v2 board
+
+Creates a user project titled **"JLS Grand Architecture"** (idempotent by
+title) and adds the tracker plus every phased issue as items. Because the
+milestones are already assigned, you do **not** need a custom field for
+the phases — open the board and add a **Group by: Milestone** view to get
+M0–M4 swimlanes for free.
+
+Manual equivalent:
+
+```sh
+num=$(gh project create --owner anadon --title "JLS Grand Architecture" --format json --jq '.number')
+gh project item-add "$num" --owner anadon --url https://github.com/anadon/JLS/issues/224
+# …repeat item-add per issue; then in the UI: New view → Board → Group by → Milestone
+```
+
+If `gh project` errors with a scope message, run the
+`gh auth refresh -s project,read:project` above and re-run
+`SKIP_PROJECT=` (i.e. just the project step) — the milestone/label steps
+already done are untouched.
+
+## Cross-links and dependencies (optional, mostly already done)
+
+- **Narrative cross-links** between issues already exist: the new issues'
+  bodies and the comments on #77/#78/#167/#212/#59/#163/#96/#84 reference
+  #224 and each other. Nothing to run.
+- **Sub-issue hierarchy** (#220–#223 under #224) is already created via
+  the native sub-issues API. To add more children later:
+
+  ```sh
+  # GraphQL: attach issue N as a sub-issue of #224
+  gh api graphql -f query='mutation($p:ID!,$c:ID!){
+    addSubIssue(input:{issueId:$p, subIssueId:$c}){ issue { number } } }' \
+    -f p="$(gh api repos/anadon/JLS/issues/224 --jq .node_id)" \
+    -f c="$(gh api repos/anadon/JLS/issues/NNN --jq .node_id)"
+  ```
+
+- **Blocking dependencies** (a stronger "blocked by" than a mention) can be
+  set with the issue-dependencies REST API if you want the machine-readable
+  edges of the spine — e.g. #212 blocked by #220 and #222; #220, #221, #222
+  blocked by #77:
+
+  ```sh
+  gh api -X POST repos/anadon/JLS/issues/212/dependencies/blocked_by \
+    -F issue_id="$(gh api repos/anadon/JLS/issues/220 --jq .id)"
+  ```
+
+  (This endpoint is newer; skip it if your `gh`/API version rejects it —
+  the milestone + tracker structure already conveys the ordering.)
+
+## After running
+
+Verify at `https://github.com/anadon/JLS/milestones` and the repo's
+**Projects** tab, then update the checkboxes in #224 as milestones
+complete. When `docs/grand-architecture.md` merges to `master`, the
+`blob/<branch>` links in the program's issues can be repointed to
+`blob/master` (a find-and-replace in the five issue bodies).

--- a/docs/grand-architecture.md
+++ b/docs/grand-architecture.md
@@ -5,284 +5,490 @@ Where `ARCHITECTURE.md` maps HEAD — where code lives *today* — this
 document answers a different question: **given how JLS is actually used,
 what it could become, and every currently-open issue, what is the single
 most correct target architecture to converge on?** It is a determination,
-not a work order: it names the shape, the keystone, the layer boundaries,
-the sequence, and — just as importantly — what is deliberately excluded.
+not a work order: it names the shape, the keystone, the connective
+mechanism, the layer boundaries, the sequence, and — just as importantly —
+what is deliberately excluded.
 
-The central finding up front: **the open issues are not a backlog, they
-are a latent architecture.** All 46 open issues map cleanly onto six
-layers with one enabling triad at the bottom. That they map so cleanly is
-the strongest evidence that the target below is the right one — it was
-already being built toward, one issue at a time, without a picture of the
-whole. This document draws the picture.
+The central finding, stated once and defended throughout: **the open
+issues are not a backlog, they are a latent architecture — a set of
+modules wired by dependencies and ordering that no one has yet drawn as a
+whole.** All ~46 open issues map cleanly onto six layers over one enabling
+triad, and the layers are already emerging as packages (`jls.elem` with a
+shipped `ElementRegistry`, `jls.collab.{op,crdt,net,session}`,
+`jls.hdl.{scan,yosys,layout,imp}`). What is missing is (1) the enforced
+headless core boundary and (2) an explicit **module/plugin interface with
+full dependency and ordering support** to replace today's implicit package
+coupling and closed static registry. This revision centers the design on
+that mechanism, grounded in a survey of how comparable tools and other
+ecosystems solved the same problems.
 
 ## 1. What JLS is (the load-bearing facts)
 
-Any target has to hold these fixed, because they are the actual product:
+Any target must hold these fixed, because they are the actual product:
 
 - **A single self-contained jar** is the deployment model students and
-  labs rely on. Help works offline and version-locked to the binary
-  (recorded decision, `ARCHITECTURE.md`); installers bundle a runtime so
-  no JDK is required. The architecture may not assume a network, a
-  server, or an install step.
+  labs rely on; help works offline and version-locked to the binary
+  (recorded decision, `ARCHITECTURE.md`). The architecture may not assume
+  a network, a server, or an install step. This single constraint, more
+  than any other, decides the plugin model (see §4).
 - **Two co-equal front ends, not one.** The GUI editor (Swing) *and* the
-  headless batch/grading surface (`-b -t`, VCD, image/Verilog export,
-  the `ghcr.io/anadon/jls` container) are both first-class. Autograders
-  and CI consume the headless surface; the batch interface is already a
-  documented stability contract (`docs/batch-interface.md`).
+  headless batch/grading surface (`-b -t`, VCD, image/Verilog export, the
+  `ghcr.io/anadon/jls` container) are both first-class; the batch
+  interface is already a stability contract (`docs/batch-interface.md`).
 - **~69k lines of Swing-dominated Java**, single-maintainer, audience of
-  first-year students and their instructors. This was assessed
-  explicitly against a Kotlin/Scala rewrite and the answer was **no**
-  (#96): the correct move is Java-25-baseline + Kotlin's transferable
-  practices as *compiler-enforced* properties, incrementally.
-- **A schematic-first model with typed pins, bit-widths, wire nets,
-  subcircuits, and a discrete-event simulator.** That element graph is
-  the asset everything else walks — the exporter's input, the registry's
-  subject, the replication unit, the autograder's oracle.
+  first-year students and instructors. Assessed explicitly against a
+  Kotlin/Scala rewrite → **no** (#96): Java-25 baseline plus Kotlin's
+  transferable practices as *compiler-enforced* properties, incrementally.
+- **A schematic-first model** — typed pins, bit-widths, wire nets,
+  subcircuits, a discrete-event simulator. That element graph is the asset
+  everything else walks.
 
 ## 2. What JLS could be (the latent product)
 
-The open issues, read together, describe a tool considerably larger than
-"draw gates and watch them blink." Three trajectories are already funded
-by real issues and real prototypes:
+Three trajectories are already funded by real issues and working code:
 
-- **A serious datapath / CPU teaching tool.** The `riscv/` tree already
-  builds a working RV32I CPU strictly through the model, with a
-  reference simulator and differential fuzzing; #201 (multi-port register
-  file, sign/zero-extend), #199 (synchronous memory), #202 (RV32I worked
-  example as an integration golden) push JLS from gate toys to full
-  single-cycle/pipelined processors.
+- **A serious datapath / CPU teaching tool.** `riscv/` already builds a
+  working RV32I CPU through the model, with a reference simulator and
+  differential fuzzing; #201 (register file, sign/zero-extend), #199
+  (synchronous memory), #202 (RV32I integration golden) push from gate
+  toys to real processors.
 - **An FPGA-deployment bridge.** #59/#61/#62/#63 stage HDL export →
-  Yosys-netlist import → black-box co-simulation; #213/#215 carry the
-  drawn circuit all the way to a bitstream on a named dev board. The
-  settled stance (research-backed) is *orchestrate external tools; never
-  reimplement HDL semantics in JLS* — Verilog's own semantics are
-  self-inconsistent (Lööw, OOPSLA 2025).
+  Yosys-netlist import → subprocess co-simulation; #213/#215 carry the
+  drawn circuit to a bitstream on a named board. Settled stance:
+  orchestrate external tools, never reimplement HDL semantics.
 - **A collaborative editor.** #163 and its stack (#167→#168→#169→#170→
-  #171) make circuits editable simultaneously, pure-P2P, no server — lab
-  pairs and instructor demos as the dominant case.
+  #171) — simultaneous, pure-P2P, no server.
 
-None of these is speculative fan-out. Each has a research doc, a tracking
-issue, and (for the first two) working code in-tree. The architecture's
-job is to let all three land *without a rewrite between them* — which
-they can, because they share a spine.
+Each has a research doc, a tracking issue, and (for the first two)
+in-tree code. The architecture's job is to let all three land *without a
+rewrite between them* — which they can, because they share a spine, and
+because that spine can be made an explicit module graph.
 
-## 3. The keystone: one headless kernel, everything else a consumer
+## 3. The keystone and the connective tissue
 
-The most correct architecture has exactly one non-negotiable move, and
-everything else follows from it:
+The most correct architecture has one non-negotiable structural move and
+one organizing mechanism.
 
-> **Extract an enforced-headless core — the circuit model, the
-> simulator, persistence, the element registry, and the operation
-> vocabulary — that imports no `java.awt`, no `javax.swing`, and no
-> `jls.edit`. Make the GUI one consumer of that core, not its center.**
+**The keystone (#77): one enforced-headless kernel.** Extract a
+`jls.core` — circuit model, element registry, discrete-event simulation,
+persistence, and the operation vocabulary — that imports no `java.awt`, no
+`javax.swing`, no `jls.edit`. Make the GUI *one consumer* of that core,
+not its center. Today there is no layering: the abstract `Simulator`
+imports Swing and `jls.edit`; `Circuit` holds an `Editor` back-reference;
+batch mode is headless only because a runtime flag is set; and `JLSInfo`
+is a ~640-reference public-static hub wiring everything to everything.
+This is the highest-leverage single change in the tracker, and — per the
+tool survey in §7 — it is the one discipline on which JLS is already
+*ahead* of Digital and Logisim (it has `HeadlessCoreRatchetTest`; they
+grew GUI-entangled cores and pay for it; KiCad is now pushing the same
+boundary *out of process*).
 
-This is #77's thesis, and it is load-bearing for nearly every future
-above. Today there is *no layering*: the abstract `Simulator` imports
-Swing and `jls.edit`; `Circuit` holds an `Editor` back-reference and its
-`draw` takes a `SimpleEditor`; batch mode is headless only because a
-runtime flag is set, not because any layer is structurally GUI-free; and
-`JLSInfo` is a ~640-reference public-static hub wiring it all together.
+**The connective tissue: a module/plugin interface with dependencies and
+ordering.** The six layers below are only real if something *enforces*
+their boundaries and *wires* them deterministically. Today that wiring is
+implicit (package imports + the `JLSInfo` bus) and the one explicit
+registry — `ElementRegistry` (#78, shipped) — is closed by construction
+(a static `List.of(...)`, no discovery). The determination of this
+revision: **generalize that registry into a first-class module system.**
+Every layer and feature-cluster becomes a *module* that declares what it
+`provides`, what it `requires`, and how it orders relative to others; the
+element-provider API (#212) stops being a special case and becomes the
+canonical instance of the mechanism. §4 specifies that interface; it is
+deliberately the *minimum* that captures the value, because JLS's
+constraints (§1) forbid the heavy machinery (§4, "rejected").
 
-Three extractions, taken together, are the **enabling triad**. Almost
-every high-value issue depends on at least one:
+**The enabling triad** — each is one seam of the module system, and each
+is already partly built:
 
-| Triad member | Issue | Unlocks |
-|---|---|---|
-| **Headless core** (model+sim+persistence, zero AWT/Swing) | #77 | Embedding (autograders, services), clean testing, any future UI, the container surface being headless *by construction* not by flag |
-| **Element registry** (self-describing `ElementType` descriptors, capability interfaces, one `Orientation`) | #78 | HDL import's cell→element table, palette generation, plugin providers (#212), collapsing the ~16-point element-authoring ritual to one |
-| **Operation layer** (`CircuitOp` vocabulary + single `OpSink`) | #167 | CRDT replication (#171), precise undo, per-peer attribution, targeted revert — and it *is* the hardened network surface (#170) |
+| Triad member | Issue | State | Role in the module system |
+|---|---|---|---|
+| **Headless core** | #77 | not yet extracted | the root module every other module requires; the boundary the ratchet enforces |
+| **Element registry** | #78 | `ElementRegistry`/`ElementType` shipped, closed | the *seed* of the plugin mechanism; already a descriptor+factory table with a build-enforced totality test |
+| **Operation layer** | #167 | `OpSink`/`CircuitOp` shipped under `jls.collab.op` | the single mutation entry point every dynamic consumer (collab, undo) observes |
 
-The registry and the operation layer are already emerging in-tree
-(`Gate.Kind`, the `#23` attribute registry, `src/jls/collab/op/`). The
-core boundary is the one still to be drawn, and it is the highest-leverage
-single change in the whole tracker.
+## 4. The JLS module model (the plugin interface)
 
-## 4. The target: six layers
+This section is the heart of the revision. It is synthesized from a survey
+of JVM plugin systems (JPMS, `ServiceLoader`, OSGi, Eclipse RCP, Jenkins,
+Gradle, IntelliJ), cross-ecosystem dependency/ordering theory (systemd,
+VS Code, Emacs/Neovim, Cargo/npm/Maven, Nix, Debian), and how EDA tools
+(Digital, Logisim, DigitalJS, KiCad) actually register and extend
+components. Sources in §7. The model is the **smallest set of mechanisms
+that captures ~90% of the value at ~10% of the framework weight**, chosen
+against JLS's single-jar / single-maintainer / static-first / compile-time-
+safe constraints.
+
+### 4.1 The manifest — declarative, evaluated without running module code
+
+Each module carries a static descriptor (a `record`, or an annotation
+processed at build time), readable *without* loading the module's logic —
+the universal precondition for ordering and lazy activation:
+
+```
+ModuleManifest(
+  id:         "hdl.export",                 // stable unique name
+  apiVersion: 1,                            // single integer; major = break
+  provides:   ["hdl-export", "verilog"],    // capability tokens
+  requires:   ["core", "element-registry"], // hard deps (token OR id)
+  optional:   ["board-constraints"],        // soft: use-if-present, never a gate
+  after:      ["core"],                     // ORDERING ONLY — separate axis
+  before:     [],
+  activation: OnCommand("export-verilog")   // Eager | OnCommand | OnEvent | OnDemand
+)
+```
+
+### 4.2 The seven rules (each earned by a specific prior-art pitfall)
+
+1. **Two separate axes: dependency ≠ ordering.** `requires`/`optional`
+   answer *does it exist / is it a gate*; `before`/`after` answer *when do
+   I run*. A `requires` edge implies an `after` edge, but `after` alone
+   pulls nothing in. This is systemd's `Requires=` vs `After=` and Emacs
+   `:requires` vs `:after` — the single most important decoupling, and the
+   #1 bug source when fused. It lets JLS say "order after the board module
+   *if present*" without forcing it to load.
+2. **A strength ladder, not a boolean.** `requires` (hard, missing → fail
+   loudly) vs `optional` (soft, missing → graceful no-op, and *never*
+   eager-loads its target). Debian `Depends`/`Recommends`; IntelliJ's
+   optional `config-file` slice; systemd `Requires`/`Wants`.
+3. **Capability tokens with concrete-name fallback.** `requires:
+   ["hdl-export"]` is satisfied by any module whose `provides` contains
+   that token; 0 providers → hard error, >1 → error unless a `|`
+   alternative is declared. This is Debian `Provides` / virtual packages —
+   substitutability with a trivial string-set match, *not* OSGi's
+   namespaced capability filters (rejected as over-weight).
+4. **Do not own a version solver.** One jar ⇒ one version of everything by
+   construction (Maven "nearest wins" / JPMS "refuse to choose"). Built-in
+   modules share JLS's exact types. External modules check a single
+   `apiVersion` integer (major = break) — no ranges, no SAT, no
+   backtracking. Diamond-dependency and duplicate-type bugs are structurally
+   impossible.
+5. **Resolve once, at startup, by topological sort; fail loud on cycles.**
+   Kahn's algorithm over `requires` + `after` edges; a remaining cycle is
+   reported *with its path*, never papered over (Jenkins/IntelliJ do
+   exactly this — not OSGi start-levels, which are overkill at JLS's scale).
+6. **Two-phase init as the only cycle escape hatch.** Phase 1 `register()`:
+   construct, publish `provides` tokens, touch no other module. Phase 2
+   `start()`: resolve `requires`/`optional` references (now all present)
+   and go live. A legitimate cycle is split across the phases (Spring bean
+   construction + `afterPropertiesSet`; OSGi `INSTALLED→RESOLVED→ACTIVE`).
+7. **Lazy activation, eager opt-in for the kernel core.** Default modules
+   to a trigger (`OnCommand`/`OnEvent`/`OnDemand`); only the true core
+   (`core`, config, look-and-feel) is `Eager` and topo-ordered at boot.
+   This is VS Code `activationEvents` / lazy.nvim triggers / Emacs
+   autoloads — and it *is* the literal meaning of #212's "gated behind
+   demonstrated demand": a provider registers a cheap shim (a palette
+   entry, a menu item) and its `start()` runs on first real use.
+
+### 4.3 Discovery, isolation, and inversion of control
+
+- **Discovery = static registration first, `ServiceLoader` for external
+  providers.** The compiled-in modules are a registry list you edit —
+  exactly today's `ElementRegistry.ALL` — so the common case stays fully
+  type-checked and needs no framework. `ServiceLoader` (JDK-native, zero
+  deps, works on classpath *and* module path, and `stream()` exposes
+  provider `type()` *without instantiating*) is added only for external
+  jars, only when #212's demand gate opens. Ordering never trusts
+  `ServiceLoader` iteration order (explicitly unspecified) — the topo-sort
+  in rule 5 owns it.
+- **Type-safe SPI.** The module and extension contracts are **sealed
+  interfaces** (`permits` the built-ins; `non-sealed` for external
+  providers) with **record** manifests, under `@NullMarked` (#93/#94/#95).
+  This is strictly better than every XML-descriptor system surveyed: the
+  compiler enforces exhaustiveness and nullness instead of a runtime XML
+  parse. It also unifies the modern-Java program with the module program —
+  they are the same work.
+- **Isolation: one shared in-process namespace for first-party; out-of-
+  process for the untrusted and the external tools.** Compiled-in and
+  first-party modules share JLS's types directly, so `instanceof`/casts
+  stay sound and there is one version of every type — deliberately
+  choosing Maven/JPMS single-version over npm/OSGi coexistence, whose
+  per-plugin classloaders are the #1 pain source in Jenkins, IntelliJ, and
+  OSGi. The *out-of-process* boundary (KiCad's protobuf-over-socket IPC
+  model) is reserved for two cases where it earns its cost: **untrusted
+  third-party providers** (crash isolation + a real trust boundary — the
+  open question #212/#170 must answer before any such provider ships) and
+  the **external tool integrations already run as subprocesses** (Yosys,
+  GHDL, Icarus, ELK — where out-of-process *also* sidesteps the GPLv3
+  linking hazard, e.g. ELK's EPL-2.0, that JLS already flagged).
+- **The host publishes extension points; it never names a module.** The
+  core defines typed extension-point interfaces (element provider, palette
+  contributor, exporter, op observer); modules contribute implementations
+  discovered through the registry. The dependency graph stays a DAG rooted
+  at contracts, so adding a module never edits the core (Eclipse extension
+  registry; the inversion-of-control seam).
+
+### 4.4 What is deliberately rejected (the weight JLS does not pay)
+
+- **OSGi / Equinox / Felix** — per-bundle classloaders, the dynamic
+  "service can vanish mid-call" model, manifest ceremony, `uses`-constraint
+  debugging. A full platform to maintain; pure cost for one jar with no
+  hot-redeploy need.
+- **Full JPMS modularization** — strong encapsulation but no versioning, a
+  rigid static graph, split-package/automatic-module friction. Adopt the
+  `uses`/`provides`/`ServiceLoader` *pattern* on the classpath; a single
+  `module-info.java` is optional and only to police the public API surface.
+- **Version-range solving / side-by-side versions** — every ecosystem that
+  tried it (only OSGi truly did) paid heavily; the rest forbid it. One jar
+  ⇒ "the version in the jar."
+- **Per-plugin classloaders and, by default, process isolation** — in-
+  process shared types give compile-time safety; the subprocess/sandbox is
+  an opt-in layer for untrusted code only.
+
+## 5. The six layers, as a module graph
+
+The layers of the first determination survive intact — they are the coarse
+dependency *tiers*. What changes is that the boundaries are now **declared
+and enforced by the module manifests of §4**, not implicit. Every open
+issue lands in exactly one module with no leftovers; that clean partition
+is the strongest evidence the shape is right.
 
 ```
 ┌───────────────────────────────────────────────────────────────────────┐
-│  DISTRIBUTION & SUPPLY CHAIN  (cross-cutting, not a runtime layer)      │
-│  reproducible jar + BOM · attested/signed installers · container       │
-│  #82 #134 #184 #185 #188 #190 #191        gate: #159 coverage ratchet   │
+│  DISTRIBUTION & SUPPLY CHAIN  (cross-cutting band; not a runtime module)│
+│  reproducible jar+BOM · attested/signed installers · container image   │
+│  #82 #134 #184 #185 #188 #190 #191         gate: #159 coverage ratchet  │
 └───────────────────────────────────────────────────────────────────────┘
-        ▲ packages and ships every layer below; depends on none of them
+        ▲ packages and ships every module below; depends on none at runtime
 
+  provides: editor, palette          provides: batch, vcd, image, hdl-*
 ┌─────────────────────────────┐   ┌─────────────────────────────────────┐
-│  L5  GUI  (jls.edit/jls.ui) │   │  L4  HEADLESS SERVICES & EXPORT     │
-│  the ONLY AWT/Swing layer   │   │  batch · VCD · image · HDL · boards │
-│  #84 decompose SimpleEditor │   │  #200 net observability             │
-│  #75 keyboard/a11y  #76 theme│   │  #59/#61/#62/#63 HDL export/import  │
-│  #86 dialogs  #73 onboarding │   │      /co-sim                        │
-│  #207 #208 #210 identity/a11y│   │  #213 board constraints  #215 bits  │
-│  #214 in-editor test panel   │   │  #216 waveform/autograde interop    │
-│  #91/#162 UI harness  #101 WL│   │  #202 RV32I golden  #212 plugins    │
+│  gui   (jls.edit / jls.ui)  │   │  batch/services & hdl               │
+│  the ONLY AWT module        │   │  requires: core, element-registry   │
+│  requires: core             │   │  batch/test-vector (#200 #214)      │
+│  #84 #75 #76 #86 #73 #207   │   │  hdl.export/import/cosim            │
+│  #208 #210 · #214 test panel│   │   (#59 #61 #62 #63) out-of-process  │
+│  #91/#162 harness · #101 WL │   │  #213 boards · #215 bitstream       │
+│  ext-points: palette entry, │   │  #202 RV32I golden                  │
+│  test panel, collab overlay │   │  #212 external element providers    │
 └──────────────┬──────────────┘   └──────────────────┬──────────────────┘
-               │  both are consumers of the core       │
+   after: core │ (consumers)                          │ after: core
                │                                        │
         ┌──────┴────────────────────────────────────────┴──────┐
-        │  L3  COLLABORATION  (jls.collab.*, no Swing)          │
-        │  #163 tracking · #168 P2P transport+SAS · #169 shared │
-        │  session v1 · #170 security hardening · #171 CRDT     │
-        │  built ENTIRELY on the L0 operation vocabulary        │
+        │  collab   (jls.collab.*, no Swing)                     │
+        │  requires: core, ops · provides: collab               │
+        │  #163 · #168 net → #169 session → #171 crdt (ordered)  │
+        │  #170 security = the closed op vocabulary hardened     │
         └───────────────────────────┬───────────────────────────┘
-                                     │ replicates CircuitOps
+                     requires: core, ops · replicates CircuitOps
 ┌────────────────────────────────────┴──────────────────────────────────┐
-│  L0  jls.core — THE HEADLESS KERNEL   (zero java.awt / javax.swing /   │
-│                                        jls.edit; the keystone, #77)    │
+│  core   (jls.core)  —  THE KERNEL / ROOT MODULE   (#77, Eager)         │
+│  provides: core, element-registry, sim, persistence, ops              │
+│  requires: nothing   ·   imports no java.awt / javax.swing / jls.edit │
 │                                                                        │
-│   model         Circuit · WireNet · typed pins/bit-widths · subcircuits│
-│   elements      ElementRegistry + self-describing ElementType (#78)    │
-│                 new datapath elements: reg file, extend (#201);        │
-│                 synchronous memory (#199); loader hardening (#198)     │
+│   model         Circuit · WireNet · typed pins/bit-widths · subckt     │
+│   registry      ElementRegistry + ElementType (#78) — the seed plugin  │
+│                 mechanism; element providers are modules (#212)        │
+│                 + datapath elements #201 · sync memory #199 · #198 fix │
 │   simulation    discrete-event Simulator + BatchSimulator (headless)   │
-│   persistence   FORMAT-versioned save/load, canonical serialization    │
+│   persistence   FORMAT-versioned save/load; canonical serialization    │
 │   operations    CircuitOp vocabulary + OpSink, stable ids (#167)       │
 │                                                                        │
-│   language properties enforced across the whole kernel by the build:   │
-│     null-safety (JSpecify+NullAway #93) · records/value semantics      │
-│     (#94) · sealed hierarchy + exhaustive switch (#95)   — program #96 │
+│   built with null-safety (#93) · records/value semantics (#94) ·       │
+│   sealed exhaustive dispatch (#95)  — program #96, = the SPI's safety  │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
-**L0 — `jls.core`, the headless kernel (#77).** Model, registry,
-simulation, persistence, operations. Imports nothing GUI. This is the
-embeddable unit an autograder or service links against, and the substrate
-the container image already wants to *be* rather than merely pretend to be
-via `-Djava.awt.headless`. `JLSInfo` dissolves into it as typed seams
-(load result #58, sim handle #49, version record #36, theme/prefs #76) —
-not one mutable hub. The modern-Java program (#96: #93/#94/#95) is not a
-seventh layer; it is the **quality of L0's construction** — nullness,
-value semantics, and exhaustive dispatch as compiler obligations, landed
-package-by-package as the core is carved out.
+Notes that the module framing clarifies:
 
-**L3 — `jls.collab` (#163 stack).** Sits directly on L0's operation
-vocabulary and canonical serialization — *not* on the GUI. Its lower
-sub-layers (op → session → crdt) touch no Swing; only the presence
-overlays and peer panel reach up into L5. Pure-P2P, CRDT for the document,
-Raft-style discipline only for the peer roster, security structural (a
-closed data-only op vocabulary is the entire network surface). It is a
-consumer of L0, peer to the GUI, and is the reason the operation layer is
-worth extracting even before collaboration ships.
+- **The registry is the mechanism, generalized.** `ElementType` already
+  records a deliberate *two-layer descriptor* split — a headless core half
+  (tag/class/factory/aliases) and a separate GUI-side palette entry
+  (icon/category/help/dialog). That is exactly a module contributing to
+  *two* extension points: the `core` element-provider point and the `gui`
+  palette point. #78's registry is not merely *like* the plugin system; it
+  *is* its first instance, and #212 is the same instance opened to external
+  providers. This is precisely how Digital (`ElementTypeDescription` +
+  `ElementLibrary`, with saved subcircuits registered through the *same*
+  path as built-ins) and Logisim (`Library → Tool → ComponentFactory`) do
+  it.
+- **Collab sits on `ops`, not on the GUI.** Its lower modules (net →
+  session → crdt, in that `after` order) touch no Swing; only presence
+  overlays reach up into `gui`. #170's "closed op vocabulary" is the
+  network-facing hardening of the same `CircuitOp` grammar the editor
+  submits — the reason the operation layer is worth extracting even before
+  collaboration ships.
+- **HDL and boards are `requires: core, element-registry`** and nothing
+  else: the exporter walks the model, the importer uses the registry as its
+  Yosys-cell→element table (#61), and everything external is a subprocess.
 
-**L4 — headless services & export.** Batch grading, VCD, image export,
-and the HDL/board/bitstream pipeline. This layer is where JLS's
-*potential* concentrates, and it is realizable precisely because it needs
-only L0: the HDL exporter walks the element graph; the importer needs the
-registry (#78) as its cell→element table; the plugin provider API (#212)
-contributes `ElementType`s to that same registry via `ServiceLoader`. All
-external-tool integration is **subprocess orchestration** (Yosys, GHDL,
-Icarus, nextpnr) — no in-process HDL semantics, no linking questions.
+## 6. Two planes: modules compose the cold plane; simulation is the hot plane
 
-**L5 — `jls.edit` / `jls.ui`, the GUI.** The *only* layer permitted to
-import AWT/Swing. Everything here is a consumer of L0. This is where the
-large ergonomics debt lives (#84 decompose the 4k-line `SimpleEditor`;
-#75 keyboard/a11y; #76 color-vision-safe semantics, HiDPI, dark mode,
-persistent prefs; #86 dialog behavior; #210 stable component identity for
-automation and assistive tech; #73 onboarding) and where the in-editor
-test panel (#214) puts a GUI face on L0's existing batch `-t` engine. The
-UI test harness (#91/#162) and the Wayland rig (#101) verify this layer
-without becoming a dependency of the others.
+A module/plugin system is a *composition and wiring* mechanism operating at
+startup and human-interaction timescale. It must never sit on the
+simulation inner loop, which touches signal values millions of times per
+run — the hottest path in the program. The architecture keeps these on
+opposite sides of a line:
 
-**Distribution & supply chain (cross-cutting).** Reproducible jar+BOM
-(done), attested and signed installers (#82/#134), the per-format
-byte-reproducibility program (#188/#190/#191), reproducible-build
-conformance (#184/#185), and the coverage ratchet (#159) as the gate.
-This wraps and ships every layer and depends on none of them at runtime —
-correctly modeled as a band around the diagram, not a box inside it.
+- **Cold plane (modules).** Editing, persistence, ops, collaboration,
+  export, plugin discovery, extension-point dispatch. Wired once by the
+  §4 machinery; indirection here is free.
+- **Hot plane (inside `core`).** The discrete-event loop runs entirely
+  within the `core` module over the elaborated wiring graph, with zero
+  plugin indirection, no capability lookup, no cross-module call per event.
+  Results reach watchers (trace window, probes, collab presence) through a
+  **batched, rate-limited** channel, never per-signal.
 
-## 5. The dependency spine (what to build, in order)
+This is also where the Verilator lesson lands as a **recorded-decision
+candidate**: JLS is today a pure discrete-event *interpreter* (like Icarus
+Verilog) — fine for classroom gate circuits, but the `riscv/` CPU-scale
+trajectory (§2) is exactly where Verilator's *elaborate-to-flat* approach
+(levelize the graph once, run a statically-ordered evaluation pass, ~100×)
+pays off. The determination: keep the event loop for interactive/animated
+use, and — *if* CPU-scale designs become common — add a levelized compiled
+evaluation pass **inside the `core` module, behind the same boundary**, as
+a second simulator strategy. It is a core-internal optimization, invisible
+to every other module, and it is the honest home for the performance
+concern that a "put all data in one general store" design would instead
+put fatally on the hot path.
 
-The layers imply a strict-enough order that the sequencing is nearly
-forced:
+## 7. Prior-art grounding
+
+The determination is not invented; it is the consensus of the tool class
+and of mature plugin ecosystems, adapted to JLS's constraints.
+
+**EDA/logic-sim tools converge on four things** (sources: Digital
+[repo](https://github.com/hneemann/Digital), issue
+[#52](https://github.com/hneemann/Digital/issues/52); Logisim-evolution
+[repo](https://github.com/logisim-evolution/logisim-evolution),
+[architecture](https://deepwiki.com/logisim-evolution/logisim-evolution);
+[DigitalJS](https://github.com/tilk/digitaljs) /
+[yosys2digitaljs](https://github.com/tilk/yosys2digitaljs); KiCad
+[IPC API](https://dev-docs.kicad.org/en/apis-and-binding/ipc-api/);
+[Verilator](https://www.veripool.org/verilator/)):
+
+1. **Core/GUI layering** — a model+sim+persistence core importing no GUI
+   toolkit, editors and batch as consumers. JLS is *ahead* here (enforced
+   ratchet); KiCad is pushing the boundary out of process for isolation.
+2. **Component registration** — a self-describing *descriptor + factory*
+   in a lookup structure, never a per-type switch; saved circuits
+   registered through the *same* mechanism as primitives. JLS's #78 is a
+   direct instance and would collapse its honest ~16-step element-authoring
+   ritual to one.
+3. **HDL interop** — export-first (framed as an FPGA deployment vehicle,
+   not HDL teaching), CI-validated against real external tools that skip
+   when absent; import only via Yosys `write_json` cell→element mapping,
+   never a hand-written parser; co-sim via subprocess, never a commercial
+   dependency (Logisim's Questa coupling is the anti-pattern). JLS's staged
+   plan (#59–#63) already adopts this verbatim.
+4. **In-editor test panels** — mainstream (Digital's `TestCaseElement`,
+   Logisim's test-vector format + headless grading CLI). JLS's #214 is the
+   small, HDL-independent catch-up item over its existing `-t` engine.
+
+**Plugin/ordering ecosystems converge on** (sources:
+[JEP 261](https://openjdk.org/jeps/261);
+[`ServiceLoader`](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/ServiceLoader.html);
+[OSGi Core 7](https://docs.osgi.org/specification/osgi.core/7.0.0/);
+[Jenkins deps](https://wiki.jenkins.io/display//JENKINS/Dependencies-among-plugins.html);
+[IntelliJ deps](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html);
+[systemd ordering](https://fedoramagazine.org/systemd-unit-dependencies-and-order/);
+[VS Code activation](https://code.visualstudio.com/api/references/activation-events);
+[Debian Policy §7](https://www.debian.org/doc/debian-policy/ch-relationships.html);
+[Cargo resolver](https://doc.rust-lang.org/cargo/reference/resolver.html)):
+discovery and ordering are separate concerns (discover declaratively,
+order by topo-sort); dependency and ordering are *separate axes*; a
+required/optional strength ladder; lazy activation with an eager core;
+and — for a small single-artifact app — *don't own a version solver* and
+*don't reach for per-plugin classloaders*. Every one of these is a rule in
+§4.
+
+## 8. The dependency spine (what to build, in order)
 
 ```
-#77 headless core ──┬── enables ── L4 embedding/HDL/autograde (#59, #200, #216, #202)
-                    │
-#78 registry ───────┼── enables ── HDL import cell table (#61), plugins (#212),
-                    │              palette generation, #214 panel authoring
-                    │
-#167 operation layer┴── enables ── #168 → #169 → #170 → #171  (collab stack)
+#77 headless core  ──┬── is the root module; enables all of L4/L3 and the
+                     │    enforced boundary the module manifests declare
+#78 registry (done) ─┼── generalize the closed ElementRegistry into the
+                     │    module/extension-point mechanism of §4
+#167 op layer (done)─┴── the mutation seam collab (#168→#169→#171) requires
         │
-        └─ built on #165 stable ids + #166 canonical save (the convergence oracle)
+        └─ on #165 stable ids + #166 canonical save (the merge/undo oracle)
 
-#96 (#93/#94/#95) ── runs THROUGH the core extraction, not after it
-#84 (decompose SimpleEditor) ── the L5 counterpart to #77; do it as the
-        operation layer lands, since #167 is the first real slice out of it
+#212 external providers ── the same mechanism, ServiceLoader-discovered,
+                           opened only when the demand gate opens
+#96 (#93/#94/#95) ── runs THROUGH core extraction and IS the SPI's type-safety
+#84 (decompose SimpleEditor) ── the gui-module counterpart to #77; proceeds
+                                as the op layer lands (#167 is its first slice)
 ```
 
-Read one way: **the triad (#77, #78, #167) is the critical path.** Ship
-those and the three big futures — autograding/embedding, HDL/FPGA, and
-collaboration — stop being rewrites and become additive consumers.
-Everything in L4 and L3 is gated on the triad; everything in L5 is
-parallelizable against it because the GUI is already a de-facto consumer,
-it just imports the core through leaky seams today.
+The critical path is the enabling triad plus the module-mechanism
+generalization: extract `core` (#77), turn `ElementRegistry` (#78) into the
+§4 module/extension-point system, keep the op layer (#167) as the mutation
+seam. Ship those and the three futures (§2) attach as modules rather than
+demanding rewrites; L5 (gui) parallelizes because it is already a de-facto
+consumer through leaky seams.
 
-## 6. What the architecture deliberately excludes
+## 9. What the architecture deliberately excludes
 
-"Most correct" is as much about firm boundaries as about layers. These are
-settled non-goals; re-proposing them is re-litigating a decision, and the
-architecture is stronger for naming them:
+Firm boundaries are as load-bearing as layers; re-proposing these
+re-litigates a settled decision:
 
-- **No central server, ever, for collaboration** (#163). Pure-P2P is a
-  constraint, not a stage-one simplification.
+- **No general "central store for all data."** A path-addressed,
+  lock-and-watch-per-access, homoiconic store is elegant for the cold
+  plane but fatal on the hot plane (§6); the module system gives the same
+  composition/merge/plugin benefits without taxing simulation, so the
+  general store is not adopted.
+- **No OSGi, no version solver, no per-plugin classloaders, no in-process
+  untrusted plugins** (§4.4).
+- **No central server for collaboration** (#163); pure-P2P is a constraint.
 - **No in-house HDL simulation or parsing beyond a header scanner** (#59,
-  #63). External synthesizer + JSON netlist for import; subprocess
-  co-simulation for black boxes. SystemC import is out of scope (it is a
-  C++ program / HLS input).
-- **No language rewrite** (#96). Java 25 + Kotlin's practices as Java
-  incarnations. Kotlin and Scala were assessed and declined with reasons.
-- **No internationalization** until a concrete course requests it
-  (recorded, `ARCHITECTURE.md`). Inline English is a decision.
-- **No hosted-docs dependency in the binary.** In-jar HTML 3.2 help stays
-  the offline, version-locked student manual; hosted docs are additive,
-  not a replacement (recorded).
-- **No plugin execution surface ahead of demand** (#212, gated). The
-  registry is closed-by-construction today; opening it via `ServiceLoader`
-  is a *priced-on-demand* decision, and any such API must resolve the
-  trust/sandbox stance before it ships — the network op vocabulary (#170)
-  is closed and data-only for exactly this reason.
-- **Installers are not assumed reproducible; they are assumed attested.**
-  Byte-reproducibility is pursued per format where reachable and bounded
-  honestly where not (#188). The jar+BOM are the reproducible artifacts.
+  #63); external synthesizer + JSON netlist import, subprocess co-sim.
+  SystemC import out of scope.
+- **No language rewrite** (#96); no internationalization until a course
+  requests it; in-jar HTML help stays the offline student manual (all
+  recorded).
+- **No plugin execution surface ahead of demand** (#212, gated); the
+  registry is closed today and opens via `ServiceLoader` only when a real
+  user asks, with the trust/sandbox stance resolved first.
+- **Installers are attested, not assumed reproducible** (#188); the jar+BOM
+  are the reproducible artifacts.
 
-## 7. Why this is the *most correct* shape, not merely *a* shape
+## 10. Why this is the *most correct* shape
 
 - **It falls out of the evidence.** Every open issue lands in exactly one
-  layer with no leftovers and no forcing. A backlog that partitions this
+  module over one triad, with no forcing. A backlog that partitions this
   cleanly is describing a structure that already exists in intent.
 - **It has a single keystone with maximal leverage.** The headless-core
-  extraction (#77) is on the critical path of embedding, HDL, and
-  collaboration simultaneously. There is no competing single change with
-  that reach, which is the signature of a correct primary boundary.
-- **It preserves both front ends as co-equal.** Making the core headless
-  by *construction* is what lets the batch/autograde surface be a
-  first-class product rather than a GUI afterthought — matching how JLS is
-  actually used in courses and CI.
-- **It admits the three futures additively.** Datapath/CPU teaching, FPGA
-  deployment, and collaboration each attach to L0 (and, for collab, the
-  operation layer) without disturbing the others or the GUI — the test of
-  a layering that will still be correct after the next three programs
-  land.
-- **Its boundaries are enforced, not aspirational.** The pattern already
-  in the tree — `HeadlessCoreRatchetTest`, `NotificationRatchetTest`, the
-  `-Werror`/SpotBugs gate, the coverage ratchet (#159) — means each layer
-  boundary can be a compiler or CI obligation, so the architecture is one
-  a single maintainer can *hold* over time, which is the only kind worth
-  choosing here.
+  extraction (#77) is on the critical path of embedding, HDL, *and*
+  collaboration at once; no competing single change has that reach.
+- **The connective mechanism is minimal and prior-art-validated.** The §4
+  module model is the smallest design the surveyed ecosystems converge on
+  for a small single-artifact app — and it is a generalization of code JLS
+  *already shipped* (`ElementRegistry`/`ElementType`), not a new framework.
+- **It preserves both front ends and admits all three futures additively.**
+  gui, batch, HDL, and collab are peer consumers of `core`; each attaches
+  as a module without disturbing the others.
+- **Its boundaries are enforced, not aspirational.** `HeadlessCoreRatchetTest`,
+  `ElementRegistryTest`'s totality check, `-Werror`+NullAway, the coverage
+  ratchet (#159), and a startup topo-sort with loud cycle detection make
+  each boundary a compiler or CI obligation — the only kind of architecture
+  a single maintainer can hold.
 
-## 8. One-paragraph statement of the determination
+## 11. One-paragraph statement of the determination
 
 JLS should converge on a six-layer architecture whose foundation is an
 enforced-headless kernel (`jls.core`: model, self-describing element
 registry, discrete-event simulation, versioned persistence, and an
-invertible/serializable operation vocabulary), constructed with
-null-safety, value semantics, and sealed exhaustive dispatch as
-compiler-enforced properties. Above it sit three peer consumers — a
-pure-P2P collaboration layer built on the operation vocabulary, a
-headless services-and-export layer that orchestrates external HDL/FPGA
-toolchains, and the Swing GUI as the sole AWT-importing layer — all
-packaged and shipped by a cross-cutting reproducible-and-attested
-distribution band. The critical path is the enabling triad #77 (core),
-#78 (registry), and #167 (operations); ship it and JLS's three
-trajectories — CPU-scale teaching, FPGA deployment, and collaborative
-editing — become additive rather than rewrites.
+invertible/serializable operation vocabulary), built with null-safety,
+value semantics, and sealed exhaustive dispatch as compiler-enforced
+properties. The layers are wired and their boundaries enforced by a
+minimal **module/plugin interface with full dependency and ordering
+support** — declarative record manifests; separate dependency and ordering
+axes; a required/optional strength ladder; capability tokens with
+concrete-name fallback; startup topological ordering with loud cycle
+detection and two-phase init; lazy activation with an eager core;
+`ServiceLoader` discovery for external providers behind a demand gate; one
+shared in-process type namespace for first-party code and out-of-process
+isolation reserved for untrusted providers and external tools — which is
+the generalization of the `ElementRegistry` JLS already shipped, and the
+smallest design the plugin-ecosystem prior art converges on for a
+single-jar, single-maintainer, compile-time-safe app. Above `core` sit
+three peer consumer modules — a pure-P2P collaboration module on the
+operation vocabulary, a headless services-and-export module orchestrating
+external HDL/FPGA toolchains out of process, and the Swing GUI as the sole
+AWT-importing module — all packaged by a cross-cutting reproducible-and-
+attested distribution band, with the simulation hot loop kept inside
+`core` and off the module path entirely (and a levelized compiled
+evaluation pass reserved there for CPU-scale designs). The critical path is
+the enabling triad — #77 (core), #78 (registry, generalized into the
+module mechanism), and #167 (operations) — and shipping it turns JLS's
+three trajectories (CPU-scale teaching, FPGA deployment, collaborative
+editing) into additive modules rather than rewrites.

--- a/docs/grand-architecture.md
+++ b/docs/grand-architecture.md
@@ -1,0 +1,288 @@
+# The grand architecture JLS should have
+
+A forward-looking companion to [`ARCHITECTURE.md`](../ARCHITECTURE.md).
+Where `ARCHITECTURE.md` maps HEAD — where code lives *today* — this
+document answers a different question: **given how JLS is actually used,
+what it could become, and every currently-open issue, what is the single
+most correct target architecture to converge on?** It is a determination,
+not a work order: it names the shape, the keystone, the layer boundaries,
+the sequence, and — just as importantly — what is deliberately excluded.
+
+The central finding up front: **the open issues are not a backlog, they
+are a latent architecture.** All 46 open issues map cleanly onto six
+layers with one enabling triad at the bottom. That they map so cleanly is
+the strongest evidence that the target below is the right one — it was
+already being built toward, one issue at a time, without a picture of the
+whole. This document draws the picture.
+
+## 1. What JLS is (the load-bearing facts)
+
+Any target has to hold these fixed, because they are the actual product:
+
+- **A single self-contained jar** is the deployment model students and
+  labs rely on. Help works offline and version-locked to the binary
+  (recorded decision, `ARCHITECTURE.md`); installers bundle a runtime so
+  no JDK is required. The architecture may not assume a network, a
+  server, or an install step.
+- **Two co-equal front ends, not one.** The GUI editor (Swing) *and* the
+  headless batch/grading surface (`-b -t`, VCD, image/Verilog export,
+  the `ghcr.io/anadon/jls` container) are both first-class. Autograders
+  and CI consume the headless surface; the batch interface is already a
+  documented stability contract (`docs/batch-interface.md`).
+- **~69k lines of Swing-dominated Java**, single-maintainer, audience of
+  first-year students and their instructors. This was assessed
+  explicitly against a Kotlin/Scala rewrite and the answer was **no**
+  (#96): the correct move is Java-25-baseline + Kotlin's transferable
+  practices as *compiler-enforced* properties, incrementally.
+- **A schematic-first model with typed pins, bit-widths, wire nets,
+  subcircuits, and a discrete-event simulator.** That element graph is
+  the asset everything else walks — the exporter's input, the registry's
+  subject, the replication unit, the autograder's oracle.
+
+## 2. What JLS could be (the latent product)
+
+The open issues, read together, describe a tool considerably larger than
+"draw gates and watch them blink." Three trajectories are already funded
+by real issues and real prototypes:
+
+- **A serious datapath / CPU teaching tool.** The `riscv/` tree already
+  builds a working RV32I CPU strictly through the model, with a
+  reference simulator and differential fuzzing; #201 (multi-port register
+  file, sign/zero-extend), #199 (synchronous memory), #202 (RV32I worked
+  example as an integration golden) push JLS from gate toys to full
+  single-cycle/pipelined processors.
+- **An FPGA-deployment bridge.** #59/#61/#62/#63 stage HDL export →
+  Yosys-netlist import → black-box co-simulation; #213/#215 carry the
+  drawn circuit all the way to a bitstream on a named dev board. The
+  settled stance (research-backed) is *orchestrate external tools; never
+  reimplement HDL semantics in JLS* — Verilog's own semantics are
+  self-inconsistent (Lööw, OOPSLA 2025).
+- **A collaborative editor.** #163 and its stack (#167→#168→#169→#170→
+  #171) make circuits editable simultaneously, pure-P2P, no server — lab
+  pairs and instructor demos as the dominant case.
+
+None of these is speculative fan-out. Each has a research doc, a tracking
+issue, and (for the first two) working code in-tree. The architecture's
+job is to let all three land *without a rewrite between them* — which
+they can, because they share a spine.
+
+## 3. The keystone: one headless kernel, everything else a consumer
+
+The most correct architecture has exactly one non-negotiable move, and
+everything else follows from it:
+
+> **Extract an enforced-headless core — the circuit model, the
+> simulator, persistence, the element registry, and the operation
+> vocabulary — that imports no `java.awt`, no `javax.swing`, and no
+> `jls.edit`. Make the GUI one consumer of that core, not its center.**
+
+This is #77's thesis, and it is load-bearing for nearly every future
+above. Today there is *no layering*: the abstract `Simulator` imports
+Swing and `jls.edit`; `Circuit` holds an `Editor` back-reference and its
+`draw` takes a `SimpleEditor`; batch mode is headless only because a
+runtime flag is set, not because any layer is structurally GUI-free; and
+`JLSInfo` is a ~640-reference public-static hub wiring it all together.
+
+Three extractions, taken together, are the **enabling triad**. Almost
+every high-value issue depends on at least one:
+
+| Triad member | Issue | Unlocks |
+|---|---|---|
+| **Headless core** (model+sim+persistence, zero AWT/Swing) | #77 | Embedding (autograders, services), clean testing, any future UI, the container surface being headless *by construction* not by flag |
+| **Element registry** (self-describing `ElementType` descriptors, capability interfaces, one `Orientation`) | #78 | HDL import's cell→element table, palette generation, plugin providers (#212), collapsing the ~16-point element-authoring ritual to one |
+| **Operation layer** (`CircuitOp` vocabulary + single `OpSink`) | #167 | CRDT replication (#171), precise undo, per-peer attribution, targeted revert — and it *is* the hardened network surface (#170) |
+
+The registry and the operation layer are already emerging in-tree
+(`Gate.Kind`, the `#23` attribute registry, `src/jls/collab/op/`). The
+core boundary is the one still to be drawn, and it is the highest-leverage
+single change in the whole tracker.
+
+## 4. The target: six layers
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│  DISTRIBUTION & SUPPLY CHAIN  (cross-cutting, not a runtime layer)      │
+│  reproducible jar + BOM · attested/signed installers · container       │
+│  #82 #134 #184 #185 #188 #190 #191        gate: #159 coverage ratchet   │
+└───────────────────────────────────────────────────────────────────────┘
+        ▲ packages and ships every layer below; depends on none of them
+
+┌─────────────────────────────┐   ┌─────────────────────────────────────┐
+│  L5  GUI  (jls.edit/jls.ui) │   │  L4  HEADLESS SERVICES & EXPORT     │
+│  the ONLY AWT/Swing layer   │   │  batch · VCD · image · HDL · boards │
+│  #84 decompose SimpleEditor │   │  #200 net observability             │
+│  #75 keyboard/a11y  #76 theme│   │  #59/#61/#62/#63 HDL export/import  │
+│  #86 dialogs  #73 onboarding │   │      /co-sim                        │
+│  #207 #208 #210 identity/a11y│   │  #213 board constraints  #215 bits  │
+│  #214 in-editor test panel   │   │  #216 waveform/autograde interop    │
+│  #91/#162 UI harness  #101 WL│   │  #202 RV32I golden  #212 plugins    │
+└──────────────┬──────────────┘   └──────────────────┬──────────────────┘
+               │  both are consumers of the core       │
+               │                                        │
+        ┌──────┴────────────────────────────────────────┴──────┐
+        │  L3  COLLABORATION  (jls.collab.*, no Swing)          │
+        │  #163 tracking · #168 P2P transport+SAS · #169 shared │
+        │  session v1 · #170 security hardening · #171 CRDT     │
+        │  built ENTIRELY on the L0 operation vocabulary        │
+        └───────────────────────────┬───────────────────────────┘
+                                     │ replicates CircuitOps
+┌────────────────────────────────────┴──────────────────────────────────┐
+│  L0  jls.core — THE HEADLESS KERNEL   (zero java.awt / javax.swing /   │
+│                                        jls.edit; the keystone, #77)    │
+│                                                                        │
+│   model         Circuit · WireNet · typed pins/bit-widths · subcircuits│
+│   elements      ElementRegistry + self-describing ElementType (#78)    │
+│                 new datapath elements: reg file, extend (#201);        │
+│                 synchronous memory (#199); loader hardening (#198)     │
+│   simulation    discrete-event Simulator + BatchSimulator (headless)   │
+│   persistence   FORMAT-versioned save/load, canonical serialization    │
+│   operations    CircuitOp vocabulary + OpSink, stable ids (#167)       │
+│                                                                        │
+│   language properties enforced across the whole kernel by the build:   │
+│     null-safety (JSpecify+NullAway #93) · records/value semantics      │
+│     (#94) · sealed hierarchy + exhaustive switch (#95)   — program #96 │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**L0 — `jls.core`, the headless kernel (#77).** Model, registry,
+simulation, persistence, operations. Imports nothing GUI. This is the
+embeddable unit an autograder or service links against, and the substrate
+the container image already wants to *be* rather than merely pretend to be
+via `-Djava.awt.headless`. `JLSInfo` dissolves into it as typed seams
+(load result #58, sim handle #49, version record #36, theme/prefs #76) —
+not one mutable hub. The modern-Java program (#96: #93/#94/#95) is not a
+seventh layer; it is the **quality of L0's construction** — nullness,
+value semantics, and exhaustive dispatch as compiler obligations, landed
+package-by-package as the core is carved out.
+
+**L3 — `jls.collab` (#163 stack).** Sits directly on L0's operation
+vocabulary and canonical serialization — *not* on the GUI. Its lower
+sub-layers (op → session → crdt) touch no Swing; only the presence
+overlays and peer panel reach up into L5. Pure-P2P, CRDT for the document,
+Raft-style discipline only for the peer roster, security structural (a
+closed data-only op vocabulary is the entire network surface). It is a
+consumer of L0, peer to the GUI, and is the reason the operation layer is
+worth extracting even before collaboration ships.
+
+**L4 — headless services & export.** Batch grading, VCD, image export,
+and the HDL/board/bitstream pipeline. This layer is where JLS's
+*potential* concentrates, and it is realizable precisely because it needs
+only L0: the HDL exporter walks the element graph; the importer needs the
+registry (#78) as its cell→element table; the plugin provider API (#212)
+contributes `ElementType`s to that same registry via `ServiceLoader`. All
+external-tool integration is **subprocess orchestration** (Yosys, GHDL,
+Icarus, nextpnr) — no in-process HDL semantics, no linking questions.
+
+**L5 — `jls.edit` / `jls.ui`, the GUI.** The *only* layer permitted to
+import AWT/Swing. Everything here is a consumer of L0. This is where the
+large ergonomics debt lives (#84 decompose the 4k-line `SimpleEditor`;
+#75 keyboard/a11y; #76 color-vision-safe semantics, HiDPI, dark mode,
+persistent prefs; #86 dialog behavior; #210 stable component identity for
+automation and assistive tech; #73 onboarding) and where the in-editor
+test panel (#214) puts a GUI face on L0's existing batch `-t` engine. The
+UI test harness (#91/#162) and the Wayland rig (#101) verify this layer
+without becoming a dependency of the others.
+
+**Distribution & supply chain (cross-cutting).** Reproducible jar+BOM
+(done), attested and signed installers (#82/#134), the per-format
+byte-reproducibility program (#188/#190/#191), reproducible-build
+conformance (#184/#185), and the coverage ratchet (#159) as the gate.
+This wraps and ships every layer and depends on none of them at runtime —
+correctly modeled as a band around the diagram, not a box inside it.
+
+## 5. The dependency spine (what to build, in order)
+
+The layers imply a strict-enough order that the sequencing is nearly
+forced:
+
+```
+#77 headless core ──┬── enables ── L4 embedding/HDL/autograde (#59, #200, #216, #202)
+                    │
+#78 registry ───────┼── enables ── HDL import cell table (#61), plugins (#212),
+                    │              palette generation, #214 panel authoring
+                    │
+#167 operation layer┴── enables ── #168 → #169 → #170 → #171  (collab stack)
+        │
+        └─ built on #165 stable ids + #166 canonical save (the convergence oracle)
+
+#96 (#93/#94/#95) ── runs THROUGH the core extraction, not after it
+#84 (decompose SimpleEditor) ── the L5 counterpart to #77; do it as the
+        operation layer lands, since #167 is the first real slice out of it
+```
+
+Read one way: **the triad (#77, #78, #167) is the critical path.** Ship
+those and the three big futures — autograding/embedding, HDL/FPGA, and
+collaboration — stop being rewrites and become additive consumers.
+Everything in L4 and L3 is gated on the triad; everything in L5 is
+parallelizable against it because the GUI is already a de-facto consumer,
+it just imports the core through leaky seams today.
+
+## 6. What the architecture deliberately excludes
+
+"Most correct" is as much about firm boundaries as about layers. These are
+settled non-goals; re-proposing them is re-litigating a decision, and the
+architecture is stronger for naming them:
+
+- **No central server, ever, for collaboration** (#163). Pure-P2P is a
+  constraint, not a stage-one simplification.
+- **No in-house HDL simulation or parsing beyond a header scanner** (#59,
+  #63). External synthesizer + JSON netlist for import; subprocess
+  co-simulation for black boxes. SystemC import is out of scope (it is a
+  C++ program / HLS input).
+- **No language rewrite** (#96). Java 25 + Kotlin's practices as Java
+  incarnations. Kotlin and Scala were assessed and declined with reasons.
+- **No internationalization** until a concrete course requests it
+  (recorded, `ARCHITECTURE.md`). Inline English is a decision.
+- **No hosted-docs dependency in the binary.** In-jar HTML 3.2 help stays
+  the offline, version-locked student manual; hosted docs are additive,
+  not a replacement (recorded).
+- **No plugin execution surface ahead of demand** (#212, gated). The
+  registry is closed-by-construction today; opening it via `ServiceLoader`
+  is a *priced-on-demand* decision, and any such API must resolve the
+  trust/sandbox stance before it ships — the network op vocabulary (#170)
+  is closed and data-only for exactly this reason.
+- **Installers are not assumed reproducible; they are assumed attested.**
+  Byte-reproducibility is pursued per format where reachable and bounded
+  honestly where not (#188). The jar+BOM are the reproducible artifacts.
+
+## 7. Why this is the *most correct* shape, not merely *a* shape
+
+- **It falls out of the evidence.** Every open issue lands in exactly one
+  layer with no leftovers and no forcing. A backlog that partitions this
+  cleanly is describing a structure that already exists in intent.
+- **It has a single keystone with maximal leverage.** The headless-core
+  extraction (#77) is on the critical path of embedding, HDL, and
+  collaboration simultaneously. There is no competing single change with
+  that reach, which is the signature of a correct primary boundary.
+- **It preserves both front ends as co-equal.** Making the core headless
+  by *construction* is what lets the batch/autograde surface be a
+  first-class product rather than a GUI afterthought — matching how JLS is
+  actually used in courses and CI.
+- **It admits the three futures additively.** Datapath/CPU teaching, FPGA
+  deployment, and collaboration each attach to L0 (and, for collab, the
+  operation layer) without disturbing the others or the GUI — the test of
+  a layering that will still be correct after the next three programs
+  land.
+- **Its boundaries are enforced, not aspirational.** The pattern already
+  in the tree — `HeadlessCoreRatchetTest`, `NotificationRatchetTest`, the
+  `-Werror`/SpotBugs gate, the coverage ratchet (#159) — means each layer
+  boundary can be a compiler or CI obligation, so the architecture is one
+  a single maintainer can *hold* over time, which is the only kind worth
+  choosing here.
+
+## 8. One-paragraph statement of the determination
+
+JLS should converge on a six-layer architecture whose foundation is an
+enforced-headless kernel (`jls.core`: model, self-describing element
+registry, discrete-event simulation, versioned persistence, and an
+invertible/serializable operation vocabulary), constructed with
+null-safety, value semantics, and sealed exhaustive dispatch as
+compiler-enforced properties. Above it sit three peer consumers — a
+pure-P2P collaboration layer built on the operation vocabulary, a
+headless services-and-export layer that orchestrates external HDL/FPGA
+toolchains, and the Swing GUI as the sole AWT-importing layer — all
+packaged and shipped by a cross-cutting reproducible-and-attested
+distribution band. The critical path is the enabling triad #77 (core),
+#78 (registry), and #167 (operations); ship it and JLS's three
+trajectories — CPU-scale teaching, FPGA deployment, and collaborative
+editing — become additive rather than rewrites.

--- a/scripts/setup-architecture-project.sh
+++ b/scripts/setup-architecture-project.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# setup-architecture-project.sh — one-shot, idempotent GitHub setup for the
+# grand-architecture module program (tracking issue #224).
+#
+# Creates what the MCP-only remote session could NOT create because `gh`
+# was unavailable there: real Milestone objects, a label taxonomy, a
+# Projects v2 board, and the milestone/label assignments that connect the
+# existing issues to the program described in docs/grand-architecture.md.
+#
+# It is SAFE TO RE-RUN: milestones are created only if absent, labels use
+# `--force` (create-or-update), and issue PATCH/edit calls are idempotent.
+# Project item-adds may warn on a second run; that is harmless.
+#
+# Prerequisites:
+#   - gh >= 2.40 (`gh --version`)
+#   - Authenticated: `gh auth status`
+#   - For the Projects v2 step, the token needs the `project` scope:
+#       gh auth refresh -s project,read:project
+#
+# Usage:
+#   scripts/setup-architecture-project.sh                 # do everything
+#   DRY_RUN=1 scripts/setup-architecture-project.sh       # print, don't mutate
+#   SKIP_PROJECT=1 scripts/setup-architecture-project.sh  # milestones+labels only
+#   OWNER=anadon REPO=JLS scripts/setup-architecture-project.sh
+#
+set -euo pipefail
+
+OWNER="${OWNER:-anadon}"
+REPO="${REPO:-JLS}"
+PROJECT_TITLE="${PROJECT_TITLE:-JLS Grand Architecture}"
+export GH_REPO="$OWNER/$REPO"   # default repo for `gh issue`/`gh label`
+
+run() {  # echo + execute, or just echo under DRY_RUN
+	if [ -n "${DRY_RUN:-}" ]; then
+		printf 'DRY: %s\n' "$*"
+	else
+		"$@"
+	fi
+}
+
+require_gh() {
+	command -v gh >/dev/null 2>&1 || { echo "error: gh not installed" >&2; exit 1; }
+	gh auth status >/dev/null 2>&1 || { echo "error: run 'gh auth login'" >&2; exit 1; }
+}
+
+# --- phase -> milestone metadata -------------------------------------------
+# Titles match the M0..M4 sections of tracking issue #224.
+declare -a PHASES=(M0 M1 M2 M3 M4)
+declare -A M_TITLE=(
+	[M0]="M0 — Boundary seed & type-safety"
+	[M1]="M1 — Headless kernel (keystone)"
+	[M2]="M2 — Module runtime & extension points"
+	[M3]="M3 — Consumer modules"
+	[M4]="M4 — External providers & scale"
+)
+declare -A M_DESC=(
+	[M0]="Registry (#78) and op layer (#167) shipped; complete type-safety #93/#94/#95. See docs/grand-architecture.md."
+	[M1]="Extract the enforced-headless jls.core (#77) — the root module every other module requires."
+	[M2]="Module/plugin runtime (#220), extension-point catalog (#223), isolation/trust decision (#222)."
+	[M3]="gui decomposition (#84), HDL modules (#59/#61/#62/#63/#213/#215), collab (#163 stack), batch/test (#200/#214), theme (#76)."
+	[M4]="External element providers (#212, demand-gated) and the CPU-scale simulation decision (#221)."
+)
+# Issue -> phase assignment (authoritative source: tracking issue #224).
+declare -A M_ISSUES=(
+	[M0]="78 167 93 94 95"
+	[M1]="77"
+	[M2]="220 223 222"
+	[M3]="84 59 61 62 63 213 215 163 168 169 170 171 200 214 76"
+	[M4]="212 221"
+)
+
+# --- label taxonomy ---------------------------------------------------------
+# name|color|description   (colors are 6-hex, no leading '#')
+declare -a LABELS=(
+	"architecture|5319e7|Grand-architecture module program (tracking #224)"
+	"kind:decision|d93f0b|A decision-and-decision-record issue; outcome recorded in ARCHITECTURE.md"
+	"phase:M0|c5def5|Program phase M0 — boundary seed & type-safety"
+	"phase:M1|7fdbca|Program phase M1 — headless kernel"
+	"phase:M2|bfd4f2|Program phase M2 — module runtime & extension points"
+	"phase:M3|fef2c0|Program phase M3 — consumer modules"
+	"phase:M4|f9d0c4|Program phase M4 — external providers & scale"
+	"area:core|0e8a16|jls.core kernel: model, registry, sim, persistence, ops"
+	"area:module|1d76db|Module/plugin runtime and extension points"
+	"area:gui|fbca04|jls.edit/jls.ui — the only AWT layer"
+	"area:hdl|006b75|HDL export/import/co-sim and board/bitstream flow"
+	"area:collab|b60205|Pure-P2P collaboration modules"
+	"area:batch|0052cc|Headless batch/grading/export services"
+	"area:distribution|5319e7|Reproducible/attested packaging & supply chain"
+)
+# Seed area/kind labels on the core program issues (extend later as desired).
+declare -A LABEL_ISSUES=(
+	[architecture]="220 221 222 223 224 77 78 167"
+	[kind:decision]="221 222"
+	[area:core]="77 78 167"
+	[area:module]="220 222 223 212"
+	[area:gui]="84 214 76"
+	[area:hdl]="59 213 215"
+	[area:collab]="163"
+	[area:batch]="200"
+)
+
+# --- steps ------------------------------------------------------------------
+milestone_number() {  # print the number of a milestone by exact title, or empty
+	gh api "repos/$OWNER/$REPO/milestones?state=all&per_page=100" \
+		--jq ".[] | select(.title==\"$1\") | .number" 2>/dev/null | head -n1
+}
+
+setup_milestones() {
+	echo "== Milestones =="
+	for p in "${PHASES[@]}"; do
+		local title="${M_TITLE[$p]}" num
+		num="$(milestone_number "$title" || true)"
+		if [ -z "$num" ]; then
+			if [ -n "${DRY_RUN:-}" ]; then
+				echo "DRY: create milestone '$title'"; num="?"
+			else
+				num="$(gh api -X POST "repos/$OWNER/$REPO/milestones" \
+					-f title="$title" -f description="${M_DESC[$p]}" --jq '.number')"
+			fi
+			echo "  created $p -> #milestone $num"
+		else
+			echo "  exists  $p -> #milestone $num"
+		fi
+		for issue in ${M_ISSUES[$p]}; do
+			[ "$num" = "?" ] && { echo "DRY: assign #$issue -> $title"; continue; }
+			run gh api -X PATCH "repos/$OWNER/$REPO/issues/$issue" -F "milestone=$num" \
+				>/dev/null && echo "  assigned #$issue -> $p"
+		done
+	done
+}
+
+setup_labels() {
+	echo "== Labels =="
+	for spec in "${LABELS[@]}"; do
+		IFS='|' read -r name color desc <<<"$spec"
+		run gh label create "$name" --color "$color" --description "$desc" --force \
+			>/dev/null && echo "  label $name"
+	done
+	for name in "${!LABEL_ISSUES[@]}"; do
+		for issue in ${LABEL_ISSUES[$name]}; do
+			run gh issue edit "$issue" --add-label "$name" >/dev/null \
+				&& echo "  #$issue += $name"
+		done
+	done
+	# Apply the phase labels to the same issues the milestones cover.
+	for p in "${PHASES[@]}"; do
+		for issue in ${M_ISSUES[$p]}; do
+			run gh issue edit "$issue" --add-label "phase:$p" >/dev/null \
+				&& echo "  #$issue += phase:$p"
+		done
+	done
+}
+
+project_number() {  # print number of a user project by exact title, or empty
+	gh project list --owner "$OWNER" --format json \
+		--jq ".projects[] | select(.title==\"$PROJECT_TITLE\") | .number" 2>/dev/null | head -n1
+}
+
+setup_project() {
+	echo "== Project (v2) =="
+	if ! gh project list --owner "$OWNER" >/dev/null 2>&1; then
+		echo "  skip: token lacks 'project' scope. Run: gh auth refresh -s project,read:project" >&2
+		return 0
+	fi
+	local num; num="$(project_number || true)"
+	if [ -z "$num" ]; then
+		if [ -n "${DRY_RUN:-}" ]; then echo "DRY: create project '$PROJECT_TITLE'"; return 0; fi
+		num="$(gh project create --owner "$OWNER" --title "$PROJECT_TITLE" --format json --jq '.number')"
+		echo "  created project #$num"
+	else
+		echo "  exists project #$num"
+	fi
+	# Add the tracker + every phased issue as items. Milestones are already
+	# assigned, so in the board UI you can "Group by: Milestone" with no
+	# custom field. (Projects v2 surfaces the native Milestone automatically.)
+	local all="224 ${M_ISSUES[M0]} ${M_ISSUES[M1]} ${M_ISSUES[M2]} ${M_ISSUES[M3]} ${M_ISSUES[M4]}"
+	for issue in $all; do
+		run gh project item-add "$num" --owner "$OWNER" \
+			--url "https://github.com/$OWNER/$REPO/issues/$issue" >/dev/null 2>&1 \
+			&& echo "  item + #$issue" || true
+	done
+	echo "  Tip: open the board, add a 'Group by: Milestone' view for the M0..M4 swimlanes."
+}
+
+main() {
+	require_gh
+	setup_milestones
+	setup_labels
+	[ -n "${SKIP_PROJECT:-}" ] || setup_project
+	echo "Done. Review: https://github.com/$OWNER/$REPO/milestones and the Projects tab."
+}
+main "$@"


### PR DESCRIPTION
## What & why

Records the **target ("grand") architecture** for JLS and the tooling to stand up its planning scaffolding. Companion to `ARCHITECTURE.md`: that maps HEAD, this maps the target.

- **`docs/grand-architecture.md`** — the determination. JLS's ~46 open issues partition cleanly into six layers over one enabling triad (#77 headless core, #78 element registry, #167 operation layer); the layers should be wired and enforced by an explicit **module/plugin interface with full dependency + ordering support** — a minimal model (declarative record manifests; separate dependency vs ordering axes; required/optional strength ladder; capability tokens; startup topological ordering with loud cycle detection + two-phase init; lazy activation with an eager core; `ServiceLoader` discovery behind a demand gate; in-process shared types with out-of-process isolation reserved for untrusted providers and external tools). It is the generalization of the `ElementRegistry` already shipped, grounded in a prior-art survey (JVM plugin systems; systemd/VS Code/Emacs/Debian dependency-ordering practice; Digital/Logisim/DigitalJS/KiCad/Verilator). A cold-plane/hot-plane split keeps the simulation loop inside `core`, off the module path.

- **`scripts/setup-architecture-project.sh` + `docs/architecture-project-setup.md`** — idempotent `gh` tooling to create the repo-level scaffolding the planning session could not (its GitHub surface had no milestone/label/project creation and no `gh`): Milestone objects M0–M4, a phase/area/kind label taxonomy, milestone+label assignments for the program issues, and a "JLS Grand Architecture" Projects v2 board. Run locally where `gh` is available.

Planning artifacts already created on the tracker side (this PR is the docs+tooling half): umbrella tracking issue #224 with sub-issues #220 (module runtime), #223 (extension-point catalog), #222 (isolation/trust decision), #221 (CPU-scale simulation decision), plus role-recording comments on #77/#78/#167/#212/#59/#163/#96/#84.

Relates #224 (does not close it — it is the living tracker for this program).

## Testing

No production code changes — documentation plus a standalone `gh` helper script that is not part of the build, so `mvn verify` is unaffected. The script is shell-syntax-checked (`bash -n`) and defaults to a `DRY_RUN=1` preview mode; it performs only create-if-absent / `--force` / idempotent-PATCH operations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYgEw9SBGdBxgnLoEZMJq7)_