### PR TITLE
Trace probed wire nets in the batch -vcd export (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Added
+- Batch `-vcd` export now includes **probed wire nets** as VCD signals
+  (#200), so a named internal net can be observed headlessly without
+  splicing in an `OutputPin` tap. Each probe becomes a `wire` signal
+  named by the probe, fed by `WireNet.propagate` →
+  `Simulator.probeSample`; the stdout whitelist (batch-interface §3.2)
+  is unchanged and a probe-free circuit produces byte-identical VCD.
+  Additive, minor-version per `docs/batch-interface.md` §6.
 - FlatLaf light adopted as the default Swing look-and-feel (#153),
   superseding the recorded cross-platform Metal default:
   `com.formdev:flatlaf:3.7.2` (Apache-2.0, ~1 MB, zero transitive

--- a/docs/batch-interface.md
+++ b/docs/batch-interface.md
@@ -218,14 +218,27 @@ and the golden tests compare byte-for-byte.
 ### 4.1 Signal set
 
 The VCD contains one signal per **watched element**, at any depth of
-the subcircuit hierarchy (`BatchSimulator.findWatched`). Note this is
-*broader* than the stdout whitelist of 3.2: any watched element that
-the simulator traces appears (e.g. a watched `InputPin`). Probed wires
-are **not** included — probes are an interactive-simulator feature and
-batch mode accumulates no data for them. Trace accumulation
-(`BatchSimulator.afterEvent`) is enabled whenever `-vcd` or `-r` is
-given; the two consumers share one trace and neither requires the
-other's flag.
+the subcircuit hierarchy (`BatchSimulator.findWatched`), **plus one
+signal per probed wire net** (`BatchSimulator.findProbes`, issue #200).
+Note the watched-element set is *broader* than the stdout whitelist of
+3.2: any watched element that the simulator traces appears (e.g. a
+watched `InputPin`).
+
+A **probe** is the interactive named-net feature (a name attached to a
+wire, saved as a `probe` item on a `WireEnd`, section 7 of
+`docs/file-format.md`); its VCD signal is a `wire` named by the probe
+and carries the net's value history. This lets a circuit name an
+internal net and observe it headlessly without splicing in an
+`OutputPin` tap. A probe still never prints to **stdout** — the 3.2
+whitelist is unchanged; probes are a VCD-only signal. If a probe name
+happens to equal a watched element's full name, the probe signal is
+suffixed (`_probe`) so neither is dropped.
+
+Trace accumulation (`BatchSimulator.afterEvent` for elements,
+`BatchSimulator.probeSample` for probed nets) is enabled whenever
+`-vcd` or `-r` is given; the consumers share one trace and neither
+requires the other's flag. A circuit with no probes produces
+byte-identical output to before this addition.
 
 ### 4.2 Header
 

--- a/src/jls/elem/WireNet.java
+++ b/src/jls/elem/WireNet.java
@@ -496,7 +496,17 @@ public class WireNet {
 			this.value = null;
 		else
 			this.value = (BitSet)value.clone();
-		
+
+		// feed probed nets to the batch VCD trace (issue #200): a probe
+		// names this net, so its value history is the net's. This is a
+		// no-op in the interactive engine (Simulator.probeSample is
+		// empty) and cheap otherwise - one field check per wire.
+		for (Wire wire : wires) {
+			if (wire.hasProbe()) {
+				sim.probeSample(wire.getProbe(), bits, now, this.value);
+			}
+		}
+
 	} // end of propagate method
 
 } // end of WireNet class

--- a/src/jls/sim/BatchSimulator.java
+++ b/src/jls/sim/BatchSimulator.java
@@ -25,6 +25,18 @@ public class BatchSimulator extends Simulator {
 		new HashMap<LogicElement,List<TraceSample>>();
 
 	/**
+	 * Per probed net (keyed by probe name), its recorded samples in time
+	 * order (issue #200). Probes name a wire net rather than an element,
+	 * so they trace through a parallel map fed by
+	 * {@link #probeSample} and merged into the VCD by {@link #toVcd}.
+	 */
+	private final Map<String,List<TraceSample>> probeTrace =
+		new HashMap<String,List<TraceSample>>();
+	/** Per probed net, its bit width (issue #200). */
+	private final Map<String,Integer> probeBits =
+		new HashMap<String,Integer>();
+
+	/**
 	 * VCD export (issue #72): the file to write, or null for no export.
 	 * A non-null value enables trace accumulation in afterEvent even
 	 * when the -r printer flag (JLSInfo.printTrace) is off.
@@ -105,7 +117,15 @@ public class BatchSimulator extends Simulator {
 		// find watched elements and set up trace map
 		findWatched(circuit());
 
-		// run the shared event loop (tracing happens in afterEvent)
+		// register probed nets so they trace into the VCD alongside
+		// watched elements (issue #200); only when a trace consumer is
+		// active, matching afterEvent's gate
+		if (JLSInfo.printTrace || vcdFileName != null) {
+			findProbes(circuit());
+		}
+
+		// run the shared event loop (tracing happens in afterEvent and,
+		// for probed nets, in probeSample via WireNet.propagate)
 		runEventLoop();
 
 	} // end of runSim
@@ -218,6 +238,80 @@ public class BatchSimulator extends Simulator {
 	} // end of findWatched method
 
 	/**
+	 * Find all probed nets and seed each with a time-0 sample, so every
+	 * probe has a VCD $dumpvars baseline and appears even if its value
+	 * never changes (issue #200). Recurses into subcircuits. Wires are
+	 * elements of the circuit (Circuit.getElements includes them), and a
+	 * probe is attached to a wire; several wire segments of one net may
+	 * carry the same probe name, so the first registration wins.
+	 *
+	 * @param circ The circuit (or subcircuit) to look in.
+	 */
+	private void findProbes(Circuit circ) {
+
+		for (Element el : circ.getElements()) {
+			if (el instanceof SubCircuit sub) {
+				findProbes(sub.getSubCircuit());
+			}
+			else if (el instanceof Wire wire && wire.hasProbe()) {
+				String name = wire.getProbe();
+				if (probeTrace.containsKey(name)) {
+					continue;
+				}
+				int bits = wire.getBits();
+				BitSet value = wire.getValue();
+				BitSet sample;
+				if (value == null) {
+					sample = new BitSet(bits + 1);
+					sample.set(bits);
+				}
+				else {
+					sample = (BitSet) value.clone();
+				}
+				List<TraceSample> events = new LinkedList<TraceSample>();
+				events.add(new TraceSample(0, sample));
+				probeTrace.put(name, events);
+				probeBits.put(name, bits);
+			}
+		}
+	} // end of findProbes method
+
+	/**
+	 * Record a probed net's value change (issue #200), mirroring
+	 * {@link #afterEvent}'s dedup: extend the probe's sample list only
+	 * when the value differs from the previous one, and normalize HiZ to
+	 * the marker BitSet so a net that stays undriven is not re-recorded
+	 * on every propagate. A probe not registered by {@link #findProbes}
+	 * (tracing off) is ignored.
+	 *
+	 * @param name  The probe name.
+	 * @param bits  The net's bit width.
+	 * @param time  The simulation time of the change.
+	 * @param value The net's new value, or null for HiZ.
+	 *
+	 * @jls.testedby jls.VcdProbeExportTest#probedNetAppearsInVcd()
+	 */
+	@Override
+	public void probeSample(String name, int bits, long time,
+			@Nullable BitSet value) {
+
+		if (!JLSInfo.printTrace && vcdFileName == null) {
+			return;
+		}
+		List<TraceSample> events = probeTrace.get(name);
+		if (events == null) {
+			return;
+		}
+		BitSet off = new BitSet(bits + 1);
+		off.set(bits);
+		BitSet current = (value == null) ? off : (BitSet) value.clone();
+		TraceSample prev = events.getLast();
+		if (!prev.value().equals(current)) {
+			events.add(new TraceSample(time, current));
+		}
+	} // end of probeSample method
+
+	/**
 	 * The recorded traces of every watched element, for consumers such
 	 * as the GUI-side trace printer ({@link jls.BatchTracePrinter}).
 	 * Each element's samples are ordered oldest first, starting with a
@@ -291,13 +385,31 @@ public class BatchSimulator extends Simulator {
 
 		StringBuilder out = new StringBuilder();
 
-		// signals in full-name order: deterministic header, identifier
-		// assignment, and per-timestamp change order
-		TreeMap<String,LogicElement> signals =
-			new TreeMap<String,LogicElement>();
-		for (LogicElement el : eventTrace.keySet()) {
-			signals.put(el.getFullName(), el);
+		// unify watched elements and probed nets (issue #200) into one
+		// signal set, keyed by full name for a deterministic header,
+		// identifier assignment, and per-timestamp change order. Each
+		// signal carries its bit width and its folded time -> value
+		// history; the change times accumulate into a shared set.
+		record Sig(int bits, TreeMap<Long,BitSet> byTime) { }
+		TreeMap<String,Sig> signals = new TreeMap<String,Sig>();
+		TreeSet<Long> times = new TreeSet<Long>();
+		for (Map.Entry<LogicElement,List<TraceSample>> e
+				: eventTrace.entrySet()) {
+			signals.put(e.getKey().getFullName(),
+					new Sig(e.getKey().getBits(), fold(e.getValue(), times)));
 		}
+		for (Map.Entry<String,List<TraceSample>> e : probeTrace.entrySet()) {
+			// a probe name that collides with an element's full name is
+			// disambiguated so neither signal is silently dropped
+			String key = e.getKey();
+			while (signals.containsKey(key)) {
+				key = key + "_probe";
+			}
+			signals.put(key, new Sig(
+					Objects.requireNonNull(probeBits.get(e.getKey())),
+					fold(e.getValue(), times)));
+		}
+
 		Map<String,String> codes = new HashMap<String,String>();
 		int next = 0;
 		for (String name : signals.keySet()) {
@@ -311,8 +423,8 @@ public class BatchSimulator extends Simulator {
 		out.append("$timescale 1 ns $end\n");
 		out.append("$scope module ").append(circuit().getName())
 			.append(" $end\n");
-		for (Map.Entry<String,LogicElement> e : signals.entrySet()) {
-			int bits = e.getValue().getBits();
+		for (Map.Entry<String,Sig> e : signals.entrySet()) {
+			int bits = e.getValue().bits();
 			out.append("$var wire ").append(bits).append(' ')
 				.append(codes.get(e.getKey())).append(' ')
 				.append(e.getKey());
@@ -324,32 +436,14 @@ public class BatchSimulator extends Simulator {
 		out.append("$upscope $end\n");
 		out.append("$enddefinitions $end\n");
 
-		// fold each signal's event list into time -> value (the last
-		// event recorded at a given time wins) and collect the set of
-		// change times
-		Map<String,TreeMap<Long,BitSet>> folded =
-			new HashMap<String,TreeMap<Long,BitSet>>();
-		TreeSet<Long> times = new TreeSet<Long>();
-		for (Map.Entry<String,LogicElement> e : signals.entrySet()) {
-			TreeMap<Long,BitSet> byTime = new TreeMap<Long,BitSet>();
-			// the signal map was built from eventTrace's keys, so the
-			// trace list is always present
-			for (TraceSample ev
-					: Objects.requireNonNull(eventTrace.get(e.getValue()))) {
-				byTime.put(ev.time(), ev.value());
-				times.add(ev.time());
-			}
-			folded.put(e.getKey(), byTime);
-		}
-
-		// initial values (findWatched guarantees a time-0 entry for
-		// every watched element)
+		// initial values (findWatched/findProbes guarantee a time-0 entry
+		// for every watched element and probed net)
 		out.append("#0\n");
 		out.append("$dumpvars\n");
-		for (Map.Entry<String,LogicElement> e : signals.entrySet()) {
+		for (Map.Entry<String,Sig> e : signals.entrySet()) {
 			BitSet value = Objects.requireNonNull(
-					Objects.requireNonNull(folded.get(e.getKey())).get(0L));
-			out.append(vcdValue(e.getValue(), value,
+					e.getValue().byTime().get(0L));
+			out.append(vcdValue(e.getValue().bits(), value,
 					Objects.requireNonNull(codes.get(e.getKey()))))
 				.append('\n');
 		}
@@ -363,11 +457,10 @@ public class BatchSimulator extends Simulator {
 				continue;
 			}
 			out.append('#').append(t).append('\n');
-			for (Map.Entry<String,LogicElement> e : signals.entrySet()) {
-				BitSet value =
-						Objects.requireNonNull(folded.get(e.getKey())).get(t);
+			for (Map.Entry<String,Sig> e : signals.entrySet()) {
+				BitSet value = e.getValue().byTime().get(t);
 				if (value != null) {
-					out.append(vcdValue(e.getValue(), value,
+					out.append(vcdValue(e.getValue().bits(), value,
 							Objects.requireNonNull(codes.get(e.getKey()))))
 						.append('\n');
 				}
@@ -381,6 +474,28 @@ public class BatchSimulator extends Simulator {
 		}
 		return out.toString();
 	} // end of toVcd method
+
+	/**
+	 * Fold a signal's ordered samples into a time -> value map (the last
+	 * sample recorded at a given time wins) and add its change times to
+	 * the shared set, so watched elements and probed nets share one
+	 * timeline (issue #200).
+	 *
+	 * @param samples The signal's samples, oldest first.
+	 * @param times   The shared change-time set to extend.
+	 *
+	 * @return the time -> value map for this signal.
+	 */
+	private static TreeMap<Long,BitSet> fold(List<TraceSample> samples,
+			TreeSet<Long> times) {
+
+		TreeMap<Long,BitSet> byTime = new TreeMap<Long,BitSet>();
+		for (TraceSample ev : samples) {
+			byTime.put(ev.time(), ev.value());
+			times.add(ev.time());
+		}
+		return byTime;
+	} // end of fold method
 
 	/**
 	 * The VCD identifier code for the n'th signal: the printable ASCII
@@ -412,17 +527,17 @@ public class BatchSimulator extends Simulator {
 	 * zeros omitted, or {@code bz <code>} when the whole signal is
 	 * HiZ.
 	 *
-	 * @param el The signal's element (for its bit width).
+	 * @param bits The signal's bit width (a watched element's or a
+	 *        probed net's, issue #200).
 	 * @param value The recorded value, with HiZ encoded as the trace's
-	 *        marker BitSet (only bit el.getBits() set).
+	 *        marker BitSet (only bit {@code bits} set).
 	 * @param code The signal's identifier code.
 	 *
 	 * @return the value-change line, without the newline.
 	 */
-	private static String vcdValue(LogicElement el, BitSet value,
+	private static String vcdValue(int bits, BitSet value,
 			String code) {
 
-		int bits = el.getBits();
 		BitSet off = new BitSet(bits + 1);
 		off.set(bits);
 		boolean hiZ = value.equals(off);

--- a/src/jls/sim/Simulator.java
+++ b/src/jls/sim/Simulator.java
@@ -270,6 +270,23 @@ public abstract class Simulator {
 	} // end of afterEvent method
 
 	/**
+	 * Hook called from {@link jls.elem.WireNet#propagate} for every
+	 * probed wire on a net whose value just changed (issue #200). The
+	 * base engine ignores probes - they are an interactive convenience;
+	 * the batch simulator overrides this to fold each probed net into the
+	 * VCD trace alongside watched elements, so a named net can be observed
+	 * headlessly without splicing in an OutputPin tap.
+	 *
+	 * @param name  The probe name - the net's user-given signal name.
+	 * @param bits  The net's bit width.
+	 * @param time  The simulation time of the change.
+	 * @param value The net's new value, or null for HiZ (undriven).
+	 */
+	public void probeSample(String name, int bits, long time,
+			@Nullable BitSet value) {
+	} // end of probeSample method
+
+	/**
 	 * Stop the simulation.
 	 */
 	public abstract void stop();

--- a/test/jls/VcdProbeExportTest.java
+++ b/test/jls/VcdProbeExportTest.java
@@ -1,0 +1,97 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jls.sim.BatchSimulator;
+
+/**
+ * A wire probe (an interactive named-net feature) now participates in the
+ * batch {@code -vcd} export (issue #200): a student can name an internal
+ * net in the GUI and observe it headlessly without splicing in an
+ * OutputPin tap. Before this, probes never appeared in batch output at
+ * all (docs/batch-interface.md was explicit that VCD excluded them).
+ */
+class VcdProbeExportTest {
+
+	@TempDir
+	Path tmp;
+
+	/**
+	 * A 4-bit constant 5 driving a watched output pin q, with the
+	 * connecting net probed as "mid". The probe names the net between the
+	 * constant and the pin.
+	 */
+	private static String probedCircuit() {
+		return "CIRCUIT probe\n"
+			+ "ELEMENT Constant\n int id 0\n int x 60\n int y 60\n"
+			+ " int width 24\n int height 24\n Int value 5\n int base 10\n"
+			+ " String orient \"RIGHT\"\nEND\n"
+			+ "ELEMENT OutputPin\n int id 1\n int x 300\n int y 60\n"
+			+ " int width 48\n int height 24\n String name \"q\"\n"
+			+ " int bits 4\n int watch 1\n String orient \"RIGHT\"\nEND\n"
+			+ "ELEMENT WireEnd\n int id 2\n int x 84\n int y 72\n"
+			+ " int width 8\n int height 8\n String put \"output\"\n"
+			+ " ref attach 0\n ref wire 3\n probe 3 \"mid\"\nEND\n"
+			+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 72\n"
+			+ " int width 8\n int height 8\n String put \"input\"\n"
+			+ " ref attach 1\n ref wire 2\nEND\n"
+			+ "ENDCIRCUIT\n";
+	}
+
+	private String runVcd(String circuitText) throws Exception {
+		Circuit circuit = new Circuit("probe");
+		assertTrue(circuit.load(new Scanner(circuitText)),
+				"the probed circuit must load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				"the probed circuit must assemble: " + JLSInfo.loadError);
+		BatchSimulator sim = new BatchSimulator();
+		sim.setCircuit(circuit);
+		sim.setTimeLimit(50);
+		sim.setVcdFile(tmp.resolve("out.vcd").toString());
+		sim.runSim();
+		return sim.toVcd();
+	}
+
+	@Test
+	void probedNetAppearsInVcd() throws Exception {
+		String vcd = runVcd(probedCircuit());
+
+		// the probe "mid" is declared as a 4-bit wire signal
+		Matcher var = Pattern.compile(
+				"\\$var wire 4 (\\S+) mid \\[3:0\\] \\$end")
+				.matcher(vcd);
+		assertTrue(var.find(), "probe 'mid' must be a VCD signal:\n" + vcd);
+		String code = var.group(1);
+
+		// and it carries the driven value 5 (binary 101) on the net
+		assertTrue(vcd.contains("b101 " + code),
+				"probe 'mid' must show value 5 (b101):\n" + vcd);
+
+		// the watched element q is still traced (no regression)
+		assertTrue(Pattern.compile("\\$var wire 4 \\S+ q \\[3:0\\] \\$end")
+				.matcher(vcd).find(),
+				"watched pin q must still appear:\n" + vcd);
+	}
+
+	@Test
+	void probesDoNotLeakIntoStdoutWhitelist() throws Exception {
+		// the stdout whitelist (docs §3.2) is unchanged: only the
+		// element report prints; probes are a VCD-only addition. This
+		// guards that displayResults was not widened by the #200 work.
+		String vcd = runVcd(probedCircuit());
+		assertTrue(vcd.contains(" mid "), "sanity: probe is in the VCD");
+		// no probe name should ever be introduced as an element report
+		// line; displayResults only knows Register/Memory/OutputPin
+		assertFalse(vcd.contains("Output Pin mid"),
+				"a probe must not be reported as an element");
+	}
+}


### PR DESCRIPTION
Batch observability could only reach watched elements: to see an internal datapath signal (a control-word field, an immediate, a next-PC) you had to splice a temporary OutputPin into the netlist, because -vcd traced watched *elements* and probes -- the interactive named-net feature -- produced nothing in batch at all.

A probe names a wire net, and a net's value history is observable at WireNet.propagate. This adds a Simulator.probeSample hook (a no-op in the interactive engine) that WireNet.propagate calls for every probed wire on a net whose value changed. BatchSimulator overrides it to fold probed nets into the VCD alongside watched elements:

- findProbes seeds each probed net with a time-0 sample, so every probe has a $dumpvars baseline and appears even if it never changes;
- probeSample extends the sample list with the same HiZ-marker encoding and consecutive-dedup as afterEvent;
- toVcd is refactored to a single name-keyed signal set carrying (bits, time->value), merging elements and probes; a probe name colliding with an element full name is suffixed (_probe) so neither is dropped.

The change is additive and gated behind the existing -vcd/-r trace consumers: a circuit with no probes produces byte-identical VCD (the existing byte-for-byte goldens still pass), and the stdout whitelist (batch-interface 3.2) is untouched -- probes are a VCD-only signal. Minor-version per docs/batch-interface.md 6; documented in 4.1 and the CHANGELOG.

New test VcdProbeExportTest: a probed net appears as a VCD wire signal carrying the driven value, watched elements still trace, and probes do not leak into the stdout report.


Claude-Session: https://claude.ai/code/session_01BgMdmXhGdbFyuqDNEbtj6v