### PR TITLE
Bound the uncaught-exception handler's exit so unattended displays ca…

### DIFF
--- a/src/jls/DefaultExceptionHandler.java
+++ b/src/jls/DefaultExceptionHandler.java
@@ -4,6 +4,9 @@ import java.nio.charset.StandardCharsets;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 
 import org.jspecify.annotations.Nullable;
 
@@ -23,6 +26,35 @@ public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHa
 	private @Nullable Circuit circuit = null;
 	/** Memory released when handling an OutOfMemoryError so recovery can proceed. */
 	private int @Nullable [] extraSpace = new int[10000];
+
+	// -- termination seams (issue #208) ---------------------------------
+	// The interactive branches show a modal dialog and only then exit. On
+	// an unattended display (the Xvfb UI-CI lane), no human dismisses the
+	// dialog, so the modal blocks the handler thread forever and the exit
+	// never runs - the process hangs until a wall-clock timeout instead of
+	// failing fast (issue #208). GraphicsEnvironment.isHeadless() is false
+	// under Xvfb, so it cannot tell a CI lane from a real user; rather than
+	// classify the session, we guarantee a bounded exit unconditionally: a
+	// daemon watchdog force-terminates after a short interval, so a
+	// dismissed dialog exits immediately and an unattended one exits when
+	// the watchdog fires. These fields are package-private seams the tests
+	// drive (a blocking dialog + recording exiters) without a real display.
+
+	/** Ensures exactly one termination path runs, whichever fires first. */
+	private final AtomicBoolean terminated = new AtomicBoolean(false);
+	/** Orderly, immediate exit (dialog dismissed / batch path). */
+	IntConsumer exiter = System::exit;
+	/** Hard exit the watchdog uses, in case shutdown hooks also hang. */
+	IntConsumer hardExiter = code -> Runtime.getRuntime().halt(code);
+	/** Runs the modal dialog; may block indefinitely when unattended. */
+	Consumer<Runnable> dialogRunner = Runnable::run;
+	/** How long the watchdog waits before forcing termination. */
+	long watchdogMillis = Long.getLong("jls.exitWatchdogMillis", 5000L);
+	/**
+	 * Forces the interactive branch even without a real {@link JLSStart}
+	 * (test seam); null means the live {@code jls != null} decision.
+	 */
+	@Nullable Boolean interactiveOverride = null;
 
 	/**
 	 * Create a handler with no JLS window or circuit attached yet;
@@ -60,65 +92,115 @@ public final class DefaultExceptionHandler implements Thread.UncaughtExceptionHa
 	 */
 	@Override
 	public void uncaughtException(Thread t, Throwable th) {
-		
+
 		// if already trying to recover, forget it
 		if (recovering) {
-			System.exit(1);
+			terminate(1, false);
+			return;
 		}
 		recovering = true;
-		
+
+		boolean interactive = interactiveOverride != null
+				? interactiveOverride.booleanValue()
+				: (jls != null);
+
 		// if out of memory
 		if (th instanceof OutOfMemoryError) {
-			
+
 			// free up some memory and garbage collect
 			extraSpace = null;
 			System.gc();
-			
+
 			// if batch, print message and quit
-			if (jls == null) {
+			if (!interactive) {
 				System.out.println("Not enough memory to simulate circuit");
 				System.out.println("Run JLS again and give JVM more memory");
+				terminate(1, false);
 			}
-			
-			// otherwise display message and quit
+
+			// otherwise display message and quit -- but arm the watchdog
+			// first so an unattended display cannot hang here (issue #208);
+			// the branch has already freed extraSpace for this path
 			else {
-				
-				TellUser.error(null,
-						"Not enough memory", "Error");
-				TellUser.warn(null,
-						"Run JLS again and give JVM more memory", "Warning");
+				armWatchdog();
+				dialogRunner.accept(() -> {
+					TellUser.error(null, "Not enough memory", "Error");
+					TellUser.warn(null,
+							"Run JLS again and give JVM more memory",
+							"Warning");
+				});
+				terminate(1, false);
 			}
-			System.exit(1);
 		}
-		
+
 		// all other errors/exceptions...
 		else {
-			
+
 			// if batch, print message and quit
-			if (jls == null) {
+			if (!interactive) {
 				saveTrace(th);
 				System.out.println("UNEXPECTED INTERNAL ERROR!");
 				System.out.println("JLS will create a file called JLSerror in the current folder/directory.");
 				System.out.println("Please attach it to a bug report at https://github.com/anadon/JLS/issues so it can be fixed.");
-				System.exit(1);
+				terminate(1, false);
 			}
-			
-			// otherwise show message and quit
+
+			// otherwise show message and quit. The trace is written before
+			// the dialog, and the watchdog is armed before it, so the
+			// JLSerror file lands and the process exits within a bounded
+			// time whether or not a human ever dismisses the dialog (#208)
 			else {
 				saveTrace(th);
-				String msg = "<html>" + 
-					"UNEXPECTED INTERNAL ERROR! Try to save circuit(s)." + 
-					"<p>" + 
+				armWatchdog();
+				String msg = "<html>" +
+					"UNEXPECTED INTERNAL ERROR! Try to save circuit(s)." +
+					"<p>" +
 					"JLS will create a file called JLSerror in the current folder/directory." +
 					"<br>Please attach it to a bug report at https://github.com/anadon/JLS/issues so it can be fixed." +
 					"<br><br>Try restarting JLS using checkpoints of open circuits" +
 					"<br>(i.e., <i>file</i>.jls~, where <i>file</i> is the name of the open circuit)" +
 					"</html>";
-				TellUser.error(null, msg, "Error");
-				System.exit(1);
+				dialogRunner.accept(() -> TellUser.error(null, msg, "Error"));
+				terminate(1, false);
 			}
 		}
 	} // end of uncaughtException method
+
+	/**
+	 * Terminate the process exactly once, whichever path fires first
+	 * (issue #208). The immediate branches call this after their dialog;
+	 * the watchdog calls it with {@code hard} true to bypass shutdown
+	 * hooks that might themselves hang.
+	 *
+	 * @param code The exit status.
+	 * @param hard True to use the hard-halt exiter (the watchdog path).
+	 */
+	private void terminate(int code, boolean hard) {
+		if (terminated.compareAndSet(false, true)) {
+			(hard ? hardExiter : exiter).accept(code);
+		}
+	} // end of terminate method
+
+	/**
+	 * Arm a daemon watchdog that force-terminates after
+	 * {@link #watchdogMillis}, so a modal error dialog on an unattended
+	 * display (the Xvfb UI-CI lane) cannot block the handler thread past
+	 * a bounded time (issue #208). If the dialog is dismissed first, the
+	 * immediate {@link #terminate} wins and this fires harmlessly into the
+	 * already-set {@code terminated} guard.
+	 */
+	private void armWatchdog() {
+		Thread watchdog = new Thread(() -> {
+			try {
+				Thread.sleep(watchdogMillis);
+			} catch (InterruptedException ignored) {
+				return;
+			}
+			terminate(1, true);
+		}, "jls-exit-watchdog");
+		watchdog.setDaemon(true);
+		watchdog.start();
+	} // end of armWatchdog method
 	
 	/**
 	 * Save stack trace in a file.

--- a/test/jls/DefaultExceptionHandlerWatchdogTest.java
+++ b/test/jls/DefaultExceptionHandlerWatchdogTest.java
@@ -1,0 +1,135 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * DefaultExceptionHandler bounded-exit guarantee (issue #208). The
+ * interactive branch used to show a modal dialog and only then call
+ * System.exit; on an unattended display (the Xvfb UI-CI lane) the modal
+ * blocks forever and the process hangs until a wall-clock timeout. These
+ * tests drive the handler's termination seams - a blocking dialog stand-in
+ * and recording exiters - so the watchdog behaviour is exercised without a
+ * real display: a hung dialog must still terminate within a bounded time.
+ */
+class DefaultExceptionHandlerWatchdogTest {
+
+	@AfterEach
+	void removeTraceFile() {
+		// saveTrace writes JLSerror in the working directory; don't leave it
+		new File("JLSerror").delete();
+	}
+
+	/**
+	 * P2: a display-present-unattended run - modelled by a dialog that
+	 * never returns - must still exit within a bounded time via the
+	 * watchdog, instead of hanging (P1's exit-124 failure at 76ebb20).
+	 */
+	@Test
+	void watchdogTerminatesWhenDialogHangs() throws Exception {
+		DefaultExceptionHandler handler = new DefaultExceptionHandler();
+		handler.interactiveOverride = Boolean.TRUE;
+		handler.watchdogMillis = 200L;
+
+		AtomicInteger code = new AtomicInteger(-999);
+		AtomicBoolean viaHardExit = new AtomicBoolean(false);
+		CountDownLatch exited = new CountDownLatch(1);
+		handler.exiter = c -> { code.set(c); exited.countDown(); };
+		handler.hardExiter = c -> {
+			viaHardExit.set(true);
+			code.set(c);
+			exited.countDown();
+		};
+
+		// a dialog that never returns, exactly as a modal blocks an
+		// unattended display; released after the assertions
+		CountDownLatch release = new CountDownLatch(1);
+		AtomicBoolean dialogEntered = new AtomicBoolean(false);
+		handler.dialogRunner = show -> {
+			dialogEntered.set(true);
+			try {
+				release.await();
+			} catch (InterruptedException ignored) {
+				Thread.currentThread().interrupt();
+			}
+		};
+
+		Thread worker = new Thread(
+				() -> handler.uncaughtException(Thread.currentThread(),
+						new RuntimeException("boom")),
+				"hang-worker");
+		worker.setDaemon(true);
+		worker.start();
+
+		assertTrue(exited.await(3, TimeUnit.SECONDS),
+				"the watchdog must terminate a hung dialog within bounds");
+		assertTrue(dialogEntered.get(), "the dialog was shown");
+		assertTrue(viaHardExit.get(), "the watchdog uses the hard exiter");
+		assertEquals(1, code.get(), "exit is non-zero");
+		release.countDown();
+	}
+
+	/**
+	 * P3: the attended path is unchanged - a dialog that returns (the user
+	 * dismissed it) exits immediately through the orderly exiter, well
+	 * before the watchdog would fire, and never uses the hard path.
+	 */
+	@Test
+	void dismissedDialogExitsImmediatelyWithoutWatchdog() throws Exception {
+		DefaultExceptionHandler handler = new DefaultExceptionHandler();
+		handler.interactiveOverride = Boolean.TRUE;
+		handler.watchdogMillis = 10_000L;
+
+		AtomicInteger code = new AtomicInteger(-999);
+		AtomicBoolean viaHardExit = new AtomicBoolean(false);
+		CountDownLatch exited = new CountDownLatch(1);
+		handler.exiter = c -> { code.set(c); exited.countDown(); };
+		handler.hardExiter = c -> { viaHardExit.set(true); exited.countDown(); };
+
+		AtomicBoolean dialogEntered = new AtomicBoolean(false);
+		handler.dialogRunner = show -> dialogEntered.set(true); // returns at once
+
+		handler.uncaughtException(Thread.currentThread(),
+				new RuntimeException("boom"));
+
+		assertTrue(exited.await(2, TimeUnit.SECONDS), "exited promptly");
+		assertTrue(dialogEntered.get(), "the dialog was shown to the user");
+		assertFalse(viaHardExit.get(),
+				"a dismissed dialog exits orderly, not via the watchdog");
+		assertEquals(1, code.get(), "exit is non-zero");
+	}
+
+	/**
+	 * P4 guard: the batch/headless path is untouched - it prints, writes
+	 * the trace, and exits non-zero with no dialog at all.
+	 */
+	@Test
+	void batchPathExitsWithoutDialog() throws Exception {
+		DefaultExceptionHandler handler = new DefaultExceptionHandler();
+		handler.interactiveOverride = Boolean.FALSE;
+
+		AtomicInteger code = new AtomicInteger(-999);
+		CountDownLatch exited = new CountDownLatch(1);
+		handler.exiter = c -> { code.set(c); exited.countDown(); };
+		AtomicBoolean dialogEntered = new AtomicBoolean(false);
+		handler.dialogRunner = show -> dialogEntered.set(true);
+
+		handler.uncaughtException(Thread.currentThread(),
+				new RuntimeException("boom"));
+
+		assertTrue(exited.await(2, TimeUnit.SECONDS), "batch exits");
+		assertEquals(1, code.get(), "exit is non-zero");
+		assertFalse(dialogEntered.get(), "batch shows no dialog");
+		assertTrue(new File("JLSerror").isFile(), "the trace file is written");
+	}
+}


### PR DESCRIPTION
…n't hang (#208)

DefaultExceptionHandler's interactive branch showed a modal error dialog and only then called System.exit. On a display-present-unattended run -- the @Tag("display") UI suite and first-light rigs under Xvfb, where GraphicsEnvironment.isHeadless() is false but no human is there -- the modal blocks the handler thread forever, the following System.exit never runs, and the process hangs until a wall-clock timeout (exit 124) instead of failing fast (issue #208).

Rather than classify the session (isHeadless can't tell an Xvfb CI lane from a user), guarantee a bounded exit unconditionally: before showing the dialog, arm a short daemon watchdog that force-halts after a timeout. A dismissed dialog exits immediately through the orderly exiter; an unattended one exits when the watchdog fires. A single AtomicBoolean ensures exactly one termination path runs. Applied to both the general and the OutOfMemory interactive branches; saveTrace still runs first, so JLSerror is written either way. The batch/headless path is unchanged.

The exit and dialog paths are package-private seams so the regression test drives them without a real display: a dialog stand-in that never returns still terminates within bounds via the watchdog (P2); a dialog that returns exits orderly before the watchdog (P3); the batch path exits with no dialog and writes the trace (P4). Watchdog interval is overridable via -Djls.exitWatchdogMillis for CI tuning.

riscv/gui/GuiDriver.java keeps its own handler neutralization (:97-104): the GUI driver was not re-exercised here, so per issue #208's method the workaround is left in place rather than removed on an unverified run.


Claude-Session: https://claude.ai/code/session_01BgMdmXhGdbFyuqDNEbtj6v
