### PR TITLE
Guard legacy Splitter/Binder loads against misread noncontig sets (#198)

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -294,7 +294,7 @@ Version-1 and version-2 writers emit exactly these 32 tags:
 |---|---|---|
 | `Adder` | ripple adder | |
 | `AndGate` | AND gate | |
-| `Binder` | wire bundler | `pair` items: (input index, bundle bit); `orient` values `UP`/`DOWN` require version 2 (§4) |
+| `Binder` | wire bundler | `pair` items: (input index, bundle bit); **requires `String noncontig "true"`** (see note below); `orient` values `UP`/`DOWN` require version 2 (§4) |
 | `Clock` | clock generator | |
 | `Constant` | constant driver | value is an `Int` item |
 | `Decoder` | decoder | |
@@ -315,7 +315,7 @@ Version-1 and version-2 writers emit exactly these 32 tags:
 | `Register` | latch / D flip-flop | |
 | `ShiftRegister` | combinational barrel shifter | despite the name, stateless; tag and attributes match the bsiever-fork 4.6 element (issue #122) |
 | `SigGen` | signal generator | |
-| `Splitter` | wire unbundler | `pair` items: (output index, bundle bit); `orient` values `UP`/`DOWN` require version 2 (§4) |
+| `Splitter` | wire unbundler | `pair` items: (output index, bundle bit); **requires `String noncontig "true"`** (see note below); `orient` values `UP`/`DOWN` require version 2 (§4) |
 | `StateMachine` | finite state machine | state list encoded as ordered `String state`/`output`/`trans`/`next` items with interleaved `int`/`long` values; the item *sequence* is significant for this type only |
 | `Stop` | simulation stop control | |
 | `SubCircuit` | nested circuit instance | body contains one nested `CIRCUIT` block (no `FORMAT` line) |
@@ -336,6 +336,22 @@ Additional notes:
 - **Gate `pair`/sequence-free types**: for every type except
   `StateMachine`, items are order-independent; `pair` items are
   applied in file order.
+- **`Binder`/`Splitter` `noncontig` flag** (issue #198): the
+  `pair` semantics tabulated above — `(index, bundle bit)`, where
+  several pairs sharing an `index` accumulate their bits into that
+  one put — are the *non-contiguous* reading, selected only when the
+  element carries `String noncontig "true"`. A conformant writer
+  MUST emit this flag on every `Binder`/`Splitter`; JLS itself
+  always does. Its absence selects a legacy reading in which each
+  `pair a b` is instead one contiguous bit range `[a..b]` on a
+  distinct put — a different port count and bit routing. A reader
+  MUST NOT silently apply the legacy reading to a set whose ranges
+  overlap or descend (bits reused across puts, or `a > b`): that is
+  the signature of a `noncontig` file missing the flag, and the
+  reference reader rejects it with a diagnostic naming the flag
+  rather than mis-loading a different element. A genuine legacy
+  group (pre-flag JLS saves) has disjoint ascending ranges and
+  still loads.
 - **`TestGen`** is a loadable-but-not-writable tag: the reference
   reader accepts it (it exists for the batch test facility) but a
   conformant writer never emits it. Readers MAY reject it.

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -309,10 +309,68 @@ public abstract sealed class Group extends LogicElement
 			}
 			ranges.set(v1, e);
 		} else {
-			// Legacy save file: sorted, contiguous ranges
-			ranges.add(new Entry(v1, v2));
+			// Legacy save file: sorted, contiguous ranges. A legitimate
+			// GUI-authored legacy group assigns each bundle bit to
+			// exactly one put, so its contiguous ranges are disjoint and
+			// ascending (issue #198, O5: the dialog's `picked` flag
+			// forbids reusing a bit). A descending or overlapping range
+			// is instead the signature of a file that meant the
+			// (put index, bundle bit) "noncontig" reading but omitted
+			// the required `noncontig "true"` flag - which would
+			// otherwise silently mis-load as a different element (issue
+			// #198, O2). Reject it with a message that names the fix
+			// rather than mis-loading.
+			if (v1 > v2) {
+				throw new IllegalArgumentException(noncontigHint(v1, v2));
+			}
+			Entry candidate = new Entry(v1, v2);
+			for (Entry existing : ranges) {
+				if (existing != null && rangesOverlap(existing, candidate)) {
+					throw new IllegalArgumentException(
+							noncontigHint(v1, v2));
+				}
+			}
+			ranges.add(candidate);
 		}
 	} // end of setPair method
+
+	/**
+	 * Whether two contiguous legacy ranges share any bit index. Both
+	 * entries are ascending, non-empty contiguous ranges here (built by
+	 * {@link Entry#Entry(int,int)} in the legacy load path), so an
+	 * endpoint comparison suffices.
+	 *
+	 * @param a One range.
+	 * @param b The other range.
+	 * @return True if the ranges intersect.
+	 */
+	private static boolean rangesOverlap(Entry a, Entry b) {
+		if (a.getSize() == 0 || b.getSize() == 0) {
+			return false;
+		}
+		return a.getMin() <= b.getMax() && b.getMin() <= a.getMax();
+	} // end of rangesOverlap method
+
+	/**
+	 * The load-error message for a legacy (flag-absent) {@code pair} set
+	 * that overlaps or descends - the signature of a misread
+	 * {@code noncontig} file (issue #198). Names the missing flag so a
+	 * third-party writer can fix its output.
+	 *
+	 * @param v1 The offending pair's first value.
+	 * @param v2 The offending pair's second value.
+	 * @return The message, consumed as a {@code LoadError} detail.
+	 */
+	private String noncontigHint(int v1, int v2) {
+		return "this " + getClass().getSimpleName().toLowerCase()
+				+ "'s bit routing has an invalid or overlapping range at "
+				+ "pair (" + v1 + " " + v2 + "): a legacy contiguous group "
+				+ "never reuses a bit or lists a descending range. A file "
+				+ "written to the (index, bundle bit) pair semantics must "
+				+ "declare `String noncontig \"true\"` on this element - "
+				+ "the flag JLS writes for every group - or be re-saved "
+				+ "from JLS";
+	} // end of noncontigHint method
 	
 	/**
 	 * The bit routing of this binder/splitter, one entry per bundled

--- a/test/jls/CircuitLoadErrorTest.java
+++ b/test/jls/CircuitLoadErrorTest.java
@@ -61,6 +61,64 @@ class CircuitLoadErrorTest {
 	 * so the circuit simulated subtly wrong with no diagnostic. It must now be
 	 * rejected during assembly (issue #58).
 	 */
+	/**
+	 * A Splitter/Binder pair set is read two incompatible ways: with
+	 * {@code String noncontig "true"} each {@code pair i b} accumulates
+	 * bundle bit {@code b} into put {@code i}; without it (the legacy
+	 * default) each {@code pair a b} is a distinct contiguous range
+	 * {@code [a..b]}. A third-party writer that follows the spec's
+	 * "(index, bundle bit)" pair semantics but omits the flag used to
+	 * silently mis-load as a different element (issue #198). Such a
+	 * flag-absent set has overlapping ranges - the signature of the
+	 * misread - and must now be rejected with a message naming the flag.
+	 */
+	@Test
+	void legacyGroupWithOverlappingRangesNamesTheNoncontigFlag() {
+		// pairs (0,0),(0,1),(1,2) as (put,bit) meant a 2-port splitter;
+		// read as legacy contiguous ranges they are [0..0],[0..1],[1..2]
+		// - overlapping at bits 0 and 2.
+		String error = rejectAndGetError("CIRCUIT g\nELEMENT Splitter\n"
+				+ " int id 0\n int bits 4\n String orient \"RIGHT\"\n"
+				+ " int tristate 0\n pair 0 0\n pair 0 1\n pair 1 2\nEND\n"
+				+ "ENDCIRCUIT\n");
+		assertTrue(error.contains("noncontig"), "got: " + error);
+	}
+
+	/**
+	 * A genuine legacy group (pre-flag JLS saves) partitions the bundle
+	 * into disjoint ascending contiguous ranges, so it must still load
+	 * unchanged - the guard rejects only overlapping/descending sets
+	 * (issue #198, P3).
+	 */
+	@Test
+	void legacyGroupWithDisjointRangesStillLoads() {
+		JLSInfo.loadError = "";
+		Circuit circuit = new Circuit("g");
+		assertTrue(circuit.load(new Scanner("CIRCUIT g\nELEMENT Splitter\n"
+				+ " int id 0\n int bits 8\n String orient \"RIGHT\"\n"
+				+ " int tristate 0\n pair 0 3\n pair 4 7\nEND\n"
+				+ "ENDCIRCUIT\n")),
+				"a disjoint legacy group must still load: " + JLSInfo.loadError);
+	}
+
+	/**
+	 * The modern (flagged) path is untouched: the same shared-index
+	 * pairs that are rejected without the flag load fine with it, since
+	 * they accumulate into puts rather than forming ranges (issue #198,
+	 * P4).
+	 */
+	@Test
+	void noncontigGroupWithSharedIndexStillLoads() {
+		JLSInfo.loadError = "";
+		Circuit circuit = new Circuit("g");
+		assertTrue(circuit.load(new Scanner("CIRCUIT g\nELEMENT Splitter\n"
+				+ " int id 0\n int bits 4\n String orient \"RIGHT\"\n"
+				+ " String noncontig \"true\"\n int tristate 0\n"
+				+ " pair 0 0\n pair 0 1\n pair 1 2\nEND\n"
+				+ "ENDCIRCUIT\n")),
+				"a flagged noncontig group must load: " + JLSInfo.loadError);
+	}
+
 	@Test
 	void duplicateWireEndAttachmentIsRejected() throws Exception {
 		String text = "CIRCUIT dup\n"


### PR DESCRIPTION
A `.jls` Binder/Splitter `pair a b` set is read two incompatible ways: with `String noncontig "true"` each pair is (put index, bundle bit) and several pairs sharing an index accumulate into one put; without it (the legacy default) each `pair a b` is a distinct contiguous range [a..b]. A third-party writer following the spec's documented "(index, bundle bit)" pair semantics but omitting the undocumented flag silently loaded a different element -- a different port count and bit routing, no diagnostic (issue #198, O2).

Two independent gaps, closed here:

- docs/file-format.md never named the `noncontig` flag that selects the documented pair semantics. Now the Binder/Splitter rows require it and a new §7 note explains the two readings and the overlap guard.

- The legacy load path applied the contiguous reading with no consistency check. A legitimate GUI-authored legacy group has disjoint ascending ranges (the dialog's `picked` flag forbids reusing a bit, O5); an overlapping or descending range is the signature of a misread noncontig file. Group.setPair now rejects those via IllegalArgumentException -> ELEMENT_ERROR LoadError whose message names the missing flag, instead of mis-loading.

Regression tests (CircuitLoadErrorTest): overlapping flag-absent set is rejected naming `noncontig` (P2); disjoint legacy set still loads (P3); flagged shared-index set still loads (P4). FileFormatSpecTest and GroupOrientationTest stay green.


Claude-Session: https://claude.ai/code/session_01BgMdmXhGdbFyuqDNEbtj6v
