### PR TITLE
Convert HdlModel.Port/Net/Operand and HdlExporter.Result to records (…

### DIFF
--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -383,7 +383,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 				System.exit(1);
 				return; // unreachable; keeps result definitely assigned
 			}
-			for (String warning : result.warnings) {
+			for (String warning : result.warnings()) {
 				System.err.println("jls: warning: " + warning);
 			}
 
@@ -392,7 +392,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 			Path target = Path.of(exportFile);
 			Path temp = Path.of(exportFile + ".tmp");
 			try {
-				java.nio.file.Files.writeString(temp, result.text,
+				java.nio.file.Files.writeString(temp, result.text(),
 						StandardCharsets.UTF_8);
 				try {
 					java.nio.file.Files.move(temp, target,

--- a/src/jls/hdl/HdlExporter.java
+++ b/src/jls/hdl/HdlExporter.java
@@ -2,7 +2,6 @@ package jls.hdl;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -97,25 +96,23 @@ public final class HdlExporter {
 	private HdlExporter() {
 	} // not instantiable
 
-	/** What the exporter produced: text plus non-fatal warnings. */
-	public static final class Result {
-
-		/** The rendered target-language text. */
-		public final String text;
-		/** Non-fatal messages produced during the walk, unmodifiable. */
-		public final List<String> warnings;
+	/**
+	 * What the exporter produced (a record, issue #94).
+	 *
+	 * @param text The rendered target-language text.
+	 * @param warnings Non-fatal messages produced during the walk;
+	 *                 copied and made immutable.
+	 */
+	public record Result(String text, List<String> warnings) {
 
 		/**
-		 * Captures one export's output.
-		 * @param text The rendered target-language text.
-		 * @param warnings Non-fatal messages; copied and made immutable.
+		 * Pins the warnings to an immutable copy, so the record stays a
+		 * value no matter what list the exporter handed in.
 		 */
-		Result(String text, List<String> warnings) {
-			this.text = text;
-			this.warnings = Collections.unmodifiableList(
-					new ArrayList<String>(warnings));
+		public Result {
+			warnings = List.copyOf(warnings);
 		}
-	} // end of Result class
+	} // end of Result record
 
 	/**
 	 * Export a loaded circuit through the given emitter.

--- a/src/jls/hdl/HdlModel.java
+++ b/src/jls/hdl/HdlModel.java
@@ -32,78 +32,52 @@ public final class HdlModel {
 		OUTPUT
 	} // end of Direction enum
 
-	/** One module port. */
-	public static final class Port {
+	/**
+	 * One module port (a record, issue #94).
+	 *
+	 * @param name Legalized HDL identifier for the port.
+	 * @param direction Whether the port is an input or an output.
+	 * @param bits Width of the port in bits.
+	 * @param comment Human context for the port (element kind, width).
+	 */
+	public record Port(String name, Direction direction, int bits,
+			String comment) {
+	} // end of Port record
 
-		/** Legalized HDL identifier for the port. */
-		public final String name;
-		/** Whether the port is an input or an output. */
-		public final Direction direction;
-		/** Width of the port in bits. */
-		public final int bits;
-		/** Human context for the port (element kind, width), or null. */
-		public final String comment;
-
-		/**
-		 * Builds an immutable port descriptor.
-		 * @param name legalized HDL identifier for the port
-		 * @param direction whether the port is an input or an output
-		 * @param bits width of the port in bits
-		 * @param comment human context (element kind, width), or null
-		 */
-		Port(String name, Direction direction, int bits, String comment) {
-			this.name = name;
-			this.direction = direction;
-			this.bits = bits;
-			this.comment = comment;
-		}
-	} // end of Port class
-
-	/** One internal net (a wire that is not a port). */
-	public static final class Net {
-
-		/** Legalized HDL identifier for the net. */
-		public final String name;
-		/** Width of the net in bits. */
-		public final int bits;
-
-		/**
-		 * Builds an immutable internal-net descriptor.
-		 * @param name legalized HDL identifier for the net
-		 * @param bits width of the net in bits
-		 */
-		Net(String name, int bits) {
-			this.name = name;
-			this.bits = bits;
-		}
-	} // end of Net class
+	/**
+	 * One internal net (a wire that is not a port) — a record, issue #94.
+	 *
+	 * @param name Legalized HDL identifier for the net.
+	 * @param bits Width of the net in bits.
+	 */
+	public record Net(String name, int bits) {
+	} // end of Net record
 
 	/**
 	 * A statement operand: either a reference to a whole net (or port)
 	 * or a literal value of a known width. Unattached element inputs
 	 * become zero literals, matching JLS's absent-inputs-read-as-0
-	 * simulation rule (docs/simulation-semantics.md).
+	 * simulation rule (docs/simulation-semantics.md). A record (issue
+	 * #94); exactly one of {@code netName}/{@code literalValue} is
+	 * non-null, so build instances through {@link #net} or
+	 * {@link #literal}.
+	 *
+	 * @param netName Referenced net name; null for literals.
+	 * @param literalValue Literal value; null for net references.
+	 * @param bits Operand width in bits.
 	 */
-	public static final class Operand {
-
-		/** Referenced net name; null for literals. */
-		private final @Nullable String net;
-		/** Literal value; null for net references. */
-		private final @Nullable BigInteger literal;
-		/** Operand width in bits. */
-		private final int bits;
+	public record Operand(@Nullable String netName,
+			@Nullable BigInteger literalValue, int bits) {
 
 		/**
-		 * Private canonical constructor; use {@link #net} or
-		 * {@link #literal}. Exactly one of net/literal is non-null.
-		 * @param net referenced net name, or null for a literal
-		 * @param literal literal value, or null for a net reference
-		 * @param bits operand width in bits
+		 * Rejects the component mixes the factories never produce
+		 * (both null, or both non-null).
 		 */
-		private Operand(@Nullable String net, @Nullable BigInteger literal, int bits) {
-			this.net = net;
-			this.literal = literal;
-			this.bits = bits;
+		public Operand {
+			if ((netName == null) == (literalValue == null)) {
+				throw new IllegalArgumentException(
+						"exactly one of netName/literalValue must be non-null");
+			}
 		}
 
 		/**
@@ -131,33 +105,9 @@ public final class HdlModel {
 		 * @return true if this operand references a net, false if literal
 		 */
 		public boolean isNet() {
-			return net != null;
+			return netName != null;
 		}
-
-		/**
-		 * Gives the net this operand references, if any.
-		 * @return the referenced net name, or null for a literal
-		 */
-		public @Nullable String netName() {
-			return net;
-		}
-
-		/**
-		 * Gives the constant this operand carries, if any.
-		 * @return the literal value, or null for a net reference
-		 */
-		public @Nullable BigInteger literalValue() {
-			return literal;
-		}
-
-		/**
-		 * Gives the operand's width.
-		 * @return operand width in bits
-		 */
-		public int bits() {
-			return bits;
-		}
-	} // end of Operand class
+	} // end of Operand record
 
 	/** Base of all statements: one per exported element. */
 	public abstract static class Statement {

--- a/src/jls/hdl/VerilogEmitter.java
+++ b/src/jls/hdl/VerilogEmitter.java
@@ -91,7 +91,7 @@ public final class VerilogEmitter implements HdlEmitter {
 		out.append("module ").append(model.moduleName);
 		List<String> portNames = new ArrayList<String>();
 		for (HdlModel.Port port : model.ports()) {
-			portNames.add(port.name);
+			portNames.add(port.name());
 		}
 		if (!portNames.isEmpty()) {
 			out.append(" (").append(String.join(", ", portNames))
@@ -109,12 +109,12 @@ public final class VerilogEmitter implements HdlEmitter {
 
 		for (HdlModel.Port port : model.ports()) {
 			out.append("  ").append(
-					port.direction == HdlModel.Direction.INPUT
+					port.direction() == HdlModel.Direction.INPUT
 							? "input" : "output")
-					.append(range(port.bits)).append(' ').append(port.name)
+					.append(range(port.bits())).append(' ').append(port.name())
 					.append(';');
-			if (port.comment != null) {
-				out.append("  // ").append(port.comment);
+			if (port.comment() != null) {
+				out.append("  // ").append(port.comment());
 			}
 			out.append('\n');
 		}
@@ -133,8 +133,8 @@ public final class VerilogEmitter implements HdlEmitter {
 		}
 		out.append('\n');
 		for (HdlModel.Net net : model.nets()) {
-			out.append("  wire").append(range(net.bits)).append(' ')
-					.append(net.name).append(";\n");
+			out.append("  wire").append(range(net.bits())).append(' ')
+					.append(net.name()).append(";\n");
 		}
 	} // end of netDeclarations method
 

--- a/src/jls/hdl/VhdlEmitter.java
+++ b/src/jls/hdl/VhdlEmitter.java
@@ -125,15 +125,15 @@ public final class VhdlEmitter implements HdlEmitter {
 			out.append("  port (\n");
 			for (int p = 0; p < ports.size(); p += 1) {
 				HdlModel.Port port = ports.get(p);
-				out.append("    ").append(names.of(port.name)).append(" : ")
-						.append(port.direction == HdlModel.Direction.INPUT
+				out.append("    ").append(names.of(port.name())).append(" : ")
+						.append(port.direction() == HdlModel.Direction.INPUT
 								? "in " : "out ")
-						.append(type(port.bits));
+						.append(type(port.bits()));
 				if (p < ports.size() - 1) {
 					out.append(';');
 				}
-				if (port.comment != null) {
-					out.append("  -- ").append(port.comment);
+				if (port.comment() != null) {
+					out.append("  -- ").append(port.comment());
 				}
 				out.append('\n');
 			}
@@ -157,8 +157,8 @@ public final class VhdlEmitter implements HdlEmitter {
 		out.append("architecture structural of ").append(names.moduleName)
 				.append(" is\n");
 		for (HdlModel.Net net : model.nets()) {
-			out.append("  signal ").append(names.of(net.name)).append(" : ")
-					.append(type(net.bits)).append(";\n");
+			out.append("  signal ").append(names.of(net.name())).append(" : ")
+					.append(type(net.bits())).append(";\n");
 		}
 		out.append(declarations);
 		out.append("begin\n");
@@ -727,10 +727,10 @@ public final class VhdlEmitter implements HdlEmitter {
 
 			moduleName = unique(sanitize(model.moduleName));
 			for (HdlModel.Port port : model.ports()) {
-				claim(port.name);
+				claim(port.name());
 			}
 			for (HdlModel.Net net : model.nets()) {
-				claim(net.name);
+				claim(net.name());
 			}
 			for (HdlModel.Statement statement : model.statements()) {
 				if (statement instanceof HdlModel.RegisterStatement) {

--- a/test/jls/hdl/HdlPolicyTest.java
+++ b/test/jls/hdl/HdlPolicyTest.java
@@ -29,15 +29,15 @@ class HdlPolicyTest {
 
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VerilogEmitter());
-		assertEquals(1, result.warnings.size(), "one skip warning expected");
-		assertTrue(result.warnings.get(0).contains("Display"),
-				result.warnings.get(0));
-		assertTrue(result.warnings.get(0).contains("skipped"),
-				result.warnings.get(0));
-		assertFalse(result.text.contains("Display"),
+		assertEquals(1, result.warnings().size(), "one skip warning expected");
+		assertTrue(result.warnings().get(0).contains("Display"),
+				result.warnings().get(0));
+		assertTrue(result.warnings().get(0).contains("skipped"),
+				result.warnings().get(0));
+		assertFalse(result.text().contains("Display"),
 				"a skipped element must leave no trace in the output");
 		// the rest of the circuit still exports
-		assertTrue(result.text.contains("assign y = a;"), result.text);
+		assertTrue(result.text().contains("assign y = a;"), result.text());
 	}
 
 	@Test
@@ -52,7 +52,7 @@ class HdlPolicyTest {
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VerilogEmitter());
 		List<String> kinds = new ArrayList<String>();
-		for (String warning : result.warnings) {
+		for (String warning : result.warnings()) {
 			kinds.add(warning.split(" ")[0]);
 		}
 		assertEquals(List.of("SigGen", "Stop"), kinds,
@@ -115,13 +115,13 @@ class HdlPolicyTest {
 
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VerilogEmitter());
-		VerilogStructure.assertSane(result.text);
-		assertTrue(result.text.contains("select unattached, reads 0"),
-				result.text);
-		assertTrue(result.text.contains("assign net_2 = a;"), result.text);
-		assertTrue(result.text.contains("assign y = net_2;"), result.text);
-		assertFalse(result.text.contains("case"),
-				"a folded mux must not emit a case: " + result.text);
+		VerilogStructure.assertSane(result.text());
+		assertTrue(result.text().contains("select unattached, reads 0"),
+				result.text());
+		assertTrue(result.text().contains("assign net_2 = a;"), result.text());
+		assertTrue(result.text().contains("assign y = net_2;"), result.text());
+		assertFalse(result.text().contains("case"),
+				"a folded mux must not emit a case: " + result.text());
 	}
 
 	@Test
@@ -136,12 +136,12 @@ class HdlPolicyTest {
 
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VerilogEmitter());
-		VerilogStructure.assertSane(result.text);
-		assertTrue(result.text.contains("input unattached, reads 0"),
-				result.text);
-		assertTrue(result.text.contains("assign net_0 = 2'h1;"),
-				result.text);
-		assertTrue(result.text.contains("assign y = net_0;"), result.text);
+		VerilogStructure.assertSane(result.text());
+		assertTrue(result.text().contains("input unattached, reads 0"),
+				result.text());
+		assertTrue(result.text().contains("assign net_0 = 2'h1;"),
+				result.text());
+		assertTrue(result.text().contains("assign y = net_0;"), result.text());
 	}
 
 	@Test
@@ -165,7 +165,7 @@ class HdlPolicyTest {
 		HdlModel model = HdlExporter.buildModel(cb.load());
 		assertEquals(1, model.nets().size(),
 				"the three jump-aliased wire nets must fuse into one");
-		assertEquals("mid", model.nets().get(0).name,
+		assertEquals("mid", model.nets().get(0).name(),
 				"the fused net carries the jump name");
 
 		String text = new VerilogEmitter().emit(model);
@@ -184,10 +184,10 @@ class HdlPolicyTest {
 
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VerilogEmitter());
-		assertEquals(1, result.warnings.size());
-		assertTrue(result.warnings.get(0).contains("OutputPin \"y\""),
-				result.warnings.get(0));
-		assertFalse(result.text.contains("assign y"), result.text);
+		assertEquals(1, result.warnings().size());
+		assertTrue(result.warnings().get(0).contains("OutputPin \"y\""),
+				result.warnings().get(0));
+		assertFalse(result.text().contains("assign y"), result.text());
 	}
 
 } // end of HdlPolicyTest class

--- a/test/jls/hdl/VerilogExportGoldenTest.java
+++ b/test/jls/hdl/VerilogExportGoldenTest.java
@@ -38,10 +38,10 @@ class VerilogExportGoldenTest {
 		Circuit circuit = cb.load();
 		HdlExporter.Result result =
 				HdlExporter.export(circuit, new VerilogEmitter());
-		VerilogStructure.assertSane(result.text);
+		VerilogStructure.assertSane(result.text());
 
 		String tokenized =
-				result.text.replace(JLSInfo.versionString, VERSION_TOKEN);
+				result.text().replace(JLSInfo.versionString, VERSION_TOKEN);
 		Path golden = GOLDEN_DIR.resolve(goldenName + ".v");
 		if (Boolean.getBoolean("jls.hdl.regenerate")) {
 			Files.writeString(golden, tokenized, StandardCharsets.UTF_8);

--- a/test/jls/hdl/VhdlEmitterPolicyTest.java
+++ b/test/jls/hdl/VhdlEmitterPolicyTest.java
@@ -22,8 +22,8 @@ class VhdlEmitterPolicyTest {
 
 		HdlExporter.Result result =
 				HdlExporter.export(cb.load(), new VhdlEmitter());
-		VhdlStructure.assertSane(result.text);
-		return result.text;
+		VhdlStructure.assertSane(result.text());
+		return result.text();
 	}
 
 	@Test
@@ -140,8 +140,8 @@ class VhdlEmitterPolicyTest {
 				HdlExporter.export(cb.load(), new VerilogEmitter());
 		HdlExporter.Result vhdl =
 				HdlExporter.export(cb.load(), new VhdlEmitter());
-		org.junit.jupiter.api.Assertions.assertEquals(verilog.warnings,
-				vhdl.warnings,
+		org.junit.jupiter.api.Assertions.assertEquals(verilog.warnings(),
+				vhdl.warnings(),
 				"one walk, one policy: warnings must match across languages");
 	}
 

--- a/test/jls/hdl/VhdlExportGoldenTest.java
+++ b/test/jls/hdl/VhdlExportGoldenTest.java
@@ -38,10 +38,10 @@ class VhdlExportGoldenTest {
 		Circuit circuit = cb.load();
 		HdlExporter.Result result =
 				HdlExporter.export(circuit, new VhdlEmitter());
-		VhdlStructure.assertSane(result.text);
+		VhdlStructure.assertSane(result.text());
 
 		String tokenized =
-				result.text.replace(JLSInfo.versionString, VERSION_TOKEN);
+				result.text().replace(JLSInfo.versionString, VERSION_TOKEN);
 		Path golden = GOLDEN_DIR.resolve(goldenName + ".vhdl");
 		if (Boolean.getBoolean("jls.hdl.regenerate")) {
 			Files.writeString(golden, tokenized, StandardCharsets.UTF_8);


### PR DESCRIPTION
…#94)

The last four verified value-carrier candidates from the #94 survey. Port and Net were hand-written immutable field bundles; Operand keeps its net()/literal() factories and isNet() helper, with its exactly-one- of-netName/literalValue invariant enforced in the compact constructor now that the canonical constructor is public; Result pins warnings via List.copyOf. Callers move from public final fields to the generated accessors (Operand's components are named after its old accessors, so its call sites are untouched).

Behavior evidence: full mvn clean verify runs 1109 tests, 0 failures (88 display skips, headless); the Verilog/VHDL golden-export tests pin byte-identical output. The coverage-ratchet failure is pre-existing and headless-only: unmodified master fails with identical ratios (0.508/0.495/0.544).

Closes #94.


Claude-Session: https://claude.ai/code/session_018bdH69uZW8D2JxFtXawpVj