### PR TITLE
Seal SimEvent's payload into a typed sealed hierarchy (#95)

### DIFF
--- a/src/jls/elem/Adder.java
+++ b/src/jls/elem/Adder.java
@@ -10,6 +10,13 @@ import jls.core.Geometry;
 import jls.core.GridPoint;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * An n-bit adder with carry in and carry out (n chosen by user).
@@ -379,13 +386,15 @@ public final class Adder extends LogicElement implements Timed {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo Unused.
+	 * @param todo PinChanged if an input has changed, otherwise the value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if the input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get the input values
 			BitSet a = inputs.get(0).getValue();
@@ -409,13 +418,12 @@ public final class Adder extends LogicElement implements Timed {
 			// the adder, then post an event
 			if (!allsum.equals(toBeValue)) {
 				toBeValue = (BitSet)allsum.clone();
-				sim.post(new SimEvent(now+propDelay,this,allsum));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(allsum)));
 			}
 		}
-		else {
 
-			// get the new output value
-			BitSet allsum = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet allsum) -> {
 
 			// break into sum and carry
 			BitSet sum = (BitSet)allsum.clone();
@@ -428,6 +436,11 @@ public final class Adder extends LogicElement implements Timed {
 			sumOut.propagate(sum,now,sim);
 			Output carryOut = outputs.get(1);
 			carryOut.propagate(carry,now,sim);
+		}
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 	} // end of react method
 

--- a/src/jls/elem/Binder.java
+++ b/src/jls/elem/Binder.java
@@ -6,6 +6,7 @@ import java.util.BitSet;
 import jls.Circuit;
 import jls.core.Geometry;
 import jls.core.Orientation;
+import jls.sim.SimEvent;
 import jls.sim.Simulator;
 
 /**
@@ -229,7 +230,7 @@ public final class Binder extends Group implements TriProp {
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// create output value
 		BitSet newValue = new BitSet(bits);

--- a/src/jls/elem/Clock.java
+++ b/src/jls/elem/Clock.java
@@ -10,6 +10,13 @@ import jls.core.Geometry;
 import jls.core.GridPoint;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Clock element.
@@ -393,7 +400,7 @@ public final class Clock extends LogicElement {
 		out.setValue(zero);
 		BitSet one = new BitSet();
 		one.flip(0);
-		sim.post(new SimEvent(cycleTime-oneTime,this,one));
+		sim.post(new SimEvent(cycleTime-oneTime,this,new NewValue(one)));
 
 	} // end of initSim method
 
@@ -402,29 +409,34 @@ public final class Clock extends LogicElement {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo The value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// send new value; a Clock has no inputs, so it only ever
-		// reacts to its own posted value events (todo is never null)
-		BitSet send = (BitSet)todo;
-		if (send == null) {
+		// reacts to its own posted value events
+		switch (todo) {
+
+		case NewValue(BitSet send) -> {
+			Output out = outputs.get(0);
+			out.propagate(send,now,sim);
+
+			// post next event
+			BitSet next = (BitSet)send.clone();
+			next.flip(0);
+			int when = oneTime;
+			if (send.cardinality() == 0) {
+				when = cycleTime - oneTime;
+			}
+			sim.post(new SimEvent(now+when,this,new NewValue(next)));
+		}
+
+		case PinChanged _, TriStateOff _, StateChanged _, MemoryRead _,
+				MemoryWrite _, TableOutput _ ->
 			throw new IllegalStateException(
 					"clock reacted without a value to output");
 		}
-		Output out = outputs.get(0);
-		out.propagate(send,now,sim);
-
-		// post next event
-		BitSet next = (BitSet)send.clone();
-		next.flip(0);
-		int when = oneTime;
-		if (send.cardinality() == 0) {
-			when = cycleTime - oneTime;
-		}
-		sim.post(new SimEvent(now+when,this,next));
 
 	} // end of react method
 

--- a/src/jls/elem/Constant.java
+++ b/src/jls/elem/Constant.java
@@ -8,6 +8,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Constant output value.
@@ -473,7 +480,7 @@ public final class Constant extends LogicElement {
 		out.setValue(opposite);
 
 		// post output event
-		sim.post(new SimEvent(0,this,bitval));
+		sim.post(new SimEvent(0,this,new NewValue(bitval)));
 	} // end of initSim method
 
 	/**
@@ -481,31 +488,36 @@ public final class Constant extends LogicElement {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo The value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// get the new output value; a Constant has no inputs, so it only
-		// ever reacts to its own posted value events (todo is never null)
-		BitSet newValue = (BitSet)todo;
-		if (newValue == null) {
+		// ever reacts to its own posted value events
+		switch (todo) {
+
+		case NewValue(BitSet newValue) -> {
+
+			// send correct number of bits to output
+			Output out = (Output)(outputs.toArray()[0]);
+			if (!out.isAttached())
+				return;
+			WireEnd end = out.getWireEnd();
+			if (end == null)
+				throw new IllegalStateException("attached output has no wire end");
+			int bits = end.getBits();
+			BitSet mask = new BitSet(bits);
+			mask.set(0,bits);
+			newValue.and(mask);
+			out.propagate(newValue,now,sim);
+		}
+
+		case PinChanged _, TriStateOff _, StateChanged _, MemoryRead _,
+				MemoryWrite _, TableOutput _ ->
 			throw new IllegalStateException(
 					"constant reacted without a value to output");
 		}
-
-		// send correct number of bits to output
-		Output out = (Output)(outputs.toArray()[0]);
-		if (!out.isAttached())
-			return;
-		WireEnd end = out.getWireEnd();
-		if (end == null)
-			throw new IllegalStateException("attached output has no wire end");
-		int bits = end.getBits();
-		BitSet mask = new BitSet(bits);
-		mask.set(0,bits);
-		newValue.and(mask);
-		out.propagate(newValue,now,sim);
 
 	} // end of react method
 

--- a/src/jls/elem/Decoder.java
+++ b/src/jls/elem/Decoder.java
@@ -10,6 +10,13 @@ import jls.Circuit;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.SimEvent;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 import jls.sim.Simulator;
 
 /**
@@ -446,7 +453,7 @@ public final class Decoder extends LogicElement implements Timed {
 		// set post output change to 1
 		BitSet one = new BitSet(1);
 		one.flip(0);
-		sim.post(new SimEvent(0,this,one));
+		sim.post(new SimEvent(0,this,new NewValue(one)));
 
 		// set to-be value
 		toBeValue = (BitSet)one.clone();
@@ -457,13 +464,15 @@ public final class Decoder extends LogicElement implements Timed {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo Unused.
+	 * @param todo PinChanged if an input has changed, otherwise the value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if the input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get the input value
 			BitSet value = inputs.get(0).getValue();
@@ -479,17 +488,21 @@ public final class Decoder extends LogicElement implements Timed {
 			// the decoder, then post an event
 			if (!newValue.equals(toBeValue)) {
 				toBeValue = (BitSet)newValue.clone();
-				sim.post(new SimEvent(now+propDelay,this,newValue));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(newValue)));
 			}
 		}
-		else {
 
-			// get the new output value
-			BitSet newValue = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet newValue) -> {
 
 			// send to output
 			Output out = outputs.get(0);
 			out.propagate(newValue,now,sim);
+		}
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 	} // end of react method
 

--- a/src/jls/elem/Display.java
+++ b/src/jls/elem/Display.java
@@ -11,6 +11,7 @@ import jls.BitSetUtils;
 import jls.Circuit;
 import jls.core.Geometry;
 import jls.core.Orientation;
+import jls.sim.SimEvent;
 import jls.sim.Simulator;
 
 /**
@@ -383,7 +384,7 @@ public final class Display extends LogicElement {
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		currentValue = inputs.get(0).getValue();
 	} // end of react method

--- a/src/jls/elem/Extend.java
+++ b/src/jls/elem/Extend.java
@@ -214,7 +214,7 @@ public final class Extend extends Gate implements TriProp {
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// get the input value
 		BitSet value = inputs.get(0).getValue();

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -10,6 +10,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Superclass of all simple gates (AND, OR, etc).
@@ -673,7 +680,7 @@ public abstract sealed class Gate extends LogicElement
 		// drive the all-zero-inputs output value
 		BitSet initial = computeOutput();
 		if (!initial.isEmpty()) {
-			sim.post(new SimEvent(0,this,initial));
+			sim.post(new SimEvent(0,this,new NewValue(initial)));
 		}
 		toBeValue = (BitSet)initial.clone();
 	} // end of initSim method
@@ -683,13 +690,15 @@ public abstract sealed class Gate extends LogicElement
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if the input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			BitSet value = computeOutput();
 
@@ -697,14 +706,17 @@ public abstract sealed class Gate extends LogicElement
 			// this gate, then post an event
 			if (!value.equals(toBeValue)) {
 				toBeValue = (BitSet)value.clone();
-				sim.post(new SimEvent(now+propDelay,this,value));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(value)));
 			}
 		}
-		else {
 
-			// send the new output value to the output
-			BitSet newValue = (BitSet)todo;
+		// send the new output value to the output
+		case NewValue(BitSet newValue) ->
 			outputs.get(0).propagate(newValue,now,sim);
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 	} // end of react method
 

--- a/src/jls/elem/InputPin.java
+++ b/src/jls/elem/InputPin.java
@@ -7,6 +7,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Input pin of a subcircuit.
@@ -185,21 +192,28 @@ public final class InputPin extends Pin implements TriProp {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo The value to send.
+	 * @param todo The value to send (TriStateOff for the undriven value).
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// send to output
 		Output out = outputs.get(0);
-		BitSet value = (BitSet)todo;
-		if (value == null) {
+		switch (todo) {
+
+		case TriStateOff _ -> {
 			currentValue = null;
-			out.propagate(value,now,sim);
+			out.propagate(null,now,sim);
 		}
-		else {
+
+		case NewValue(BitSet value) -> {
 			currentValue = (BitSet)value.clone();
 			out.propagate((BitSet)value.clone(),now,sim);
+		}
+
+		case PinChanged _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/JumpEnd.java
+++ b/src/jls/elem/JumpEnd.java
@@ -9,6 +9,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Receiving end of a named wire.
@@ -393,23 +400,30 @@ public final class JumpEnd extends LogicElement {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo The value to send along.
+	 * @param todo The value to send along (TriStateOff for the undriven
+	 *             value).
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
-		// get the input value
-		BitSet value = (BitSet)todo;
-		currentValue = null;
-		if (value != null)
-			currentValue = (BitSet)value.clone();
-
-		// send to output
+		// get the input value and send it to the output
 		Output out = outputs.get(0);
-		if (value == null)
+		switch (todo) {
+
+		case TriStateOff _ -> {
+			currentValue = null;
 			out.propagate(null,now,sim);
-		else
+		}
+
+		case NewValue(BitSet value) -> {
+			currentValue = (BitSet)value.clone();
 			out.propagate((BitSet)value.clone(),now,sim);
+		}
+
+		case PinChanged _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
+		}
 
 	} // end of react method
 

--- a/src/jls/elem/JumpStart.java
+++ b/src/jls/elem/JumpStart.java
@@ -487,7 +487,7 @@ public final class JumpStart extends LogicElement
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 
 		// get the input value
@@ -497,9 +497,11 @@ public final class JumpStart extends LogicElement
 
 		// send to all matching jump ends
 		for (JumpEnd jend : jumpEnds) {
-			BitSet newValue = null;
+			SimEvent.Payload newValue;
 			if (currentValue != null)
-				newValue = (BitSet)currentValue.clone();
+				newValue = new SimEvent.NewValue((BitSet)currentValue.clone());
+			else
+				newValue = new SimEvent.TriStateOff();
 			sim.post(new SimEvent(now,jend,newValue));
 		}
 	} // end of react method

--- a/src/jls/elem/LogicElement.java
+++ b/src/jls/elem/LogicElement.java
@@ -540,7 +540,7 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	 * Overridden by most elements.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		throw new UnsupportedOperationException("no react");
 	} // end of react method

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -10,6 +10,13 @@ import org.jspecify.annotations.Nullable;
 import jls.*;
 import jls.core.Geometry;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Memory element, initialized internally or from a file.
@@ -1292,40 +1299,21 @@ public final class Memory extends LogicElement
 	} // end of initSim method
 
 	/**
-	 * The memory operation implied by the current input signals: WRITE a
-	 * word, READ a word, or OFF when the chip is not selected.
-	 */
-	private static enum MemoryAction {
-		/** Write a word to memory. */
-		WRITE,
-		/** Read a word from memory. */
-		READ,
-		/** The chip is not selected; drive no value. */
-		OFF};
-
-	/**
 	 * React to an event.
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the pending
+	 *             memory operation completing (MemoryWrite, MemoryRead, or
+	 *             TriStateOff when the chip is not selected).
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
-		// todo
-		/**
-		 * A pending memory operation scheduled as a future event: the
-		 * action to perform, the target address, and the data involved.
-		 */
-		class MemAction {
-			@Nullable MemoryAction action;
-			int addr;
-			@Nullable BitSet data;
-		};
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get inputs
 			BitSet csb = getInput("CS").getValue();
@@ -1352,37 +1340,31 @@ public final class Memory extends LogicElement
 			if (type == Type.RAM && !cs && !we) {
 
 				// do a write
-				MemAction act = new MemAction();
-				act.action = MemoryAction.WRITE;
-				act.addr = BitSetUtils.ToInt(addr);
 				BitSet data = (BitSet)(getInput("input").getValue());
 				if (data == null)
 					data = new BitSet();
-				act.data = (BitSet)(data.clone());
-				sim.post(new SimEvent(now+accessTime,this,act));
+				sim.post(new SimEvent(now+accessTime,this,
+						new MemoryWrite(BitSetUtils.ToInt(addr),
+								(BitSet)(data.clone()))));
 			}
 
 			// if chip select and output enable ...
 			if (!cs && !oe) {
 
 				// do a read
-				MemAction act = new MemAction();
-				act.action = MemoryAction.READ;
-				act.addr = BitSetUtils.ToInt(addr);
-				sim.post(new SimEvent(now+accessTime,this,act));
+				sim.post(new SimEvent(now+accessTime,this,
+						new MemoryRead(BitSetUtils.ToInt(addr))));
 			}
 			else {
 
 				// turn off tristate output
-				MemAction act = new MemAction();
-				act.action = MemoryAction.OFF;
-				sim.post(new SimEvent(now+accessTime,this,act));
+				sim.post(new SimEvent(now+accessTime,this,
+						new TriStateOff()));
 			}
 		}
-		else {
 
-			// finish read or write
-			MemAction act = (MemAction)todo;
+		// a write completing...
+		case MemoryWrite(int addr, BitSet data) -> {
 
 			// the stores exist once the simulation has started
 			WordStore mem = this.mem;
@@ -1390,67 +1372,67 @@ public final class Memory extends LogicElement
 				throw new IllegalStateException("react before initSim");
 			}
 
-			// if a write...
-			if (act.action == MemoryAction.WRITE) {
+			// get the value to write
+			BitSet value = (BitSet)data.clone();
 
-				// a WRITE action always carries the data to write
-				BitSet actData = act.data;
-				if (actData == null) {
-					throw new IllegalStateException("WRITE action without data");
-				}
+			// if address is not legal, don't write anything
+			if (addr >= capacity)
+				return;
 
-				// get the value to write
-				BitSet value = (BitSet)actData.clone();
+			// save in activity history (newest first, bounded)
+			WriteRecord rec = new WriteRecord();
+			rec.what = (BitSet)(data.clone());
+			rec.where = addr;
+			rec.when = now;
+			activity.addFirst(rec);
+			if (activity.size() > ACTIVITY_LIMIT)
+				activity.removeLast();
 
-				// if address is not legal, don't write anything
-				if (act.addr >= capacity)
-					return;
+			// store in memory
+			mem.put(addr, value);
+		}
 
-				// save in activity history (newest first, bounded)
-				WriteRecord rec = new WriteRecord();
-				rec.what = (BitSet)(actData.clone());
-				rec.where = act.addr;
-				rec.when = now;
-				activity.addFirst(rec);
-				if (activity.size() > ACTIVITY_LIMIT)
-					activity.removeLast();
+		// a read completing...
+		case MemoryRead(int addr) -> {
 
-				// store in memory
-				mem.put(act.addr, value);
+			// the stores exist once the simulation has started
+			WordStore mem = this.mem;
+			if (mem == null) {
+				throw new IllegalStateException("react before initSim");
 			}
 
-			// else if its a read...
-			else if (act.action == MemoryAction.READ){
-
-				// if invalid address, turn off tristate output
-				if (act.addr >= capacity) {
-					currentValue = null;
-					getOutput("output").propagate(null,now,sim);
-					return;
-				}
-
-				// get value from memory
-				BitSet stored = mem.get(act.addr);
-				BitSet value;
-				if (stored == null) {
-					value =  new BitSet();
-				}
-				else {
-					value = (BitSet)stored.clone();
-				}
-
-				// send to output
-				getOutput("output").propagate(value,now,sim);
-
-				// set current value
-				currentValue = (BitSet)value.clone();
-			}
-
-			// else it is to turn off the tristate output
-			else {
+			// if invalid address, turn off tristate output
+			if (addr >= capacity) {
 				currentValue = null;
 				getOutput("output").propagate(null,now,sim);
+				return;
 			}
+
+			// get value from memory
+			BitSet stored = mem.get(addr);
+			BitSet value;
+			if (stored == null) {
+				value =  new BitSet();
+			}
+			else {
+				value = (BitSet)stored.clone();
+			}
+
+			// send to output
+			getOutput("output").propagate(value,now,sim);
+
+			// set current value
+			currentValue = (BitSet)value.clone();
+		}
+
+		// the chip is not selected: turn off the tristate output
+		case TriStateOff _ -> {
+			currentValue = null;
+			getOutput("output").propagate(null,now,sim);
+		}
+
+		case NewValue _, StateChanged _, TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/Mux.java
+++ b/src/jls/elem/Mux.java
@@ -11,6 +11,13 @@ import jls.core.GridPoint;
 import jls.core.GridSize;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Multiplexor.
@@ -517,13 +524,15 @@ public final class Mux extends LogicElement implements Timed {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo Null if an input change, the new output value otherwise.
+	 * @param todo PinChanged if an input change, the new output value otherwise.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get the selector input
 			BitSet bw = inputs.get(0).getValue();
@@ -546,17 +555,21 @@ public final class Mux extends LogicElement implements Timed {
 			// the mux, then post an event
 			if (!newValue.equals(toBeValue)) {
 				toBeValue = (BitSet)newValue.clone();
-				sim.post(new SimEvent(now+propDelay,this,newValue));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(newValue)));
 			}
 		}
-		else {
 
-			// get the new output value
-			BitSet value = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet value) -> {
 
 			// send to output
 			Output sumOut = outputs.get(0);
 			sumOut.propagate(value,now,sim);
+		}
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/OutputPin.java
+++ b/src/jls/elem/OutputPin.java
@@ -192,7 +192,7 @@ public final class OutputPin extends Pin implements TriProp {
 	 *            Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// send to output
 		Input in = inputs.get(0);

--- a/src/jls/elem/Pause.java
+++ b/src/jls/elem/Pause.java
@@ -164,7 +164,7 @@ public final class Pause extends LogicElement {
 	 * @jls.testedby jls.SimulationSemanticsRegressionTest#pausePausesOnlyOnNonZeroInput()
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// find the attached input
 		for (Input input : inputs) {

--- a/src/jls/elem/Register.java
+++ b/src/jls/elem/Register.java
@@ -10,6 +10,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * n-bit register (level or edge triggered).
@@ -757,7 +764,8 @@ public final class Register extends LogicElement
 		notq.setValue(new BitSet(1));
 
 		// post output event at time 0 to drive the initial value
-		sim.post(new SimEvent(0,this,currentValue.clone()));
+		sim.post(new SimEvent(0,this,
+				new NewValue((BitSet)currentValue.clone())));
 
 	} // end of initSim method
 
@@ -766,13 +774,15 @@ public final class Register extends LogicElement
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the value to output.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			BitSet inVal = inputs.get(1).getValue();
 			if (inVal == null)
@@ -788,7 +798,8 @@ public final class Register extends LogicElement
 				if (d.equals(toBeValue))
 					break;
 				toBeValue = (BitSet)d.clone();
-				sim.post(new SimEvent(now+propDelay,this,d.clone()));
+				sim.post(new SimEvent(now+propDelay,this,
+						new NewValue((BitSet)d.clone())));
 				break;
 			case PosFF:
 				if (currentC == 1)
@@ -798,7 +809,8 @@ public final class Register extends LogicElement
 				if (d.equals(toBeValue))
 					break;
 				toBeValue = (BitSet)d.clone();
-				sim.post(new SimEvent(now+propDelay,this,d.clone()));
+				sim.post(new SimEvent(now+propDelay,this,
+						new NewValue((BitSet)d.clone())));
 				break;
 			case NegFF:
 				if (currentC == 0)
@@ -808,15 +820,15 @@ public final class Register extends LogicElement
 				if (d.equals(toBeValue))
 					break;
 				toBeValue = (BitSet)d.clone();
-				sim.post(new SimEvent(now+propDelay,this,d.clone()));
+				sim.post(new SimEvent(now+propDelay,this,
+						new NewValue((BitSet)d.clone())));
 				break;
 			}
 			currentC = c;
 		}
-		else {
 
-			// get the new output value
-			BitSet newQ = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet newQ) -> {
 
 			// save for watch
 			currentValue = (BitSet)newQ.clone();
@@ -831,6 +843,11 @@ public final class Register extends LogicElement
 			q.propagate(qOut,now,sim);
 			Output notq = outputs.get(1);
 			notq.propagate(notQOut,now,sim);
+		}
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/ShiftRegister.java
+++ b/src/jls/elem/ShiftRegister.java
@@ -9,6 +9,13 @@ import jls.*;
 import jls.core.Geometry;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Combinational barrel shifter (issue #122). The bsiever fork lineage
@@ -611,13 +618,15 @@ public final class ShiftRegister extends LogicElement implements Timed {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo Null if an input change, the new output value otherwise.
+	 * @param todo PinChanged if an input change, the new output value otherwise.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get the amount to shift
 			BitSet bw = inputs.get(0).getValue();
@@ -663,17 +672,21 @@ public final class ShiftRegister extends LogicElement implements Timed {
 			// through the shifter, then post an event
 			if (!newValue.equals(toBeValue)) {
 				toBeValue = (BitSet)newValue.clone();
-				sim.post(new SimEvent(now+propDelay,this,newValue));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(newValue)));
 			}
 		}
-		else {
 
-			// get the new output value
-			BitSet value = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet value) -> {
 
 			// send to output
 			Output out = outputs.get(0);
 			out.propagate(value,now,sim);
+		}
+
+		case TriStateOff _, StateChanged _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/SigSim.java
+++ b/src/jls/elem/SigSim.java
@@ -126,7 +126,7 @@ public abstract sealed class SigSim extends LogicElement
 
 				// post event
 				BitSet bval = BitSetUtils.Create(value);
-				sim.post(new SimEvent(0,pin,bval));
+				sim.post(new SimEvent(0,pin,new SimEvent.NewValue(bval)));
 			}
 
 			// get the rest of the events for this pin and add to local event list
@@ -193,7 +193,8 @@ public abstract sealed class SigSim extends LogicElement
 
 					// post event
 					BitSet bval = BitSetUtils.Create(value);
-					sim.post(new SimEvent(newTime,pin,bval));
+					sim.post(new SimEvent(newTime,pin,
+							new SimEvent.NewValue(bval)));
 				}
 
 				// update time
@@ -210,7 +211,7 @@ public abstract sealed class SigSim extends LogicElement
 	 * @param todo The value to send.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		throw new UnsupportedOperationException("react in SigGen called");
 	} // end of react method

--- a/src/jls/elem/Splitter.java
+++ b/src/jls/elem/Splitter.java
@@ -201,7 +201,7 @@ public final class Splitter extends Group implements TriProp {
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// get the input value
 		BitSet value = inputs.get(0).getValue();

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -17,6 +17,13 @@ import jls.Circuit;
 import jls.TellUser;
 import jls.core.Geometry;
 import jls.sim.SimEvent;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 import jls.sim.Simulator;
 
 /**
@@ -730,13 +737,16 @@ public final class StateMachine extends LogicElement
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the state
+	 *             being entered.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get clock input value
 			BitSet cval = getInput("clock").getValue();
@@ -798,18 +808,26 @@ public final class StateMachine extends LogicElement
 			busy = true;
 
 			// post event
-			sim.post(new SimEvent(now+propDelay,this,newState));
+			sim.post(new SimEvent(now+propDelay,this,
+					new StateChanged(newState)));
 		}
-		else {
 
-			// get the new state
-			currentState = (State)todo;
+		// the transition completing: enter the new state
+		case StateChanged(State next) -> {
+
+			// set the new state
+			currentState = next;
 
 			// send values to outputs
-			currentState.sendOutputs(now,sim);
+			next.sendOutputs(now,sim);
 
 			// no longer busy
 			busy = false;
+		}
+
+		case NewValue _, TriStateOff _, MemoryRead _, MemoryWrite _,
+				TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/Stop.java
+++ b/src/jls/elem/Stop.java
@@ -144,7 +144,7 @@ public final class Stop extends LogicElement {
 	 * @param todo Should be null.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// find the attached input
 		for (Input input : inputs) {

--- a/src/jls/elem/SubCircuit.java
+++ b/src/jls/elem/SubCircuit.java
@@ -624,16 +624,18 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	 * @param todo Unused.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
 
 		// send all input values to input pins of subcircuit
 		for (Input in : inputs) {
 			InputPin pin = inmap.get(in);
 			if (pin == null)
 				throw new IllegalStateException("input has no mapped subcircuit input pin");
-			BitSet copy = null;
+			SimEvent.Payload copy;
 			if (in.getValue() != null)
-				copy = (BitSet)in.getValue().clone();
+				copy = new SimEvent.NewValue((BitSet)in.getValue().clone());
+			else
+				copy = new SimEvent.TriStateOff();
 			sim.post(new SimEvent(now,pin,copy));
 		}
 

--- a/src/jls/elem/TriState.java
+++ b/src/jls/elem/TriState.java
@@ -11,6 +11,13 @@ import jls.core.GridPoint;
 import jls.core.GridSize;
 import jls.core.Orientation;
 import jls.sim.*;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 
 /**
  * Tri-state buffer(s).
@@ -469,14 +476,17 @@ public final class TriState extends LogicElement implements Timed {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the value to
+	 *             output (TriStateOff to stop driving the output).
 	 * @jls.testedby jls.SimulationSemanticsRegressionTest#triStateDoesNotRepostUnchangedOutputEvents()
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if the input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// get control input
 			BitSet control = inputs.get(1).getValue();
@@ -489,7 +499,7 @@ public final class TriState extends LogicElement implements Timed {
 				if (toBeValue == null)
 					return;
 				toBeValue = null;
-				sim.post(new SimEvent(now+propDelay,this,"off"));
+				sim.post(new SimEvent(now+propDelay,this,new TriStateOff()));
 			}
 			else {
 
@@ -503,25 +513,28 @@ public final class TriState extends LogicElement implements Timed {
 				if (value.equals(toBeValue))
 					return;
 				toBeValue = (BitSet)value.clone();
-				sim.post(new SimEvent(now+propDelay,this,value));
+				sim.post(new SimEvent(now+propDelay,this,new NewValue(value)));
 			}
 
 		}
 
 		// if gate is turning off, propagate null
-		else if (todo instanceof String) {
+		case TriStateOff _ -> {
 
 			Output out = outputs.get(0);
 			out.propagate(null,now,sim);
 		}
-		else {
 
-			// get the new output value
-			BitSet newValue = (BitSet)todo;
+		// the new output value arriving
+		case NewValue(BitSet newValue) -> {
 
 			// propagate value
 			Output out = outputs.get(0);
 			out.propagate(newValue,now,sim);
+		}
+
+		case StateChanged _, MemoryRead _, MemoryWrite _, TableOutput _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -16,6 +16,13 @@ import jls.Circuit;
 import jls.TellUser;
 import jls.core.Geometry;
 import jls.sim.SimEvent;
+import jls.sim.SimEvent.MemoryRead;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
+import jls.sim.SimEvent.StateChanged;
+import jls.sim.SimEvent.TableOutput;
+import jls.sim.SimEvent.TriStateOff;
 import jls.sim.Simulator;
 
 /**
@@ -1368,24 +1375,6 @@ public final class TruthTable extends LogicElement
 	/** The value (0 or 1) each output will have once its pending event fires,
 	 *  indexed by output position. Null until {@link #initSim} allocates it. */
 	private int @Nullable [] toBeValue;
-	/**
-	 * A pending output change carried through the simulator: an output pin's
-	 * position (index into the outputs list) paired with the BitSet value it
-	 * should take on when the scheduled event fires.
-	 */
-	static class Out {
-		/** Index of the output pin in the outputs list. */
-		int position;
-		/** The value the output pin should take on. Set before the pending
-		 *  event is posted, so non-null by the time the event fires. */
-		@Nullable BitSet value;
-
-		/**
-		 * Create a pending output change.
-		 */
-		Out() {
-		}
-	}
 
 	/**
 	 * Initialize this element by setting its output pins and to-be values to 0.
@@ -1413,10 +1402,8 @@ public final class TruthTable extends LogicElement
 				toBe[pos] = 1;
 				BitSet val = new BitSet(1);
 				val.set(0);
-				Out out = new Out();
-				out.position = pos;
-				out.value = val;
-				sim.post(new SimEvent(propDelay,this,out));
+				sim.post(new SimEvent(propDelay,this,
+						new TableOutput(pos,val)));
 			}
 			pos += 1;
 		}
@@ -1428,13 +1415,16 @@ public final class TruthTable extends LogicElement
 	 *
 	 * @param now The current simulation time.
 	 * @param sim The simulator to post events to.
-	 * @param todo If null, an input has changed, otherwise it is the value to output.
+	 * @param todo PinChanged if an input has changed, otherwise the pending
+	 *             output change to drive.
 	 */
 	@Override
-	public void react(long now, Simulator sim, @org.jspecify.annotations.Nullable Object todo) {
+	public void react(long now, Simulator sim, SimEvent.Payload todo) {
+
+		switch (todo) {
 
 		// if an input has changed ...
-		if (todo == null) {
+		case PinChanged _ -> {
 
 			// find a matching row of the truth table
 			int matchingRow = -1;
@@ -1485,26 +1475,24 @@ public final class TruthTable extends LogicElement
 					BitSet val = new BitSet(1);
 					if (outValue == 1)
 						val.set(0);
-					Out out = new Out();
-					out.position = pos;
-					out.value = val;
-					sim.post(new SimEvent(now+propDelay,this,out));
+					sim.post(new SimEvent(now+propDelay,this,
+							new TableOutput(pos,val)));
 				}
 				pos += 1;
 			}
 		}
-		else {
 
-			// get the new output
-			Out newOut = (Out)todo;
+		// a pending output change arriving: send to the output
+		case TableOutput(int position, BitSet val) -> {
 
-			// send to output
-			Output out = outputs.get(newOut.position);
-			BitSet val = newOut.value;
-			if (val == null)
-				throw new IllegalStateException("pending output event has no value");
+			Output out = outputs.get(position);
 			BitSet newVal = (BitSet)val.clone();
 			out.propagate(newVal,now,sim);
+		}
+
+		case NewValue _, TriStateOff _, StateChanged _, MemoryRead _,
+				MemoryWrite _ ->
+			throw new IllegalStateException("unexpected payload: " + todo);
 		}
 
 	} // end of react method

--- a/src/jls/elem/WireNet.java
+++ b/src/jls/elem/WireNet.java
@@ -504,7 +504,8 @@ public class WireNet {
 			// notify, so there is nothing to react
 			LogicElement element = p.getElement();
 			if (element != null) {
-				sim.post(new SimEvent(now, (Reacts) element, null));
+				sim.post(new SimEvent(now, (Reacts) element,
+						new SimEvent.PinChanged()));
 			}
 		}
 

--- a/src/jls/sim/Reacts.java
+++ b/src/jls/sim/Reacts.java
@@ -21,10 +21,10 @@ public interface Reacts {
 	 *
 	 * @param now The current simulation time.
 	 * @param sim A reference to the simulator in case element needs to post an event.
-	 * @param todo Information needed to react to an event.
-	 *             This will typically be null for input pin signal changes.
+	 * @param todo The payload saying what to do about the event.
+	 *             This will be PinChanged for input pin signal changes.
 	 */
     public abstract void react(long now, Simulator sim,
-            @org.jspecify.annotations.Nullable Object todo);
+            SimEvent.Payload todo);
 
     } // end of Reacts interface

--- a/src/jls/sim/SimEvent.java
+++ b/src/jls/sim/SimEvent.java
@@ -1,6 +1,8 @@
 package jls.sim;
 
-import org.jspecify.annotations.Nullable;
+import java.util.BitSet;
+
+import jls.elem.State;
 
 /**
  * A simulation event (typically a signal value change).
@@ -8,6 +10,78 @@ import org.jspecify.annotations.Nullable;
  * @author David A. Poplawski
  */
 public final class SimEvent implements Comparable<SimEvent> {
+
+	/**
+	 * What the reacting element should do when this event fires
+	 * (issue #95). Sealed over the records in this compilation unit so
+	 * every react() can switch exhaustively with no default arm: adding
+	 * a payload kind is a compile error at every consumer until it is
+	 * handled. The records replace the old untyped Object todo and its
+	 * sentinels (null meant "inputs changed", the String "off" meant
+	 * "turn the tri-state output off").
+	 */
+	public sealed interface Payload {
+	} // end of Payload interface
+
+	/**
+	 * An input signal changed: re-read the inputs and react to their
+	 * current values (formerly the null todo sentinel).
+	 */
+	public record PinChanged() implements Payload {
+	} // end of PinChanged record
+
+	/**
+	 * A scheduled output change arriving: drive the given value on the
+	 * output (formerly a raw BitSet todo).
+	 *
+	 * @param value The value the output should take on.
+	 */
+	public record NewValue(BitSet value) implements Payload {
+	} // end of NewValue record
+
+	/**
+	 * A scheduled turn-off arriving: stop driving the output
+	 * (propagate the undriven/HiZ value; formerly the String "off"
+	 * sentinel and null-BitSet postings).
+	 */
+	public record TriStateOff() implements Payload {
+	} // end of TriStateOff record
+
+	/**
+	 * A state machine transition completing: enter the new state and
+	 * assert its outputs.
+	 *
+	 * @param state The state the machine is entering.
+	 */
+	public record StateChanged(State state) implements Payload {
+	} // end of StateChanged record
+
+	/**
+	 * A memory write completing: store the data in the addressed word.
+	 *
+	 * @param address The word address being written.
+	 * @param data The value to store.
+	 */
+	public record MemoryWrite(int address, BitSet data) implements Payload {
+	} // end of MemoryWrite record
+
+	/**
+	 * A memory read completing: drive the addressed word on the output.
+	 *
+	 * @param address The word address being read.
+	 */
+	public record MemoryRead(int address) implements Payload {
+	} // end of MemoryRead record
+
+	/**
+	 * A truth table output change completing: drive the value on the
+	 * output pin at the given position.
+	 *
+	 * @param position Index of the output pin in the outputs list.
+	 * @param value The value the output pin should take on.
+	 */
+	public record TableOutput(int position, BitSet value) implements Payload {
+	} // end of TableOutput record
 
 	/** The next sequence number, assigned at construction (post order). */
 	private static long sequence = 0;
@@ -23,19 +97,19 @@ public final class SimEvent implements Comparable<SimEvent> {
 	private final long seq;
 	/** The element whose react runs when this event fires. */
 	private final Reacts callBack;
-	/** The event payload; null means "inputs changed, re-read them". */
-	private final @Nullable Object todo;
+	/** The event payload: what the reacting element should do. */
+	private final Payload todo;
 
 	/**
 	 * Create a new event object with the given time and callback.
 	 *
 	 * @param time The time the event will occur
 	 * @param callBack The object to tell when the event occurs.
-	 * @param todo An object containing information about what the
-	 *             reacting object should do about this event.
-	 *             Null typically means an input pin has changed value.
+	 * @param todo The payload saying what the reacting object should do
+	 *             about this event. PinChanged means an input signal
+	 *             has changed value.
 	 */
-	public SimEvent(long time, Reacts callBack, @Nullable Object todo) {
+	public SimEvent(long time, Reacts callBack, Payload todo) {
 
 		this.time = time;
 		seq = sequence;
@@ -77,7 +151,7 @@ public final class SimEvent implements Comparable<SimEvent> {
 	/**
 	 * Decide whether this JLSEvent object and another are equal.
 	 * They will be equal if the have the same time, the same callback
-	 * object, and the same todo object.
+	 * object, and the same todo payload.
 	 *
 	 * @param other The object to compare this one with.
 	 *
@@ -93,8 +167,7 @@ public final class SimEvent implements Comparable<SimEvent> {
 			return false;
 		if (this.callBack != oth.callBack)
 			return false;
-		return this.todo == null ? oth.todo == null :
-			this.todo.equals(oth.todo);
+		return this.todo.equals(oth.todo);
 	} // end of equals method
 
 	/**
@@ -132,12 +205,11 @@ public final class SimEvent implements Comparable<SimEvent> {
 	} // end of getCallBack method
 
 	/**
-	 * Get the todo object
+	 * Get the todo payload.
 	 *
-	 * @return the todo object, or null meaning "inputs changed,
-	 *         re-read them".
+	 * @return the payload saying what the reacting element should do.
 	 */
-	public @Nullable Object getTodo() {
+	public Payload getTodo() {
 
 		return todo;
 	} // end of getTodo method

--- a/test/jls/SimulationSemanticsRegressionTest.java
+++ b/test/jls/SimulationSemanticsRegressionTest.java
@@ -475,13 +475,13 @@ class SimulationSemanticsRegressionTest {
 		CountingSimulator sim = new CountingSimulator();
 		element.initSim(sim);
 		attached.setValue(BitSetUtils.Create(0));
-		element.react(10, sim, null);
+		element.react(10, sim, new SimEvent.PinChanged());
 		assertEquals(0, sim.pauses, "a zero input must not pause");
 		attached.setValue(BitSetUtils.Create(1));
-		element.react(20, sim, null);
+		element.react(20, sim, new SimEvent.PinChanged());
 		assertEquals(1, sim.pauses, "a non-zero input must pause");
 		attached.setValue(BitSetUtils.Create(0));
-		element.react(30, sim, null);
+		element.react(30, sim, new SimEvent.PinChanged());
 		assertEquals(1, sim.pauses, "a change back to zero must not pause");
 	}
 
@@ -556,24 +556,24 @@ class SimulationSemanticsRegressionTest {
 		// turn on with data 5: one event
 		control.setValue(BitSetUtils.Create(1));
 		data.setValue(BitSetUtils.Create(5));
-		tri.react(10, sim, null);
+		tri.react(10, sim, new SimEvent.PinChanged());
 		assertEquals(1, sim.posts, "the first value must be scheduled");
 
 		// unrelated notification, same output: no new event
-		tri.react(20, sim, null);
+		tri.react(20, sim, new SimEvent.PinChanged());
 		assertEquals(1, sim.posts,
 				"an unchanged output must not be rescheduled");
 
 		// data change: one more event
 		data.setValue(BitSetUtils.Create(9));
-		tri.react(30, sim, null);
+		tri.react(30, sim, new SimEvent.PinChanged());
 		assertEquals(2, sim.posts, "a changed value must be scheduled");
 
 		// turn off: one event; turning off again: none
 		control.setValue(BitSetUtils.Create(0));
-		tri.react(40, sim, null);
+		tri.react(40, sim, new SimEvent.PinChanged());
 		assertEquals(3, sim.posts, "turning off must be scheduled");
-		tri.react(50, sim, null);
+		tri.react(50, sim, new SimEvent.PinChanged());
 		assertEquals(3, sim.posts,
 				"an already-off gate must not be rescheduled");
 	}

--- a/test/jls/sim/SimEventContractTest.java
+++ b/test/jls/sim/SimEventContractTest.java
@@ -4,7 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.BitSet;
+
 import org.junit.jupiter.api.Test;
+
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
 
 /**
  * Ordering and identity contract of {@link SimEvent}, pinned by the
@@ -27,18 +32,30 @@ class SimEventContractTest {
 		}
 
 		@Override
-		public void react(long now, Simulator sim, Object todo) {
+		public void react(long now, Simulator sim, SimEvent.Payload todo) {
 		}
 	} // end of NoOp class
 
 	/** The shared callback for events that must compare equal. */
 	private static final Reacts CALLBACK = new NoOp();
 
+	/**
+	 * Build a NewValue payload carrying the given small value.
+	 *
+	 * @param value The value the payload's BitSet should hold.
+	 *
+	 * @return the payload.
+	 */
+	private static NewValue value(long value) {
+
+		return new NewValue(BitSet.valueOf(new long[] { value }));
+	}
+
 	@Test
 	void earlierTimeOrdersFirst() {
 
-		SimEvent early = new SimEvent(1, CALLBACK, null);
-		SimEvent late = new SimEvent(2, CALLBACK, null);
+		SimEvent early = new SimEvent(1, CALLBACK, new PinChanged());
+		SimEvent late = new SimEvent(2, CALLBACK, new PinChanged());
 		assertEquals(-1, early.compareTo(late));
 		assertEquals(1, late.compareTo(early));
 	}
@@ -46,8 +63,8 @@ class SimEventContractTest {
 	@Test
 	void equalTimesOrderByCreationSequence() {
 
-		SimEvent first = new SimEvent(5, CALLBACK, null);
-		SimEvent second = new SimEvent(5, CALLBACK, null);
+		SimEvent first = new SimEvent(5, CALLBACK, new PinChanged());
+		SimEvent second = new SimEvent(5, CALLBACK, new PinChanged());
 		assertEquals(-1, first.compareTo(second),
 				"same-time events must pop in creation order");
 		assertEquals(1, second.compareTo(first));
@@ -56,41 +73,42 @@ class SimEventContractTest {
 	@Test
 	void selfComparisonIsZero() {
 
-		SimEvent event = new SimEvent(7, CALLBACK, null);
+		SimEvent event = new SimEvent(7, CALLBACK, new PinChanged());
 		assertEquals(0, event.compareTo(event));
 	}
 
 	@Test
 	void equalsRequiresTimeCallbackAndTodo() {
 
-		SimEvent event = new SimEvent(3, CALLBACK, "todo");
-		assertTrue(event.equals(new SimEvent(3, CALLBACK, "todo")),
+		SimEvent event = new SimEvent(3, CALLBACK, value(1));
+		assertTrue(event.equals(new SimEvent(3, CALLBACK, value(1))),
 				"same time, callback, and todo must be equal");
-		assertFalse(event.equals(new SimEvent(4, CALLBACK, "todo")),
+		assertFalse(event.equals(new SimEvent(4, CALLBACK, value(1))),
 				"a different time must not be equal");
-		assertFalse(event.equals(new SimEvent(3, new NoOp(), "todo")),
+		assertFalse(event.equals(new SimEvent(3, new NoOp(), value(1))),
 				"a different callback must not be equal");
-		assertFalse(event.equals(new SimEvent(3, CALLBACK, "other")),
+		assertFalse(event.equals(new SimEvent(3, CALLBACK, value(2))),
 				"a different todo must not be equal");
 		assertFalse(event.equals("not a SimEvent"),
 				"a non-SimEvent must not be equal");
 	}
 
 	@Test
-	void nullTodoEqualsNullTodoOnly() {
+	void pinChangedTodoEqualsPinChangedTodoOnly() {
 
-		SimEvent bare = new SimEvent(3, CALLBACK, null);
-		assertTrue(bare.equals(new SimEvent(3, CALLBACK, null)));
-		assertFalse(bare.equals(new SimEvent(3, CALLBACK, "todo")));
+		SimEvent bare = new SimEvent(3, CALLBACK, new PinChanged());
+		assertTrue(bare.equals(new SimEvent(3, CALLBACK, new PinChanged())));
+		assertFalse(bare.equals(new SimEvent(3, CALLBACK, value(1))));
 	}
 
 	@Test
 	void hashCodeIsTheEventTime() {
 
 		// documented contract: the hash code is the event time
-		assertEquals(42, new SimEvent(42, CALLBACK, null).hashCode());
-		SimEvent a = new SimEvent(9, CALLBACK, "x");
-		SimEvent b = new SimEvent(9, CALLBACK, "x");
+		assertEquals(42,
+				new SimEvent(42, CALLBACK, new PinChanged()).hashCode());
+		SimEvent a = new SimEvent(9, CALLBACK, value(1));
+		SimEvent b = new SimEvent(9, CALLBACK, value(1));
 		assertEquals(a.hashCode(), b.hashCode(),
 				"equal events must hash equally");
 	}

--- a/test/jls/sim/SimEventDedupTest.java
+++ b/test/jls/sim/SimEventDedupTest.java
@@ -4,7 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.BitSet;
+
 import org.junit.jupiter.api.Test;
+
+import jls.BitSetUtils;
+import jls.sim.SimEvent.MemoryWrite;
+import jls.sim.SimEvent.NewValue;
+import jls.sim.SimEvent.PinChanged;
 
 /**
  * Pins the intentionally non-structural equality of {@link SimEvent}
@@ -17,7 +24,9 @@ import org.junit.jupiter.api.Test;
  * generated structural {@code equals} would include {@code seq},
  * making every event distinct and silently disabling the simulator's
  * {@code dupCheck} dedup set.  These tests fail if anyone "cleans up"
- * SimEvent into a record or makes equals structural.</p>
+ * SimEvent into a record or makes equals structural.  The todo is the
+ * sealed typed payload (issue #95); the payload records' structural
+ * equality is what makes two same-shaped postings coalesce.</p>
  */
 class SimEventDedupTest {
 
@@ -31,7 +40,7 @@ class SimEventDedupTest {
 		}
 
 		@Override
-		public void react(long now, Simulator sim, Object todo) {
+		public void react(long now, Simulator sim, SimEvent.Payload todo) {
 			reacts += 1;
 		}
 	}
@@ -54,6 +63,18 @@ class SimEventDedupTest {
 	}
 
 	/**
+	 * Build a NewValue payload carrying the given small value.
+	 *
+	 * @param value The value the payload's BitSet should hold.
+	 *
+	 * @return the payload.
+	 */
+	private static NewValue value(long value) {
+
+		return new NewValue(BitSet.valueOf(new long[] { value }));
+	}
+
+	/**
 	 * Two events with the same (time, callBack, todo) but different
 	 * sequence numbers are equal with equal hash codes -- the dedup
 	 * contract -- while compareTo still tells them apart by seq.
@@ -62,8 +83,8 @@ class SimEventDedupTest {
 	void equalsIgnoresSeqButCompareToDoesNot() {
 
 		Recorder cb = new Recorder();
-		SimEvent first = new SimEvent(5, cb, "todo");
-		SimEvent second = new SimEvent(5, cb, "todo");
+		SimEvent first = new SimEvent(5, cb, value(1));
+		SimEvent second = new SimEvent(5, cb, value(1));
 
 		assertEquals(first, second,
 				"same (time, callBack, todo) must be equal");
@@ -83,8 +104,8 @@ class SimEventDedupTest {
 
 		PlainSimulator sim = new PlainSimulator();
 		Recorder cb = new Recorder();
-		sim.post(new SimEvent(3, cb, null));
-		sim.post(new SimEvent(3, cb, null));
+		sim.post(new SimEvent(3, cb, new PinChanged()));
+		sim.post(new SimEvent(3, cb, new PinChanged()));
 
 		assertEquals(1, sim.eventQueue.size(),
 				"the duplicate posting must be coalesced");
@@ -102,8 +123,8 @@ class SimEventDedupTest {
 
 		PlainSimulator sim = new PlainSimulator();
 		Recorder cb = new Recorder();
-		sim.post(new SimEvent(3, cb, "a"));
-		sim.post(new SimEvent(3, cb, "b"));
+		sim.post(new SimEvent(3, cb, value(1)));
+		sim.post(new SimEvent(3, cb, value(2)));
 
 		assertEquals(2, sim.eventQueue.size(),
 				"different todo payloads must not be coalesced");
@@ -121,15 +142,43 @@ class SimEventDedupTest {
 
 		PlainSimulator sim = new PlainSimulator();
 		Recorder cb = new Recorder();
-		sim.post(new SimEvent(3, cb, null));
+		sim.post(new SimEvent(3, cb, new PinChanged()));
 		sim.run();
 		assertEquals(1, cb.reacts, "the first posting reacts");
 
-		sim.post(new SimEvent(3, cb, null));
+		sim.post(new SimEvent(3, cb, new PinChanged()));
 		assertEquals(1, sim.eventQueue.size(),
 				"an equal event must be accepted after the dequeue");
 		sim.run();
 		assertEquals(2, cb.reacts, "the re-posted event reacts too");
+	}
+
+	/**
+	 * Payload kinds that replaced identity-equality inner classes
+	 * (Memory's MemAction, TruthTable's Out) coalesce structurally
+	 * like every other payload: two same-shaped pending memory writes
+	 * are one event.  Under the pre-#95 identity classes both would
+	 * have fired; the records make dedup uniform across all payload
+	 * kinds.  The duplicate op was idempotent, so simulated values are
+	 * unchanged -- only duplicate activity-history entries and trace
+	 * samples disappear.  This test pins that behavior change as
+	 * intentional (issue #95).
+	 */
+	@Test
+	void formerIdentityPayloadsNowCoalesceStructurally() {
+
+		PlainSimulator sim = new PlainSimulator();
+		Recorder cb = new Recorder();
+		sim.post(new SimEvent(4, cb,
+				new MemoryWrite(9, BitSet.valueOf(new long[] { 5 }))));
+		sim.post(new SimEvent(4, cb,
+				new MemoryWrite(9, BitSet.valueOf(new long[] { 5 }))));
+
+		assertEquals(1, sim.eventQueue.size(),
+				"same-shaped memory writes must coalesce (issue #95)");
+
+		sim.run();
+		assertEquals(1, cb.reacts, "one surviving event, one react");
 	}
 
 	/**
@@ -146,17 +195,19 @@ class SimEventDedupTest {
 			public void initSim(Simulator sim) {
 			}
 			@Override
-			public void react(long now, Simulator sim, Object todo) {
-				order.append(todo);
+			public void react(long now, Simulator sim,
+					SimEvent.Payload todo) {
+				order.append(BitSetUtils.ToInt(
+						((NewValue)todo).value()));
 			}
 		};
-		sim.post(new SimEvent(7, logger, "c"));
-		sim.post(new SimEvent(2, logger, "a"));
-		sim.post(new SimEvent(2, logger, "b"));
+		sim.post(new SimEvent(7, logger, value(3)));
+		sim.post(new SimEvent(2, logger, value(1)));
+		sim.post(new SimEvent(2, logger, value(2)));
 
 		sim.run();
-		assertTrue(order.toString().equals("abc"),
-				"expected time-then-seq order abc, got " + order);
+		assertTrue(order.toString().equals("123"),
+				"expected time-then-seq order 123, got " + order);
 	}
 
 } // end of SimEventDedupTest class


### PR DESCRIPTION
Replace the untyped `private final @Nullable Object todo` in SimEvent
with a sealed Payload interface and seven records nested in the same
compilation unit (implicit permits):

- PinChanged            - formerly the null sentinel ("inputs changed")
- NewValue(BitSet)      - formerly a raw BitSet todo
- TriStateOff           - formerly the "off" String sentinel
                          (TriState.java:492) and null-BitSet postings
                          (JumpStart/SubCircuit) and Memory's OFF action
- StateChanged(State)   - formerly a raw State todo (StateMachine)
- MemoryWrite(int,BitSet) / MemoryRead(int)
                        - formerly Memory's local MemAction class with
                          @Nullable action/data fields (enum removed)
- TableOutput(int,BitSet)
                        - formerly TruthTable's static Out class with a
                          @Nullable value field (class removed)

The adjudicated #95 decision enumerated only the first four records;
MemoryWrite/MemoryRead/TableOutput are additions required to carry the
address/position/data of the former MemAction/Out payload classes
without an untyped escape hatch. The decision record on the issue
should be amended to list all seven.

Reacts.react now takes SimEvent.Payload (non-null); every dispatching
react() implementer (Adder, Clock, Constant, Decoder, Gate, InputPin,
JumpEnd, Memory, Mux, Register, ShiftRegister, StateMachine, TriState,
TruthTable) is an exhaustive switch with record-pattern destructuring
and no default arm - a new payload kind is a compile error at every
consumer. All ~30 sim.post(new SimEvent(...)) producer sites post typed
payloads. Elements whose react ignores todo (Pause, Stop, Display,
Binder, Splitter, Extend, OutputPin, JumpStart, SubCircuit, SigSim,
LogicElement base) only had their signatures retyped.

Equality semantics: SimEvent.equals still compares (time, callBack,
todo) and excludes seq, and hashCode stays (int)time (the #231
hashCode fix is deferred). The payload records reproduce the old dedup
behavior for the previously value-equal shapes (PinChanged <-> null,
TriStateOff <-> "off", NewValue <-> BitSet.equals). One deliberate
behavior change: Memory/TruthTable ops move from identity to
structural equality, so in the dedup re-post window (a second
same-time input notification accepted after the first PinChanged
dequeues) a recomputed identical MemoryWrite/MemoryRead/TableOutput
now coalesces with the still-pending one instead of firing twice. The
duplicate op was idempotent, so simulated values are unchanged - only
duplicate memory activity-history entries and afterEvent trace samples
disappear. Pinned as intentional by the new
SimEventDedupTest.formerIdentityPayloadsNowCoalesceStructurally test.
BatchSimulator truth-table goldens are byte-identical
(BatchSimulationGoldenTest, ElementSimulationGoldenTest,
SequentialGoldenTest, VcdExportGoldenTest all green).

SimEventDedupTest and SimEventContractTest are updated to typed
payloads while still pinning the equals-excludes-seq contract.
SimpleEditor instanceof sites (held for #84) and the Circuit /
HdlExporter dispatch chains are untouched.

Closes #95

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
