### PR TITLE
Complete the capability-interface layer for elements (#78)

### DIFF
--- a/src/jls/Circuit.java
+++ b/src/jls/Circuit.java
@@ -27,6 +27,7 @@ import jls.elem.LogicElement;
 import jls.elem.Output;
 import jls.elem.Put;
 import jls.elem.SubCircuit;
+import jls.elem.Watchable;
 import jls.elem.Wire;
 import jls.elem.WireEnd;
 import jls.elem.WireNet;
@@ -1708,8 +1709,8 @@ public class Circuit {
 			if (el instanceof SubCircuit sub) {
 				sub.getSubCircuit().clearAllWatches();
 			} else {
-				if (!el.isUneditable())
-					el.setWatched(false);
+				if (!el.isUneditable() && el instanceof Watchable watchable)
+					watchable.setWatched(false);
 			}
 		}
 	} // end of clearAllWatches method

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -66,6 +66,8 @@ import jls.elem.Memory;
 import jls.elem.OutputPin;
 import jls.elem.Register;
 import jls.elem.SubCircuit;
+import jls.elem.Timed;
+import jls.elem.Watchable;
 import jls.hdl.HdlEmitter;
 import jls.hdl.HdlExportException;
 import jls.hdl.HdlExporter;
@@ -578,7 +580,7 @@ public class JLSStart extends JFrame implements ChangeListener {
 		ordered.sort(Comparator.comparing(
 				(Element el) -> el.getName() == null ? "" : el.getName()));
 		for (Element el : ordered) {
-			if (el.isWatched()) {
+			if (el instanceof Watchable watchable && watchable.isWatched()) {
 				switch (el) {
 					case Register reg -> reg.printValue(qual);
 					case Memory mem -> mem.printChangedValues(qual);
@@ -2582,11 +2584,14 @@ public class JLSStart extends JFrame implements ChangeListener {
 							System.exit(1);
 						}
 						String tf = scan.next();
-						if (tf.equals("true")) {
-							element.setWatched(true);
-						}
-						else if (tf.equals("false")) {
-							element.setWatched(false);
+						if (tf.equals("true") || tf.equals("false")) {
+							boolean watched = tf.equals("true");
+							if (element instanceof Watchable watchable) {
+								watchable.setWatched(watched);
+							}
+							else if (element instanceof SubCircuit sub) {
+								sub.setWatched(watched);
+							}
 						}
 						else {
 							System.out.print(paramFile + ": expected true or false,");
@@ -2614,7 +2619,9 @@ public class JLSStart extends JFrame implements ChangeListener {
 							System.out.println(" got \"" + delay + "\"");
 							System.exit(1);
 						}
-						element.setDelay(delay);
+						if (element instanceof Timed timed) {
+							timed.setDelay(delay);
+						}
 					}
 
 					// register info
@@ -2740,8 +2747,8 @@ public class JLSStart extends JFrame implements ChangeListener {
 				Circuit c = sub.getSubCircuit();
 				setPropDelays(c,cl,delay);
 			}
-			else if (el.getClass() == cl && el instanceof LogicElement lel) {
-				lel.setDelay(delay);
+			else if (el.getClass() == cl && el instanceof Timed timed) {
+				timed.setDelay(delay);
 			}
 		}
 	} // end of setPropDelays method

--- a/src/jls/collab/op/FlipElement.java
+++ b/src/jls/collab/op/FlipElement.java
@@ -7,6 +7,7 @@ import jls.Circuit;
 import jls.edit.SwingTextMetrics;
 import jls.elem.Element;
 import jls.elem.ElementId;
+import jls.elem.Rotatable;
 
 /**
  * Flip (mirror) an element (issue #167). Self-inverse.
@@ -19,17 +20,17 @@ public record FlipElement(ElementId id) implements CircuitOp {
 	public void apply(Circuit circuit, Graphics g) throws OpRejected {
 
 		Element el = Ops.resolve(circuit, id);
-		if (!el.canFlip()) {
+		if (!(el instanceof Rotatable rot) || !rot.canFlip()) {
 			throw new OpRejected("element '" + id + "' cannot flip");
 		}
-		el.flip(SwingTextMetrics.forGraphics(g));
+		rot.flip(SwingTextMetrics.forGraphics(g));
 	} // end of apply method
 
 	@Override
 	public CircuitOp invert(Circuit before) throws OpRejected {
 
 		Element el = Ops.resolve(before, id);
-		if (!el.canFlip()) {
+		if (!(el instanceof Rotatable rot) || !rot.canFlip()) {
 			throw new OpRejected("element '" + id + "' cannot flip");
 		}
 		return this;

--- a/src/jls/collab/op/RotateElement.java
+++ b/src/jls/collab/op/RotateElement.java
@@ -8,6 +8,7 @@ import jls.core.Orientation;
 import jls.edit.SwingTextMetrics;
 import jls.elem.Element;
 import jls.elem.ElementId;
+import jls.elem.Rotatable;
 
 /**
  * Rotate an element a quarter turn (issue #167). Inverse: the opposite
@@ -23,10 +24,10 @@ public record RotateElement(ElementId id, boolean clockwise)
 	public void apply(Circuit circuit, Graphics g) throws OpRejected {
 
 		Element el = Ops.resolve(circuit, id);
-		if (!el.canRotate()) {
+		if (!(el instanceof Rotatable rot) || !rot.canRotate()) {
 			throw new OpRejected("element '" + id + "' cannot rotate");
 		}
-		el.rotate(clockwise ? Orientation.RIGHT
+		rot.rotate(clockwise ? Orientation.RIGHT
 				: Orientation.LEFT, SwingTextMetrics.forGraphics(g));
 	} // end of apply method
 
@@ -34,7 +35,7 @@ public record RotateElement(ElementId id, boolean clockwise)
 	public CircuitOp invert(Circuit before) throws OpRejected {
 
 		Element el = Ops.resolve(before, id);
-		if (!el.canRotate()) {
+		if (!(el instanceof Rotatable rot) || !rot.canRotate()) {
 			throw new OpRejected("element '" + id + "' cannot rotate");
 		}
 		return new RotateElement(id, !clockwise);

--- a/src/jls/collab/op/ToggleWatched.java
+++ b/src/jls/collab/op/ToggleWatched.java
@@ -6,6 +6,7 @@ import java.io.PrintWriter;
 import jls.Circuit;
 import jls.elem.Element;
 import jls.elem.ElementId;
+import jls.elem.Watchable;
 
 /**
  * Toggle whether an element's value is watched during batch simulation
@@ -19,17 +20,17 @@ public record ToggleWatched(ElementId id) implements CircuitOp {
 	public void apply(Circuit circuit, Graphics g) throws OpRejected {
 
 		Element el = Ops.resolve(circuit, id);
-		if (!el.canWatch()) {
+		if (!(el instanceof Watchable watchable)) {
 			throw new OpRejected("element '" + id + "' cannot be watched");
 		}
-		el.setWatched(!el.isWatched());
+		watchable.setWatched(!watchable.isWatched());
 	} // end of apply method
 
 	@Override
 	public CircuitOp invert(Circuit before) throws OpRejected {
 
 		Element el = Ops.resolve(before, id);
-		if (!el.canWatch()) {
+		if (!(el instanceof Watchable)) {
 			throw new OpRejected("element '" + id + "' cannot be watched");
 		}
 		return this;

--- a/src/jls/edit/DelayChangeDialog.java
+++ b/src/jls/edit/DelayChangeDialog.java
@@ -17,9 +17,10 @@ import jls.elem.Timed;
  * {@code Element.DelayChange} inner dialog so the element model stays
  * headless; the editor's "Change Timing" action opens it through
  * {@link #open(Element)}. The dialog reads and writes the element's
- * propagation delay / access time through its public
- * {@link Element#getDelay()} / {@link Element#setDelay(int)} accessors, so
- * it works for any timed element without touching the model's internals.
+ * propagation delay / access time through the {@link Timed} capability's
+ * {@link Timed#getDelay()} / {@link Timed#setDelay(int)} accessors (issue
+ * #78), so it works for any timed element without touching the model's
+ * internals.
  */
 public final class DelayChangeDialog {
 
@@ -37,7 +38,9 @@ public final class DelayChangeDialog {
 	 */
 	public static void open(Element el) {
 
-		new Form(el, el instanceof Timed t && t.usesAccessTime());
+		if (el instanceof Timed timed) {
+			new Form(timed, timed.usesAccessTime());
+		}
 	} // end of open method
 
 	/**
@@ -48,7 +51,7 @@ public final class DelayChangeDialog {
 	private static final class Form extends ElementFormDialog {
 
 		/** The element whose timing this form edits. */
-		private final Element element;
+		private final Timed element;
 		/** Field to enter the delay or access time. */
 		private final JTextField delayField = new JTextField(10);
 		/** Keypad for the delay field. */
@@ -60,7 +63,7 @@ public final class DelayChangeDialog {
 		 * @param el The element whose timing is being changed.
 		 * @param isMemory True if this is a memory element, false if not.
 		 */
-		private Form(Element el, boolean isMemory) {
+		private Form(Timed el, boolean isMemory) {
 
 			// set up window title
 			super("Change Timing", null);

--- a/src/jls/edit/ElementQuickMenus.java
+++ b/src/jls/edit/ElementQuickMenus.java
@@ -6,7 +6,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import jls.elem.Constant;
-import jls.elem.Element;
+import jls.elem.QuickEditable;
 
 /**
  * GUI-side "quick change" shortcut menus (issue #77). The former
@@ -25,15 +25,15 @@ public final class ElementQuickMenus {
 
 	/**
 	 * Build the quick-change menu for an element, mirroring the element's
-	 * former {@code setupQuickMenu}. Only called for elements whose
-	 * {@code quickChange()} is true.
+	 * former {@code setupQuickMenu}. Only called for elements that declare
+	 * the {@link QuickEditable} capability (issue #78).
 	 *
 	 * @param el The element the menu is for.
 	 * @param sed The editor to reset and repaint after a quick change.
 	 * @return the menu item (a submenu) to add to the popup.
 	 * @throws UnsupportedOperationException if the element has no quick menu.
 	 */
-	public static JMenuItem build(Element el, SimpleEditor sed) {
+	public static JMenuItem build(QuickEditable el, SimpleEditor sed) {
 
 		if (el instanceof Constant c) {
 			return constantMenu(c, sed);

--- a/src/jls/edit/InteractiveSimulator.java
+++ b/src/jls/edit/InteractiveSimulator.java
@@ -994,7 +994,7 @@ public final class InteractiveSimulator extends Simulator {
 
 			// if a watched element
 			else if (element instanceof LogicElement el) {
-				if (el.isWatched()) {
+				if (el instanceof Watchable watchable && watchable.isWatched()) {
 
 					// set up trace window
 					Trace tr = new Trace(el.getFullName(),el,el.getBits(),

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -85,6 +85,7 @@ import jls.elem.Clock;
 import jls.elem.Constant;
 import jls.elem.Decoder;
 import jls.elem.DelayGate;
+import jls.elem.Editable;
 import jls.elem.Element;
 import jls.elem.ElementId;
 import jls.elem.Extend;
@@ -103,7 +104,9 @@ import jls.elem.Output;
 import jls.elem.OutputPin;
 import jls.elem.Pause;
 import jls.elem.Put;
+import jls.elem.QuickEditable;
 import jls.elem.Register;
+import jls.elem.Rotatable;
 import jls.elem.ShiftRegister;
 import jls.elem.SigGen;
 import jls.elem.Splitter;
@@ -111,9 +114,11 @@ import jls.elem.StateMachine;
 import jls.elem.Stop;
 import jls.elem.SubCircuit;
 import jls.elem.Text;
+import jls.elem.Timed;
 import jls.elem.TriProp;
 import jls.elem.TriState;
 import jls.elem.TruthTable;
+import jls.elem.Watchable;
 import jls.elem.Wire;
 import jls.elem.WireEnd;
 import jls.elem.WireNet;
@@ -1412,7 +1417,7 @@ public abstract class SimpleEditor extends JPanel {
 							Element el = (Element)selected.toArray()[0];
 							if (el.isUneditable())
 								return;
-							if (!el.canWatch())
+							if (!(el instanceof Watchable))
 								return;
 							submitOp(new ToggleWatched(el.getStableId()));
 							clearSelected();
@@ -1454,7 +1459,7 @@ public abstract class SimpleEditor extends JPanel {
 							if (selected.size() != 1)
 								return;
 							Element el = (Element)selected.toArray()[0];
-							if (!el.hasTiming())
+							if (!(el instanceof Timed))
 								return;
 							doTiming();
 						}
@@ -1984,7 +1989,8 @@ public abstract class SimpleEditor extends JPanel {
 				if (selected.size() != 1)
 					return;
 				Element el = (Element)(selected.toArray()[0]);
-				if (!el.canRotate() || el.isUneditable())
+				if (!(el instanceof Rotatable rot) || !rot.canRotate()
+						|| el.isUneditable())
 					return;
 
 				// #167: through the op entry point
@@ -2006,7 +2012,8 @@ public abstract class SimpleEditor extends JPanel {
 				if (selected.size() != 1)
 					return;
 				Element el = (Element)(selected.toArray()[0]);
-				if (!el.canFlip() || el.isUneditable())
+				if (!(el instanceof Rotatable rot) || !rot.canFlip()
+						|| el.isUneditable())
 					return;
 
 				// #167: through the op entry point
@@ -3419,18 +3426,18 @@ public abstract class SimpleEditor extends JPanel {
 			private void makeOptionMenu(Element el) {
 
 				optionMenu.removeAll();
-				if (el.quickChange() && !el.isUneditable()) {
-					optionMenu.add(ElementQuickMenus.build(el, me));
+				if (el instanceof QuickEditable quick && !el.isUneditable()) {
+					optionMenu.add(ElementQuickMenus.build(quick, me));
 				}
-				if (el.canChange() && !el.isUneditable()) {
+				if (el instanceof Editable && !el.isUneditable()) {
 					optionMenu.add(modify);
 				}
-				if (el.hasTiming() && !el.isUneditable()) {
+				if (el instanceof Timed && !el.isUneditable()) {
 					optionMenu.add(timing);
 				}
-				if (el.canWatch()) {
+				if (el instanceof Watchable watchable) {
 					if (!el.isUneditable()) {
-						if (el.isWatched()) {
+						if (watchable.isWatched()) {
 							watch.setText("Un-watch Element");
 						}
 						else {
@@ -3440,7 +3447,7 @@ public abstract class SimpleEditor extends JPanel {
 					}
 					optionMenu.add(view);
 				}
-				if(el.canRotate())
+				if(el instanceof Rotatable rot && rot.canRotate())
 				{
 					if(!el.isUneditable())
 					{
@@ -3448,7 +3455,7 @@ public abstract class SimpleEditor extends JPanel {
 						optionMenu.add(CCrotate);
 					}
 				}
-				if(el.canFlip())
+				if(el instanceof Rotatable rot && rot.canFlip())
 				{
 					if(!el.isUneditable())
 					{

--- a/src/jls/elem/Adder.java
+++ b/src/jls/elem/Adder.java
@@ -17,7 +17,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class Adder extends LogicElement implements Timed {
+public final class Adder extends LogicElement implements Timed, Rotatable {
 
 	// default values
 	/** The default number of bits. */
@@ -244,17 +244,6 @@ public final class Adder extends LogicElement implements Timed {
 
 		return bits + " bit adder";
 	} // end of showInfo method
-
-	/**
-	 * Adders have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset propagation delay to default value.

--- a/src/jls/elem/Clock.java
+++ b/src/jls/elem/Clock.java
@@ -16,7 +16,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class Clock extends LogicElement {
+public final class Clock extends LogicElement implements Rotatable, Editable {
 
 	// default values
 	/** The cycle time offered by the creation dialog's keypad. */
@@ -309,17 +309,6 @@ public final class Clock extends LogicElement {
 		return "clock, cycle time = " + cycleTime +
 				" (zero for " + (cycleTime-oneTime) + ", one for " + oneTime + ")";
 	} // end of showInfo method
-
-	/**
-	 * Clock values can be changed.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 	/**
 	 * Tells if a clock is capable of rotatating, can only rotate when output has no attachment.

--- a/src/jls/elem/Constant.java
+++ b/src/jls/elem/Constant.java
@@ -14,7 +14,8 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class Constant extends LogicElement {
+public final class Constant extends LogicElement
+		implements Rotatable, Editable, QuickEditable {
 
 	// named constants
 	/** Default constant value. */
@@ -411,27 +412,6 @@ public final class Constant extends LogicElement {
 
 	} // end of valueFits method
 
-	/**
-	 * Constants can be changed.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
-
-	/**
-	 * This element has a quick change ability.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean quickChange() {
-
-		return true;
-	} // end of quickChange method
 	/**
 	 * Add one to this constant's value (for the relocated quick-change
 	 * shortcut menu, issue #77).

--- a/src/jls/elem/Decoder.java
+++ b/src/jls/elem/Decoder.java
@@ -17,7 +17,7 @@ import jls.sim.Simulator;
  *
  * @author David A. Poplawski
  */
-public final class Decoder extends LogicElement implements Timed {
+public final class Decoder extends LogicElement implements Timed, Rotatable {
 
 	// default values
 	/** Default number of input bits. */
@@ -317,17 +317,6 @@ public final class Decoder extends LogicElement implements Timed {
 		return bits + " to " + (1<<bits) + " decoder";
 
 	} // end of showInfo method
-
-	/**
-	 * Decoders have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset propagation delay to default value.

--- a/src/jls/elem/Display.java
+++ b/src/jls/elem/Display.java
@@ -18,7 +18,7 @@ import jls.sim.Simulator;
  *
  * @author David A. Poplawski
  */
-public final class Display extends LogicElement {
+public final class Display extends LogicElement implements Rotatable {
 
 	// constants
 	/** The input width a new display starts with. */

--- a/src/jls/elem/Editable.java
+++ b/src/jls/elem/Editable.java
@@ -1,0 +1,18 @@
+package jls.elem;
+
+/**
+ * Capability interface (issue #78) for elements the user can modify
+ * after they are created and placed.
+ *
+ * <p>This replaces the {@code canChange()} predicate that defaulted to
+ * false on {@link Element}: an editable element declares the capability
+ * once, in the type system, and call sites {@code instanceof}-check it.
+ * Every element whose {@code canChange()} returned true did so
+ * unconditionally, so the capability is purely class-level and the
+ * interface needs no methods - the change dialog itself already lives
+ * on the GUI side (issue #77's {@code ElementDialogs} registry), keyed
+ * by element class, which keeps this interface headless.
+ */
+public interface Editable {
+
+} // end of Editable interface

--- a/src/jls/elem/Element.java
+++ b/src/jls/elem/Element.java
@@ -7,7 +7,6 @@ import java.util.*;
 import org.jspecify.annotations.Nullable;
 
 import jls.*;
-import jls.core.Orientation;
 
 /**
  * Super class for all logic elements (including non-active ones).
@@ -809,41 +808,6 @@ public abstract sealed class Element
 	} // end of getPut method
 
 	/**
-	 * Check whether the element can be changed after it is created and placed.
-	 * Default is not.
-	 * Overriden by elements that can.
-	 *
-	 * @return true if element can be change, false otherwise.
-	 */
-	public boolean canChange() {
-
-		return false;
-	} // end of canChange method
-
-	/**
-	 * Check whether element has a quick change (shortcut) option.
-	 * Overridden by elements than can.
-	 *
-	 * @return true if is does, false if not.
-	 */
-	public boolean quickChange() {
-
-		return false;
-	} // end of quicChange method
-
-	/**
-	 * Check whether the element has timing info, i.e., propagation delay or access time.
-	 * Default is do not.
-	 * Overridden by elements tht do.
-	 *
-	 * @return true if the element has timing info, false if not.
-	 */
-	public boolean hasTiming() {
-
-		return false;
-	} // end of hasTiming method
-
-	/**
 	 * The save-format version this element's current state requires
 	 * (issue #79 evolution policy: a writer emits the highest version
 	 * whose features the file uses). Almost everything is expressible
@@ -856,105 +820,6 @@ public abstract sealed class Element
 	{
 		return 1;
 	}
-
-	/**
-	 * Tells if an element is capable of rotatating, defaults to false.
-	 * This method may be overridden if an element supports rotation
-	 * @return True if an element supports rotation otherwise false
-	 */
-	public boolean canRotate()
-	{
-		return false;
-	}
-
-	/**
-	 *  This method will rotate the element if it is supported.
-	 *  This must be overridden by supporting classes.
-	 * @param direction The direction to rotate
-	 * @param g The current graphics context for use in recalculating size
-	 */
-	public void rotate(Orientation direction, jls.core.@org.jspecify.annotations.Nullable TextMetrics g)
-	{
-		throw new UnsupportedOperationException("Rotate");
-	}
-
-	/**
-	 * Tells if an element is capable of flipping, defaults to false.
-	 * This method may be overridden if an element supports flipping
-	 * @return True if an element supports flipping otherwise false
-	 */
-	public boolean canFlip()
-	{
-		return false;
-	}
-
-	/**
-	 * This method will flip an element, it must be overridden by classes that support it
-	 * @param g The current graphics context to facilitate recalculation of size when flipping
-	 */
-	public void flip(jls.core.@org.jspecify.annotations.Nullable TextMetrics g)
-	{
-		throw new UnsupportedOperationException("Flip");
-	}
-
-	/**
-	 * Get the propagation delay or access time in this element.
-	 * Overridden by elements with timing info.
-	 *
-	 * @return the current delay.
-	 */
-	public int getDelay() {
-
-		return 0;
-	} // end of getDelay method
-
-	/**
-	 * Set the propagation delay or access time in this element.
-	 * Overridden by elements with timing info.
-	 *
-	 * @param temp The new delay amount.
-	 *        Must be Integer, don't change to int!
-	 */
-	public void setDelay(int temp) {
-
-		// do nothing
-	} // end of setDelay method
-
-	/**
-	 * Check wether the element can be watched.
-	 * Default is not.
-	 * Overridden by elements that can be.
-	 *
-	 * @return false;
-	 */
-	public boolean canWatch() {
-
-		return false;
-	} // end of canWatch method
-
-	/**
-	 * See if element is currently watched.
-	 * Default is not.
-	 * Overridden by elements that can be watched.
-	 *
-	 * @return false.
-	 *
-	 * @jls.testedby jls.ui.CircuitAssert#assertWatched()
-	 */
-	public boolean isWatched() {
-
-		return false;
-	} // end of isWatched method
-
-	/**
-	 * Set whether this element is watched or not.
-	 * Overridden by elements that can be watched.
-	 *
-	 * @param state Unused.
-	 */
-	public void setWatched(boolean state) {
-
-	} // end of setWatched method
 
 	/**
 	 * Display the current value of this element.

--- a/src/jls/elem/Extend.java
+++ b/src/jls/elem/Extend.java
@@ -144,17 +144,6 @@ public final class Extend extends Gate implements TriProp {
 	} // end of showInfo method
 
 	/**
-	 * An expand is just wire so has no propagation delay.
-	 *
-	 * @return false.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return false;
-	} // end of hasTiming method
-
-	/**
 	 * Propagate tri-state to output.
 	 *
 	 * @param which True if tristate, false if not.

--- a/src/jls/elem/Gate.java
+++ b/src/jls/elem/Gate.java
@@ -17,7 +17,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public abstract sealed class Gate extends LogicElement
+public abstract sealed class Gate extends LogicElement implements Rotatable
 		permits AndGate, DelayGate, Extend, NandGate, NorGate, NotGate,
 		OrGate, XorGate {
 
@@ -515,22 +515,12 @@ public abstract sealed class Gate extends LogicElement
 	} // end of resetPropDelay method
 
 	/**
-	 * Gates have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
-
-	/**
-	 * Get the propagation delay in this element.
+	 * Get the propagation delay in this element. Implements {@link Timed}
+	 * for the gate subclasses that declare it ({@link Extend} does not -
+	 * an extend is just wire, so it has no propagation delay).
 	 *
 	 * @return the current delay.
 	 */
-	@Override
 	public int getDelay() {
 
 		return propDelay;
@@ -541,7 +531,6 @@ public abstract sealed class Gate extends LogicElement
 	 *
 	 * @param temp The new delay amount.
 	 */
-	@Override
 	public void setDelay(int temp) {
 
 		propDelay = temp;

--- a/src/jls/elem/Group.java
+++ b/src/jls/elem/Group.java
@@ -15,7 +15,7 @@ import jls.core.Orientation;
  *
  * @author David A. Poplawski
  */
-public abstract sealed class Group extends LogicElement
+public abstract sealed class Group extends LogicElement implements Rotatable
 		permits Binder, Splitter {
 
 	// default values

--- a/src/jls/elem/JumpEnd.java
+++ b/src/jls/elem/JumpEnd.java
@@ -15,7 +15,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class JumpEnd extends LogicElement {
+public final class JumpEnd extends LogicElement implements Rotatable {
 
 	// default value
 	/** Default number of bits in the named wire. */

--- a/src/jls/elem/JumpStart.java
+++ b/src/jls/elem/JumpStart.java
@@ -16,7 +16,7 @@ import jls.sim.*;
  * @author David A. Poplawski
  */
 public final class JumpStart extends LogicElement
-		implements TriProp, Watchable {
+		implements TriProp, Watchable, Rotatable {
 
 	// default value
 	/** The default bit width for a new jump start. */
@@ -378,17 +378,6 @@ public final class JumpStart extends LogicElement
 			inputs.add(new Input("input",this,width,0,bits));
 		}
 	}
-
-	/**
-	 * A jump start can be watched.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canWatch() {
-
-		return true;
-	} // end of canWatch method
 
 	/**
 	 * See if this jumpstart is watched.

--- a/src/jls/elem/LogicElement.java
+++ b/src/jls/elem/LogicElement.java
@@ -488,16 +488,6 @@ public abstract sealed class LogicElement extends Element implements Reacts
 	} // end of resetPropDelay method
 
 	/**
-	 * Set propagation delay (overridden by most elements).
-	 *
-	 * @param newDelay The new delay value.
-	 */
-	@Override
-	public void setDelay(int newDelay) {
-
-	} // end of setDelay method
-
-	/**
 	 * Get the name of this element.
 	 * Overridden in elements that have names.
 	 *

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -18,7 +18,7 @@ import jls.sim.*;
  * @author David A. Poplawski
  */
 public final class Memory extends LogicElement
-		implements Timed, Watchable {
+		implements Timed, Watchable, Editable {
 
 	// types
 	/**
@@ -662,17 +662,6 @@ public final class Memory extends LogicElement
 	} // end of getBits method
 
 	/**
-	 * A memory can be watched.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canWatch() {
-
-		return true;
-	} // end of canWatch method
-
-	/**
 	 * See if this memory is watched.
 	 *
 	 * @return true if it is, false if it is not.
@@ -693,17 +682,6 @@ public final class Memory extends LogicElement
 
 		watched = state;
 	} // end of setWatched method
-
-	/**
-	 * Memories have timing info (access time).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset access time to default value.
@@ -771,17 +749,6 @@ public final class Memory extends LogicElement
 		circ.removeName(name);
 		super.remove(circ);
 	} // end of remove method
-
-	/**
-	 * Memories can be modified.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 	/**
 	 * Parse initial value text.

--- a/src/jls/elem/Mux.java
+++ b/src/jls/elem/Mux.java
@@ -17,7 +17,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class Mux extends LogicElement implements Timed {
+public final class Mux extends LogicElement implements Timed, Rotatable {
 
 	// default values
 	/** Default number of data inputs. */
@@ -348,17 +348,6 @@ public final class Mux extends LogicElement implements Timed {
 
 		return numInputs + " input, " + bits + " bit multiplexor";
 	} // end of showInfo method
-
-	/**
-	 * Multiplexors have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset propagation delay to default value.

--- a/src/jls/elem/Pin.java
+++ b/src/jls/elem/Pin.java
@@ -16,7 +16,7 @@ import jls.core.Orientation;
  * @author David A. Poplawski
  */
 public abstract sealed class Pin extends LogicElement
-		implements Watchable
+		implements Watchable, Rotatable
 		permits InputPin, OutputPin {
 
 	// saved properties
@@ -424,16 +424,6 @@ public abstract sealed class Pin extends LogicElement
 
 		return bits + " bit input pin";
 	} // end of showInfo method
-	/**
-	 * A pin be watched.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canWatch() {
-
-		return true;
-	} // end of canWatch method
 
 	/**
 	 * See if this pin is watched.

--- a/src/jls/elem/QuickEditable.java
+++ b/src/jls/elem/QuickEditable.java
@@ -1,0 +1,17 @@
+package jls.elem;
+
+/**
+ * Capability interface (issue #78) for elements that offer a "quick
+ * change" (shortcut) menu in the editor's option popup.
+ *
+ * <p>This replaces the {@code quickChange()} predicate that defaulted
+ * to false on {@link Element}: an element with a shortcut menu declares
+ * the capability once, in the type system, and call sites
+ * {@code instanceof}-check it. The Swing menu itself already lives on
+ * the GUI side (issue #77's {@code jls.edit.ElementQuickMenus}), so
+ * this interface stays headless. Only {@link Constant} has a quick
+ * menu today.
+ */
+public interface QuickEditable {
+
+} // end of QuickEditable interface

--- a/src/jls/elem/Register.java
+++ b/src/jls/elem/Register.java
@@ -17,7 +17,7 @@ import jls.sim.*;
  * @author David A. Poplawski
  */
 public final class Register extends LogicElement
-		implements Timed, Watchable {
+		implements Timed, Watchable, Rotatable, Editable {
 
 	// register types
 	/**
@@ -495,17 +495,6 @@ public final class Register extends LogicElement
 	} // end of remove method
 
 	/**
-	 * Registers have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
-
-	/**
 	 * Reset propagation delay to default value.
 	 */
 	@Override
@@ -651,28 +640,6 @@ public final class Register extends LogicElement
 		height = 0;
 		init(g);
 	} // end of flip method
-
-	/**
-	 * Registers can be modified.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
-
-	/**
-	 * A register can be watched.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canWatch() {
-
-		return true;
-	} // end of canWatch method
 
 	/**
 	 * See if this register is watched.

--- a/src/jls/elem/Rotatable.java
+++ b/src/jls/elem/Rotatable.java
@@ -1,0 +1,84 @@
+package jls.elem;
+
+import jls.core.Orientation;
+
+/**
+ * Capability interface (issue #78) for elements the user can reorient -
+ * rotate a quarter turn and/or flip (mirror).
+ *
+ * <p>Like {@link Timed} and {@link Watchable}, this replaces one of
+ * {@link Element}'s boolean-gated capability pairs: the
+ * {@code canRotate()}/{@code canFlip()} predicates plus the
+ * {@code rotate()}/{@code flip()} mutators that defaulted to
+ * "unsupported" on the base class. An element that can be reoriented
+ * declares that once, in the type system, by implementing
+ * {@code Rotatable}; call sites {@code instanceof}-check the capability
+ * instead of trusting a base-class default.
+ *
+ * <p>The predicates remain instance methods rather than being subsumed
+ * by the {@code instanceof} check because they are attachment gates,
+ * not constants: an element that could rotate when free refuses once a
+ * wire is attached to any of its puts. The {@code instanceof} check
+ * answers "can this kind of element ever be reoriented"; the predicate
+ * answers "can this one, right now".
+ *
+ * <p>Rotation and flipping share one interface because they share the
+ * attachment gate and the rebuild-the-puts mechanics, but an element
+ * may support only one of the two (jump points and subcircuits flip
+ * without rotating), so each half defaults to "unsupported" and an
+ * implementor overrides the half it provides.
+ *
+ * <p>The interface is headless: {@link jls.core.Orientation} and
+ * {@link jls.core.TextMetrics} are core types, so it stays inside the
+ * enforced core surface (issue #77) and imposes no GUI dependency.
+ */
+public interface Rotatable {
+
+	/**
+	 * Whether this element can rotate right now. Typically false once
+	 * any put has a wire attached, since rotating rebuilds the puts.
+	 *
+	 * @return true if the element currently supports rotation.
+	 */
+	default boolean canRotate() {
+
+		return false;
+	} // end of canRotate method
+
+	/**
+	 * Rotate the element a quarter turn. Only called when
+	 * {@link #canRotate()} is true.
+	 *
+	 * @param direction The direction to rotate: {@code LEFT} for
+	 *        counterclockwise, {@code RIGHT} for clockwise.
+	 * @param g The current text metrics for use in recalculating size.
+	 */
+	default void rotate(Orientation direction,
+			jls.core.@org.jspecify.annotations.Nullable TextMetrics g) {
+
+		throw new UnsupportedOperationException("Rotate");
+	} // end of rotate method
+
+	/**
+	 * Whether this element can flip right now. Typically false once any
+	 * put has a wire attached, since flipping rebuilds the puts.
+	 *
+	 * @return true if the element currently supports flipping.
+	 */
+	default boolean canFlip() {
+
+		return false;
+	} // end of canFlip method
+
+	/**
+	 * Flip (mirror) the element. Only called when {@link #canFlip()} is
+	 * true.
+	 *
+	 * @param g The current text metrics for use in recalculating size.
+	 */
+	default void flip(jls.core.@org.jspecify.annotations.Nullable TextMetrics g) {
+
+		throw new UnsupportedOperationException("Flip");
+	} // end of flip method
+
+} // end of Rotatable interface

--- a/src/jls/elem/ShiftRegister.java
+++ b/src/jls/elem/ShiftRegister.java
@@ -32,7 +32,8 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class ShiftRegister extends LogicElement implements Timed {
+public final class ShiftRegister extends LogicElement
+		implements Timed, Rotatable {
 
 	/** The shift-kind rule, shared by the dialog and the loader
 	 *  (issue #52 pattern: one string, two surfaces). */
@@ -455,17 +456,6 @@ public final class ShiftRegister extends LogicElement implements Timed {
 		}
 		return bits + " bit " + kind + " shift register";
 	} // end of showInfo method
-
-	/**
-	 * Shift registers have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset propagation delay to default value.

--- a/src/jls/elem/SigGen.java
+++ b/src/jls/elem/SigGen.java
@@ -12,7 +12,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class SigGen extends SigSim {
+public final class SigGen extends SigSim implements Editable {
 
 	// named constants
 	/** Title drawn inside the element's box. */
@@ -154,17 +154,6 @@ public final class SigGen extends SigSim {
 		super.copy(it);
 		return it;
 	} // end of copy method
-
-	/**
-	 * Signal generators can be changed.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 //	-------------------------------------------------------------------------------
 //	Simulation

--- a/src/jls/elem/StateMachine.java
+++ b/src/jls/elem/StateMachine.java
@@ -25,7 +25,7 @@ import jls.sim.Simulator;
  * @author David A. Poplawski
  */
 public final class StateMachine extends LogicElement
-		implements Timed {
+		implements Timed, Editable {
 
 	// default values
 	/** Propagation delay a new state machine starts with. */
@@ -612,17 +612,6 @@ public final class StateMachine extends LogicElement
 	} // end of reinit method
 
 	/**
-	 * State machines have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
-
-	/**
 	 * Reset propagation delay to default value.
 	 */
 	@Override
@@ -652,17 +641,6 @@ public final class StateMachine extends LogicElement
 
 		propDelay = temp;
 	} // end of setDelay method
-
-	/**
-	 * State machines can be modified.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 //	-------------------------------------------------------------------------------
 //	Simulation

--- a/src/jls/elem/SubCircuit.java
+++ b/src/jls/elem/SubCircuit.java
@@ -15,7 +15,8 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class SubCircuit extends LogicElement implements TriProp {
+public final class SubCircuit extends LogicElement
+		implements TriProp, Rotatable, Editable {
 
 	// properties
 	/**
@@ -409,17 +410,21 @@ public final class SubCircuit extends LogicElement implements TriProp {
 	} // end of showInfo method
 
 	/**
-	 * Set whether elements in the subcircuit are watched.
+	 * Set whether elements in the subcircuit are watched. The subcircuit
+	 * itself is not {@link Watchable}; this propagates the setting to the
+	 * watchable elements (and nested subcircuits) it contains.
 	 *
 	 * @param which True to set all watchable elements to watched, false to make them
 	 *        not watched.
 	 */
-	@Override
 	public void setWatched(boolean which) {
 
 		for (Element element : getSubCircuit().getElements()) {
-			if (element instanceof LogicElement le) {
-				le.setWatched(which);
+			if (element instanceof Watchable watchable) {
+				watchable.setWatched(which);
+			}
+			else if (element instanceof SubCircuit sub) {
+				sub.setWatched(which);
 			}
 		}
 	} // end of setWatched method
@@ -432,17 +437,6 @@ public final class SubCircuit extends LogicElement implements TriProp {
 
 		getSubCircuit().resetAllDelays();
 	} // end of resetPropDelay method
-
-	/**
-	 * Subcircuits can be changed.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 	/**
 	 * Remap all input and output pins to inputs and outputs.

--- a/src/jls/elem/Text.java
+++ b/src/jls/elem/Text.java
@@ -11,7 +11,7 @@ import jls.*;
  *
  * @author David A. Poplawski
  */
-public final class Text extends DisplayElement {
+public final class Text extends DisplayElement implements Editable {
 
 	// saved properties
 	/** The text to display, lines separated by newlines. */
@@ -424,16 +424,5 @@ public final class Text extends DisplayElement {
 		super.save(output);
 		output.println("END");
 	} // end of save method
-
-	/**
-	 * Text areas can be changed.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 } // end of Text method

--- a/src/jls/elem/TriState.java
+++ b/src/jls/elem/TriState.java
@@ -17,7 +17,7 @@ import jls.sim.*;
  *
  * @author David A. Poplawski
  */
-public final class TriState extends LogicElement implements Timed {
+public final class TriState extends LogicElement implements Timed, Rotatable {
 
 	// defaults
 	/** Default number of bits (gates). */
@@ -302,17 +302,6 @@ public final class TriState extends LogicElement implements Timed {
 		else
 			return bits + " tri-state gates";
 	} // end of showInfo method
-
-	/**
-	 * Tri-states have timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Reset propagation delay to default value.

--- a/src/jls/elem/TruthTable.java
+++ b/src/jls/elem/TruthTable.java
@@ -26,7 +26,7 @@ import jls.sim.Simulator;
  * @author David A. Poplawski
  */
 public final class TruthTable extends LogicElement
-		implements Timed {
+		implements Timed, Editable {
 
 	// default values
 	/** Default propagation delay (simulation time units). */
@@ -382,17 +382,6 @@ public final class TruthTable extends LogicElement
 
 		return name;
 	} // end of getName method
-
-	/**
-	 * Truth tables can be modified.
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean canChange() {
-
-		return true;
-	} // end of canChange method
 
 	/**
 	 * Truth tables cannot be copied.
@@ -1327,17 +1316,6 @@ public final class TruthTable extends LogicElement
 
 		propDelay = getDefaultDelay();
 	} // end of resetPropDelay method
-
-	/**
-	 * Combinational logic has timing info (propagation delay).
-	 *
-	 * @return true.
-	 */
-	@Override
-	public boolean hasTiming() {
-
-		return true;
-	} // end of hasTiming method
 
 	/**
 	 * Get the propagation delay in this element.

--- a/src/jls/sim/BatchSimulator.java
+++ b/src/jls/sim/BatchSimulator.java
@@ -146,7 +146,7 @@ public class BatchSimulator extends Simulator {
 
 		// see if changing element is watched
 		LogicElement el = (LogicElement)event.getCallBack();
-		if (el.isWatched()) {
+		if (el instanceof Watchable watchable && watchable.isWatched()) {
 
 			// get the event trace for this element,
 			// or create one if none yet
@@ -223,7 +223,7 @@ public class BatchSimulator extends Simulator {
 			if (el instanceof SubCircuit sub) {
 				findWatched(sub.getSubCircuit());
 			}
-			else if (el.isWatched()) {
+			else if (el instanceof Watchable watchable && watchable.isWatched()) {
 				LogicElement lel = (LogicElement)el;
 				List<TraceSample> events = new LinkedList<TraceSample>();
 				BitSet value = lel.getCurrentValue();

--- a/test/jls/collab/op/CircuitOpTest.java
+++ b/test/jls/collab/op/CircuitOpTest.java
@@ -28,7 +28,9 @@ import jls.elem.ElementId;
 import jls.elem.JumpEnd;
 import jls.elem.JumpStart;
 import jls.elem.Pin;
+import jls.elem.Rotatable;
 import jls.elem.ShiftRegister;
+import jls.elem.Watchable;
 import jls.elem.Wire;
 import jls.elem.WireEnd;
 
@@ -127,7 +129,7 @@ class CircuitOpTest {
 				+ " String orient \"LEFT\"\n int delay 10\nEND\n"
 				+ "ENDCIRCUIT\n");
 		return ElementBlocks.saveBlock(
-				find(donor, el -> el.canRotate()));
+				find(donor, CircuitOpTest::canRotate));
 	}
 
 	private static String save(Circuit circuit) {
@@ -159,6 +161,16 @@ class CircuitOpTest {
 		return matches.get(0);
 	}
 
+	/** Whether the element can rotate right now (issue #78 capability). */
+	private static boolean canRotate(Element el) {
+		return el instanceof Rotatable rot && rot.canRotate();
+	}
+
+	/** Whether the element can flip right now (issue #78 capability). */
+	private static boolean canFlip(Element el) {
+		return el instanceof Rotatable rot && rot.canFlip();
+	}
+
 	private static String serialize(CircuitOp op) {
 		StringWriter out = new StringWriter();
 		try (PrintWriter writer = new PrintWriter(out)) {
@@ -175,10 +187,10 @@ class CircuitOpTest {
 	void toggleWatchedMatchesInlineMutation() throws Exception {
 		Circuit viaOp = load();
 		Circuit inline = load();
-		Element pin = find(viaOp, el -> el instanceof Pin && el.canWatch());
+		Element pin = find(viaOp, el -> el instanceof Pin && el instanceof Watchable);
 		new ToggleWatched(pin.getStableId()).apply(viaOp, graphics());
-		Element inlinePin = find(inline,
-				el -> el instanceof Pin && el.canWatch());
+		Watchable inlinePin = (Watchable) find(inline,
+				el -> el instanceof Pin && el instanceof Watchable);
 		inlinePin.setWatched(!inlinePin.isWatched());
 		assertEquals(save(inline), save(viaOp),
 				"op and inline watch toggle must produce identical bytes");
@@ -188,10 +200,10 @@ class CircuitOpTest {
 	void rotateMatchesInlineMutation() throws Exception {
 		Circuit viaOp = loadAdder();
 		Circuit inline = loadAdder();
-		Element adder = find(viaOp, Element::canRotate);
+		Element adder = find(viaOp, CircuitOpTest::canRotate);
 		new RotateElement(adder.getStableId(), true)
 				.apply(viaOp, graphics());
-		find(inline, Element::canRotate)
+		((Rotatable) find(inline, CircuitOpTest::canRotate))
 				.rotate(Orientation.RIGHT, jls.edit.SwingTextMetrics.of(graphics()));
 		assertEquals(save(inline), save(viaOp),
 				"op and inline rotation must produce identical bytes");
@@ -201,10 +213,10 @@ class CircuitOpTest {
 	void removeMatchesInlineMutation() throws Exception {
 		Circuit viaOp = loadAdder();
 		Circuit inline = loadAdder();
-		Element adder = find(viaOp, Element::canRotate);
+		Element adder = find(viaOp, CircuitOpTest::canRotate);
 		new RemoveElements(List.of(adder.getStableId()))
 				.apply(viaOp, graphics());
-		Element inlineAdder = find(inline, Element::canRotate);
+		Element inlineAdder = find(inline, CircuitOpTest::canRotate);
 		inlineAdder.remove(inline);
 		assertEquals(save(inline), save(viaOp),
 				"op and inline removal must produce identical bytes");
@@ -220,7 +232,7 @@ class CircuitOpTest {
 	void configReplaceInstallsExactlyTheReconfiguredBlock()
 			throws Exception {
 		Circuit circuit = loadAdder();
-		Element adder = find(circuit, Element::canRotate);
+		Element adder = find(circuit, CircuitOpTest::canRotate);
 		ElementId id = adder.getStableId();
 		String reconfigured = ElementBlocks.saveBlock(adder)
 				.replace("int bits 4", "int bits 8");
@@ -276,7 +288,7 @@ class CircuitOpTest {
 	void toggleWatchedInverseRestoresBytes() throws Exception {
 		Circuit circuit = load();
 		Element pin = find(circuit,
-				el -> el instanceof Pin && el.canWatch());
+				el -> el instanceof Pin && el instanceof Watchable);
 		assertInverseRestores(circuit,
 				new ToggleWatched(pin.getStableId()));
 	}
@@ -284,7 +296,7 @@ class CircuitOpTest {
 	@Test
 	void rotateInverseRestoresBytes() throws Exception {
 		Circuit circuit = loadAdder();
-		Element adder = find(circuit, Element::canRotate);
+		Element adder = find(circuit, CircuitOpTest::canRotate);
 		assertInverseRestores(circuit,
 				new RotateElement(adder.getStableId(), true));
 		assertInverseRestores(circuit,
@@ -294,7 +306,7 @@ class CircuitOpTest {
 	@Test
 	void flipInverseRestoresBytes() throws Exception {
 		Circuit circuit = loadAdder();
-		Element adder = find(circuit, Element::canFlip);
+		Element adder = find(circuit, CircuitOpTest::canFlip);
 		assertInverseRestores(circuit,
 				new FlipElement(adder.getStableId()));
 	}
@@ -323,7 +335,7 @@ class CircuitOpTest {
 	@Test
 	void removeInverseRestoresBytes() throws Exception {
 		Circuit circuit = loadAdder();
-		Element adder = find(circuit, Element::canRotate);
+		Element adder = find(circuit, CircuitOpTest::canRotate);
 		assertInverseRestores(circuit,
 				new RemoveElements(List.of(adder.getStableId())));
 	}
@@ -338,7 +350,7 @@ class CircuitOpTest {
 	@Test
 	void configReplaceInverseRestoresBytes() throws Exception {
 		Circuit circuit = loadAdder();
-		Element adder = find(circuit, Element::canRotate);
+		Element adder = find(circuit, CircuitOpTest::canRotate);
 		String reconfigured = ElementBlocks.saveBlock(adder)
 				.replace("int bits 4", "int bits 8");
 		assertInverseRestores(circuit,
@@ -369,18 +381,18 @@ class CircuitOpTest {
 		// differently on a restored object graph
 		Circuit circuit = restored(load());
 		Element pin = find(circuit,
-				el -> el instanceof Pin && el.canWatch());
+				el -> el instanceof Pin && el instanceof Watchable);
 		assertInverseRestores(circuit,
 				new ToggleWatched(pin.getStableId()));
 		Circuit adders = restored(loadAdder());
-		Element adder = find(adders, Element::canRotate);
+		Element adder = find(adders, CircuitOpTest::canRotate);
 		assertInverseRestores(adders,
 				new RotateElement(adder.getStableId(), true));
 		assertInverseRestores(adders,
 				new RemoveElements(List.of(adder.getStableId())));
 		assertInverseRestores(adders,
 				new AddElements(List.of(donorAdderBlock())));
-		Element restoredAdder = find(adders, Element::canRotate);
+		Element restoredAdder = find(adders, CircuitOpTest::canRotate);
 		assertInverseRestores(adders, new SetElementConfig(
 				restoredAdder.getStableId(),
 				ElementBlocks.saveBlock(restoredAdder)
@@ -521,11 +533,14 @@ class CircuitOpTest {
 		String before = save(circuit);
 		ElementId unknown = ElementId.parse("nosuch:1");
 		Element pin = find(circuit,
-				el -> el instanceof Pin && el.canWatch());
+				el -> el instanceof Pin && el instanceof Watchable);
 		Element wire = find(circuit, el -> el instanceof Wire);
 		Element constant = find(circuit,
-				el -> !el.canWatch() && !(el instanceof Wire)
-						&& !el.canRotate());
+				el -> !(el instanceof Watchable) && !(el instanceof Wire)
+						&& !canRotate(el));
+		// an element with no Rotatable capability at all (issue #78):
+		// rejected by the instanceof gate, not the attachment gate
+		Element wireEnd = find(circuit, el -> el instanceof WireEnd);
 
 		CircuitOp[] invalid = {
 				new ToggleWatched(unknown),
@@ -534,7 +549,9 @@ class CircuitOpTest {
 				new AttachProbe(wire.getStableId(), ""),
 				new RemoveProbe(wire.getStableId()),
 				new RotateElement(constant.getStableId(), true),
+				new RotateElement(wireEnd.getStableId(), true),
 				new FlipElement(constant.getStableId()),
+				new FlipElement(wireEnd.getStableId()),
 				new MoveElements(List.of(), 8, 8),
 				new MoveElements(List.of(pin.getStableId(),
 						pin.getStableId()), 8, 8),
@@ -549,13 +566,27 @@ class CircuitOpTest {
 			assertEquals(before, save(circuit),
 					"a rejected op must not change the circuit");
 		}
+
+		// inversion validates the same capability gates (issue #78)
+		CircuitOp[] invalidInverts = {
+				new ToggleWatched(constant.getStableId()),
+				new RotateElement(constant.getStableId(), true),
+				new RotateElement(wireEnd.getStableId(), true),
+				new FlipElement(constant.getStableId()),
+				new FlipElement(wireEnd.getStableId()),
+		};
+		for (CircuitOp op : invalidInverts) {
+			assertThrows(OpRejected.class, () -> op.invert(circuit),
+					"inverting an op its target cannot satisfy must be "
+							+ "rejected");
+		}
 	}
 
 	@Test
 	void addRejectionsLeaveTheCircuitUnchanged() throws Exception {
 		Circuit circuit = loadAdder();
 		String before = save(circuit);
-		Element adder = find(circuit, Element::canRotate);
+		Element adder = find(circuit, CircuitOpTest::canRotate);
 		String donor = donorAdderBlock();
 
 		CircuitOp[] invalid = {
@@ -699,7 +730,7 @@ class CircuitOpTest {
 		// unknown id: resolution fails before the block is examined
 		Circuit adders = loadAdder();
 		String addersBefore = save(adders);
-		Element adder = find(adders, Element::canRotate);
+		Element adder = find(adders, CircuitOpTest::canRotate);
 		ElementId adderId = adder.getStableId();
 		String adderBlock = ElementBlocks.saveBlock(adder);
 		assertThrows(OpRejected.class,

--- a/test/jls/elem/CapabilityInterfaceTest.java
+++ b/test/jls/elem/CapabilityInterfaceTest.java
@@ -2,87 +2,230 @@ package jls.elem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
 import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.JLSInfo;
 
 /**
  * The capability-interface contract for issue #78: the boolean-gated
- * capability pairs on {@link Element} are being replaced by capability
+ * capability pairs on {@link Element} have been replaced by capability
  * interfaces that an element implements once, in the type system, so
  * that call sites {@code instanceof}-check the capability instead of the
  * base class branching on concrete leaf types (the audit's "base knows
  * its leaves" smell).
  *
- * <p>This test pins the equivalence between each capability interface
- * and the predicate it supersedes, so that adding a new element - or
- * flipping a predicate - without also declaring (or removing) the
- * interface is a build failure rather than a silent divergence. It is
- * the enforcement half of the same discipline the registry-integrity
- * test provides for loadability: the registry is walked as the total,
- * authoritative list of loadable element types.
+ * <p>This test pins, for every registered element type, exactly which
+ * capabilities it declares, so that adding a new element - or moving a
+ * capability - without updating this expectation is a build failure
+ * rather than a silent divergence. It is the enforcement half of the
+ * same discipline the registry-integrity test provides for loadability:
+ * the registry is walked as the total, authoritative list of loadable
+ * element types.
  *
- * <p>Interfaces covered this wave: {@link Timed} (supersedes
- * {@code hasTiming()} + the {@code getDelay()}/{@code setDelay()} pair,
- * and retires the {@code instanceof Memory} branch in
- * {@link Element#changeTiming()}) and {@link Watchable} (supersedes
- * {@code canWatch()} + the watch-state accessors). The remaining
- * capabilities named on #78 - {@code Rotatable}, {@code Editable},
- * {@code QuickEditable} - are deferred: {@code canRotate()} is a
- * runtime attachment gate rather than a class-level capability, and the
- * other two carry Swing/editor method signatures that cannot live on a
- * headless-core interface until the GUI method moves out (issue #77's
- * renderer split). See the class comment on {@link Timed}.
+ * <p>Interfaces covered: {@link Timed} (supersedes {@code hasTiming()}
+ * plus the delay accessors), {@link Watchable} (supersedes
+ * {@code canWatch()} plus the watch-state accessors), {@link Rotatable}
+ * (supersedes {@code canRotate()}/{@code canFlip()} plus
+ * {@code rotate()}/{@code flip()}), {@link Editable} (supersedes
+ * {@code canChange()}), and {@link QuickEditable} (supersedes
+ * {@code quickChange()}). The rotate/flip predicates survive as
+ * instance methods on {@link Rotatable} because they are attachment
+ * gates, not constants; on a freshly created (unattached) element they
+ * report the class-level capability, which this test also pins.
  */
 class CapabilityInterfaceTest {
 
+	/** The registered tags whose elements are {@link Timed}. */
+	private static final Set<String> TIMED = Set.of(
+			"Adder", "AndGate", "Decoder", "DelayGate", "Memory", "Mux",
+			"NandGate", "NorGate", "NotGate", "OrGate", "Register",
+			"ShiftRegister", "StateMachine", "TriState", "TruthTable",
+			"XorGate");
+
+	/** The registered tags whose elements are {@link Watchable}. */
+	private static final Set<String> WATCHABLE = Set.of(
+			"InputPin", "JumpStart", "Memory", "OutputPin", "Register");
+
+	/** The registered tags whose elements are {@link Rotatable}. */
+	private static final Set<String> ROTATABLE = Set.of(
+			"Adder", "AndGate", "Binder", "Clock", "Constant", "Decoder",
+			"DelayGate", "Display", "Extend", "InputPin", "JumpEnd",
+			"JumpStart", "Mux", "NandGate", "NorGate", "NotGate", "OrGate",
+			"OutputPin", "Register", "ShiftRegister", "Splitter",
+			"SubCircuit", "TriState", "XorGate");
+
 	/**
-	 * An element implements {@link Timed} exactly when it reports
-	 * {@code hasTiming()} - no timed element lacks the interface, and no
-	 * non-timed element carries it.
+	 * The {@link Rotatable} tags that only flip: their
+	 * {@code canRotate()} stays false even when unattached.
+	 */
+	private static final Set<String> FLIP_ONLY = Set.of(
+			"JumpEnd", "JumpStart", "SubCircuit");
+
+	/**
+	 * The {@link Rotatable} tags whose predicates are pinned false even
+	 * when unattached: the display keeps its historical rotate/flip
+	 * overrides (so it stays {@code Rotatable}, faithful to the base
+	 * code) but refuses both because its puts implement the Stop
+	 * behavior.
+	 */
+	private static final Set<String> NEVER_REORIENTS = Set.of("Display");
+
+	/** The registered tags whose elements are {@link Editable}. */
+	private static final Set<String> EDITABLE = Set.of(
+			"Clock", "Constant", "Memory", "Register", "SigGen",
+			"StateMachine", "SubCircuit", "Text", "TruthTable");
+
+	/** The registered tags whose elements are {@link QuickEditable}. */
+	private static final Set<String> QUICK_EDITABLE = Set.of("Constant");
+
+	/**
+	 * Assert that a type declares an interface exactly when its tag is in
+	 * the expected set, in both directions.
+	 *
+	 * @param type The registered element type.
+	 * @param made An instance of the type.
+	 * @param capability The capability interface to check.
+	 * @param expected The tags expected to declare the capability.
+	 */
+	private static void assertCapability(ElementType type, Element made,
+			Class<?> capability, Set<String> expected) {
+
+		assertEquals(expected.contains(type.tag()),
+				capability.isInstance(made),
+				"tag '" + type.tag() + "' (" + made.getClass()
+						.getSimpleName() + "): instanceof "
+						+ capability.getSimpleName() + " must be "
+						+ expected.contains(type.tag())
+						+ " (issue #78 capability interfaces; update the "
+						+ "expected set if the capability really moved)");
+	}
+
+	/**
+	 * Every registered type declares exactly the expected capability
+	 * interfaces - no capability is missing, and none is carried by an
+	 * element that should not have it.
 	 */
 	@Test
-	void timedInterfaceMatchesHasTiming() {
+	void capabilityInterfacesMatchExpectedSetsForAllRegisteredTypes() {
 
 		Circuit circuit = new Circuit("capabilitycheck");
 		for (ElementType type : ElementRegistry.all()) {
 			Element made = type.create(circuit);
-			assertEquals(made.hasTiming(), made instanceof Timed,
-					"tag '" + type.tag() + "' (" + made.getClass()
-							.getSimpleName() + "): hasTiming()=="
-							+ made.hasTiming() + " but instanceof Timed=="
-							+ (made instanceof Timed)
-							+ "; a timed element must implement Timed "
-							+ "(issue #78 capability interfaces)");
+			assertCapability(type, made, Timed.class, TIMED);
+			assertCapability(type, made, Watchable.class, WATCHABLE);
+			assertCapability(type, made, Rotatable.class, ROTATABLE);
+			assertCapability(type, made, Editable.class, EDITABLE);
+			assertCapability(type, made, QuickEditable.class,
+					QUICK_EDITABLE);
 		}
 	}
 
 	/**
-	 * An element implements {@link Watchable} exactly when it reports
-	 * {@code canWatch()}.
+	 * A loadable fixture containing one unattached instance of every
+	 * {@link Rotatable} element type (and nothing wired, so every
+	 * attachment gate is open).
+	 *
+	 * @return The circuit file text.
+	 */
+	private static String unattachedRotatableFixture() {
+
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		for (String g : new String[] {"AndGate", "OrGate", "NandGate",
+				"NorGate", "XorGate"}) {
+			cb.gate(g, 2, 2);
+		}
+		cb.gate("NotGate", 1, 1);
+		cb.gate("DelayGate", 1, 1);
+		cb.constant(0xAB);
+		cb.extend(4);
+		cb.adder(4);
+		cb.clock(20, 10);
+		cb.decoder(2);
+		cb.display(4, 16);
+		cb.mux(4, 2);
+		cb.register(4, 3, "nff");
+		cb.shifter("ArithmeticRight", 8);
+		cb.triState(1);
+		cb.binder(4, new int[][] {{3, 2}, {1, 0}});
+		cb.splitter(4, new int[][] {{3, 2}, {1, 0}});
+		cb.jumpStart("js", 4);
+		cb.jumpEnd("js", 4);
+		cb.subCircuit("sub");
+		cb.inputPin("in1", 1);
+		cb.outputPin("out1", 1);
+		return cb.build();
+	}
+
+	/**
+	 * The surviving {@code canRotate()}/{@code canFlip()} predicates on
+	 * every {@link Rotatable} type report the class-level capability
+	 * when nothing is attached: both true, except that the flip-only
+	 * elements refuse to rotate and the {@link #NEVER_REORIENTS} tags
+	 * refuse both. This is the predicate half of the capability
+	 * contract - a dropped override (predicates falling back to
+	 * {@link Rotatable}'s false defaults) fails here instead of
+	 * silently removing rotate/flip from the editor and the collab
+	 * ops. (The predicates need initialized puts, so the elements are
+	 * loaded headlessly rather than created raw.)
 	 */
 	@Test
-	void watchableInterfaceMatchesCanWatch() {
+	void unattachedRotatableElementsReportClassLevelPredicates()
+			throws Exception {
+
+		assertTrue(ROTATABLE.containsAll(FLIP_ONLY),
+				"every flip-only tag must be Rotatable");
+		assertTrue(ROTATABLE.containsAll(NEVER_REORIENTS),
+				"every never-reorients tag must be Rotatable");
+
+		Map<Class<?>, String> tagOf = new HashMap<>();
+		Circuit scratch = new Circuit("capabilitycheck");
+		for (ElementType type : ElementRegistry.all()) {
+			tagOf.put(type.create(scratch).getClass(), type.tag());
+		}
 
 		Circuit circuit = new Circuit("capabilitycheck");
-		for (ElementType type : ElementRegistry.all()) {
-			Element made = type.create(circuit);
-			assertEquals(made.canWatch(), made instanceof Watchable,
-					"tag '" + type.tag() + "' (" + made.getClass()
-							.getSimpleName() + "): canWatch()=="
-							+ made.canWatch() + " but instanceof Watchable=="
-							+ (made instanceof Watchable)
-							+ "; a watchable element must implement Watchable "
-							+ "(issue #78 capability interfaces)");
+		assertTrue(circuit.load(new Scanner(unattachedRotatableFixture())),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+
+		Set<String> seen = new TreeSet<>();
+		for (Element el : circuit.getElements()) {
+			if (!(el instanceof Rotatable rotatable)) {
+				continue;
+			}
+			String tag = tagOf.get(el.getClass());
+			assertNotNull(tag, el.getClass().getName()
+					+ ": every Rotatable element must be registered");
+			seen.add(tag);
+			boolean expectFlip = !NEVER_REORIENTS.contains(tag);
+			boolean expectRotate = expectFlip && !FLIP_ONLY.contains(tag);
+			assertEquals(expectFlip, rotatable.canFlip(),
+					"tag '" + tag + "': unattached canFlip() must be "
+							+ expectFlip);
+			assertEquals(expectRotate, rotatable.canRotate(),
+					"tag '" + tag + "': unattached canRotate() must be "
+							+ expectRotate);
 		}
+		assertEquals(new TreeSet<>(ROTATABLE), seen,
+				"the fixture must cover every Rotatable tag");
 	}
 
 	/**
 	 * Among timed elements, {@code usesAccessTime()} is true for exactly
 	 * the memory element - the distinction that used to be an
-	 * {@code instanceof Memory} branch in {@link Element#changeTiming()}.
+	 * {@code instanceof Memory} branch in the base class's timing dialog.
 	 */
 	@Test
 	void onlyMemoryUsesAccessTime() {
@@ -106,9 +249,10 @@ class CapabilityInterfaceTest {
 	}
 
 	/**
-	 * A sanity floor on the interfaces: the memory element carries both
-	 * capabilities (it is timed with access-time semantics and watchable),
-	 * and a pure combinational gate is timed but not watchable.
+	 * A sanity floor on the interfaces: the memory element carries the
+	 * expected capability bundle (timed with access-time semantics,
+	 * watchable, editable, but fixed in orientation), and a pure
+	 * combinational gate is timed and rotatable but nothing else.
 	 */
 	@Test
 	void representativeElementsCarryTheExpectedCapabilities() {
@@ -117,13 +261,19 @@ class CapabilityInterfaceTest {
 		Element memory = ElementRegistry.forTag("Memory").create(circuit);
 		assertTrue(memory instanceof Timed, "Memory must be Timed");
 		assertTrue(memory instanceof Watchable, "Memory must be Watchable");
+		assertTrue(memory instanceof Editable, "Memory must be Editable");
+		assertFalse(memory instanceof Rotatable,
+				"Memory has a fixed orientation");
 		assertTrue(((Timed) memory).usesAccessTime(),
 				"Memory must use access-time semantics");
 
 		Element andGate = ElementRegistry.forTag("AndGate").create(circuit);
 		assertTrue(andGate instanceof Timed, "AndGate must be Timed");
+		assertTrue(andGate instanceof Rotatable, "AndGate must be Rotatable");
 		assertFalse(andGate instanceof Watchable,
 				"a plain gate is not watchable");
+		assertFalse(andGate instanceof Editable,
+				"a plain gate has no change dialog");
 		assertFalse(((Timed) andGate).usesAccessTime(),
 				"a gate uses propagation delay, not access time");
 	}

--- a/test/jls/ui/CircuitAssert.java
+++ b/test/jls/ui/CircuitAssert.java
@@ -20,6 +20,7 @@ import jls.elem.JumpStart;
 import jls.elem.LogicElement;
 import jls.elem.Output;
 import jls.elem.Put;
+import jls.elem.Watchable;
 import jls.elem.WireEnd;
 import jls.elem.WireNet;
 
@@ -215,9 +216,10 @@ public final class CircuitAssert {
 				"bit width of put \"" + putName + "\" of " + describe(el));
 	}
 
-	/** Assert the element's watched flag (per {@link Element#isWatched()}). */
+	/** Assert the element's watched flag (per {@link Watchable#isWatched()}). */
 	public static void assertWatched(Element el, boolean expected) {
-		assertEquals(expected, el.isWatched(),
+		assertEquals(expected,
+				el instanceof Watchable watchable && watchable.isWatched(),
 				"watched flag of " + describe(el));
 	}
 

--- a/test/jls/ui/KeyboardEditingFaithfulTest.java
+++ b/test/jls/ui/KeyboardEditingFaithfulTest.java
@@ -76,7 +76,7 @@ class KeyboardEditingFaithfulTest {
 		return circuit;
 	}
 
-	/** A circuit with a single input pin - a watchable element (canWatch). */
+	/** A circuit with a single input pin - a {@link jls.elem.Watchable} element. */
 	private static Circuit onePin() throws Exception {
 		CircuitTextBuilder cb = new CircuitTextBuilder();
 		cb.inputPin("A", 1);
@@ -289,7 +289,11 @@ class KeyboardEditingFaithfulTest {
 		String os = System.getProperty("os.name");
 		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
 			jls.elem.Pin pin = solePin(ui);
-			assertTrue(pin.canWatch(), "the input pin is watchable");
+			// widened to Element so the capability pin stays a runtime
+			// regression check rather than a compile-time tautology
+			jls.elem.Element pinElement = pin;
+			assertTrue(pinElement instanceof jls.elem.Watchable,
+					"the input pin is watchable");
 			boolean before = pin.isWatched();
 			selectGateAndFocusCanvas(ui, pin);
 


### PR DESCRIPTION
Add the remaining capability interfaces from #78's resolved design and
retire Element's boolean-gated capability pairs entirely:

- New jls.elem.Rotatable (canRotate/rotate + canFlip/flip; the
  predicates survive as instance methods because they are attachment
  gates, and each half defaults to "unsupported" so flip-only elements
  declare just their half), plus marker interfaces Editable
  (supersedes canChange) and QuickEditable (supersedes quickChange) -
  both markers because every implementor answered unconditionally true
  and the dialogs/menus already live GUI-side (#77).

- Declare the capabilities on the elements that carried the overrides:
  Rotatable on Gate, Group, Pin, Adder, Clock, Constant, Decoder,
  Display, JumpEnd, JumpStart, Mux, Register, ShiftRegister,
  SubCircuit, TriState (flip-only: JumpEnd, JumpStart, SubCircuit);
  Editable on Clock, Constant, Memory, Register, SigGen, StateMachine,
  SubCircuit, Text, TruthTable; QuickEditable on Constant.

- Migrate every call site from the boolean-gated base methods to
  instanceof capability checks: SimpleEditor (watch/timing keymaps,
  rotate/flip actions, option-popup construction), ElementQuickMenus
  (now typed to QuickEditable), DelayChangeDialog (works on Timed),
  collab ops RotateElement/FlipElement/ToggleWatched, plus
  Circuit.clearAllWatches, JLSStart (batch watch/propdelay parameter
  handling and result printing), BatchSimulator and
  InteractiveSimulator watch checks.

- Delete the now-unreferenced stubs on Element (canChange, quickChange,
  hasTiming, canRotate/rotate, canFlip/flip, getDelay/setDelay,
  canWatch, isWatched/setWatched), LogicElement's no-op setDelay, and
  every leaf predicate override (hasTiming, canWatch, canChange,
  quickChange) they existed to flip. SubCircuit.setWatched stays as a
  plain propagation helper (the subcircuit itself is not Watchable) and
  now recurses through Watchable/nested-SubCircuit explicitly.

- Rewrite CapabilityInterfaceTest to pin, for all 33 registered types,
  exactly which of the five capability interfaces each declares (both
  directions), that only Memory uses access time, and - on a headlessly
  loaded, fully unattached instance of every Rotatable type - the
  surviving canRotate()/canFlip() predicate values themselves: both
  true except the flip-only elements (which refuse to rotate) and
  Display (which refuses both), so a dropped predicate override fails
  the build instead of silently removing rotate/flip from the editor
  and collab ops. Extend CircuitOpTest's rejection coverage to
  elements with no Rotatable capability at all and to the
  invert()-side capability gates.

Behavior is unchanged: saves are byte-identical (round-trip and golden
suites green) and every gate keeps its former answer - the instanceof
check plus the interface's attachment gate reproduces the old
base-class default exactly.

mvn clean verify: 1109 tests, 0 failures/errors headlessly (88
display-dependent skips); the jacoco coverage-ratchet package-jls
floor failure (instructions/lines/branches) is pre-existing on master
in headless runs (proven on a clean master worktree, same three
violated limits) and unchanged by this commit.
Batch CLI exercised end-to-end: ELEMENT <name> WATCHED true/false and
TYPE <type> PROPDELAY <n> behave as before through the new
Watchable/Timed dispatch (watched-pin output and VCD transition times
confirm), and the malformed-value / non-simulated-type diagnostics are
unchanged.

Advances #78 (capability-interface conversion of §7; the descriptor,
palette-generation, orientation-unification, and pin-face stages
remain open).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
