### PR TITLE
Add the wiring vocabulary: AddWire/RemoveWire net-transplant ops (#167)

### DIFF
--- a/docs/operation-layer.md
+++ b/docs/operation-layer.md
@@ -29,10 +29,14 @@ Serialized form:
 
 ```
 OP <kind>
- String id "<replica:counter>"     (repeatable where the kind takes a group)
+ String id "<replica:counter>"     (repeatable where the kind takes a group;
+                                    AddWire: the attachment anchors, in
+                                    stable-id order - index i is local id i
+                                    inside the blocks)
  String name "<escaped>"           (AttachProbe)
- String block "<escaped>"          (AddElements, repeatable: one whole
-                                    element save block per line)
+ String block "<escaped>"          (AddElements/AddWire, repeatable: one
+                                    whole element or wire-end save block
+                                    per line)
  int dx <n>  /  int dy <n>         (MoveElements)
  int cw <0|1>                      (RotateElement)
 END
@@ -60,9 +64,41 @@ added element is therefore indistinguishable from a loaded one, and
   elements with wires attached to their puts (detaching would mutate
   wire state the inverse could not restore) and requires a jump start
   to bring every one of its jump ends along, because the editor's
-  removal cascades that way. Wired selections stay on the inline
-  delete path, under the snapshot-undo safety net, until the wiring
-  vocabulary lands.
+  removal cascades that way. A wired selection is expressed as one
+  `RemoveWire` per attached net followed by a `RemoveElements` over
+  the then-unwired elements - the kinds compose, and each keeps its
+  exact inverse.
+
+## Wire-net transplant
+
+`NetBlocks` is the wiring sibling of `ElementBlocks`: it serializes a
+whole wire net as the exact per-end blocks `WireEnd.save` writes, and
+reconstructs a net by replaying the file loader's algorithm (end
+construction, wire creation order, put attachment, probes, net
+partition), so an added net is indistinguishable from a loaded one. A
+wire-end block references other elements by the save format's
+file-local `int` ids, which mean nothing outside a whole-file save, so
+a net serialization renumbers locally: attachment anchors get local
+ids `0..k-1` and the net's ends `k..k+n-1`, both in stable-id order,
+and the anchors travel alongside the blocks as stable ids (#165).
+`AddWire`/`RemoveWire` are exact mutual inverses at net granularity:
+
+- `AddWire(attach, blocks)` validates atomically and strictly: the
+  blocks must be exactly what a save writes (the parser rejects
+  anything `WireEnd.save` could not have produced), form exactly one
+  connected net whose ends' stable ids are fresh, list every wire and
+  probe from both ends, agree on the net's tri-state flag, and attach
+  only to existing, unattached puts of the anchors carried. A
+  tri-state net re-arms the tri-state property of the input pins it
+  drives, mirroring the editor's `connect()`.
+- `RemoveWire(id)` addresses the net by any one of its wire ends and
+  removes the whole net - ends, segments, probes - detaching every put
+  exactly as the editor's inline wire deletion does (including
+  clearing the tri-state property of elements a tri-state net drove).
+  Its inverse carries the net's serialized blocks: a true, byte-exact
+  restore. Net granularity is deliberate: a gesture that deletes one
+  segment of a larger net re-partitions the remainder, and will travel
+  as `RemoveWire` plus `AddWire` ops for the surviving pieces.
 
 ## Mutation-site inventory (§7 step 1)
 
@@ -82,9 +118,10 @@ the migration commit.
 | Move-selection commit (mouse release) | `MoveElements` | op implemented + tested, and wired into the keyboard nudge (issue #75, `submitOp(new MoveElements(...))` at `SimpleEditor.java:3254`); the mouse-release drag commit is still inline (live drag must become preview-then-commit) |
 | Placement drop (fixPosition + connect) | `AddElements` (+ implicit wiring) | op implemented + tested for the unwired case; gesture still inline (the drop's `connect()` needs the wiring vocabulary, and placement must become preview-then-commit) |
 | Matching JumpEnd creation, context menu | `AddElements` | op implemented + tested (jump-source validation included); gesture still inline (the created end stays mouse-attached in `chosen` state, so the commit point is the later drop) |
-| Delete selection | `RemoveElements` | op implemented + tested with a **true inverse** (the removed elements' blocks) for unwired selections; wired selections stay inline until the wiring vocabulary lands (#167 §9's fallback narrowed to just that case). Gesture still inline |
-| Paste | `AddElements` | op machinery in place (multi-block add with paste's name/jump validation); gesture still inline (pasted wires need the wiring vocabulary) |
-| Wire-attach finish (mouse) | `AddWire` | deferred — wiring gestures become commit-time ops |
+| Delete selection | `RemoveElements` (+ `RemoveWire` per attached net when wired) | ops implemented + tested with **true inverses**, wired selections included (`wiredDeleteComposesFromRemoveWireAndRemoveElements` pins the composition; #167 §9's snapshot fallback is no longer needed for any delete). Gesture still inline |
+| Delete wire net / detach (popup delete on a wire) | `RemoveWire` | op implemented + tested with a **true inverse** (the net's serialized wire-end blocks, `NetBlocks`); gesture still inline |
+| Paste | `AddElements` + `AddWire` | op machinery in place (multi-block add with paste's name/jump validation; pasted nets travel as `AddWire`); gesture still inline |
+| Wire-attach finish (mouse) | `AddWire` | op implemented + tested at net granularity (a commit that extends an existing net travels as `RemoveWire` of the old net plus `AddWire` of the merged one); gesture still inline — wiring gestures become commit-time ops |
 | Wire-draw cancel (right button / end-wire key, two sites) | none — gesture-local cleanup of the in-progress wire; these `markChanged` calls compensate for live mutation and disappear when wiring is commit-time | deferred |
 | Quick attribute edit commit (`quickReset`) | `SetElementConfig` (element-state replace) | op implemented (a record in the sealed `CircuitOp permits` list, `CircuitOp.java:37`, with its reader case at `CircuitOpReader.java:157`); gesture still inline — dialog commits mutate in place today |
 | Element dialog commits (all element edit dialogs) | `SetElementConfig` | op implemented; gesture still inline — same |
@@ -106,14 +143,12 @@ rule 2; only the future `jls.collab.ui` may touch Swing).
 
 ## What lands next
 
-1. The wiring vocabulary (`AddWire`/`RemoveWire` over wire ends,
-   segments, and attachments), which unlocks the wired cases of
-   delete/paste and the wire-drawing gesture's commit-time op.
-2. Preview-then-commit for the move, placement, and wiring gestures,
-   anchored by the #91 gesture harness (`EditorGestureTest`) - the
-   step that migrates the gestures whose ops already exist
-   (`MoveElements`, `AddElements`, `RemoveElements`).
-3. Wiring the dialog-commit gestures onto `SetElementConfig`, whose op
+1. Preview-then-commit for the move, placement, wiring, and delete
+   gestures, anchored by the #91 gesture harness
+   (`EditorGestureTest`) - the step that migrates the gestures whose
+   ops already exist (`MoveElements`, `AddElements`,
+   `RemoveElements`, `AddWire`, `RemoveWire`).
+2. Wiring the dialog-commit gestures onto `SetElementConfig`, whose op
    already exists; the commit paths mutate in place until then.
-4. Op-inverse (precise) undo activation is explicitly *not* this
+3. Op-inverse (precise) undo activation is explicitly *not* this
    stage: snapshot undo stays user-facing until Stage 2 (#163).

--- a/src/jls/collab/op/AddWire.java
+++ b/src/jls/collab/op/AddWire.java
@@ -1,0 +1,369 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import jls.Circuit;
+import jls.core.Geometry;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Input;
+import jls.elem.Output;
+import jls.elem.Put;
+import jls.elem.TriProp;
+import jls.elem.Wire;
+import jls.elem.WireEnd;
+import jls.elem.WireNet;
+
+/**
+ * Add one whole wire net to a circuit from its serialized wire-end
+ * blocks (issue #167): the ends, the segments between them, the put
+ * attachments, and the probes, reconstructed by replaying the file
+ * loader's exact algorithm so an added net is indistinguishable from a
+ * loaded one ({@link NetBlocks}). Inverse: {@link RemoveWire} addressed
+ * at any of the net's ends.
+ *
+ * Cross-references inside the blocks use the op's local numbering; the
+ * elements the net attaches to travel as stable ids (issue #165) in
+ * {@link #attach}, index-aligned with local ids {@code 0..k-1}, so the
+ * op means the same thing on a restored or replicated circuit.
+ *
+ * Validation is atomic and strict: the blocks must be exactly what a
+ * save writes, form exactly one connected net whose ends' stable ids
+ * are fresh, list every wire (and its probe) from both of its ends, and
+ * attach only to existing, unattached puts of the anchors the op
+ * carries. Nothing is added unless every check passes.
+ *
+ * @param attach The stable ids of the attachment anchors, in stable-id
+ *            order; index {@code i} is local id {@code i} inside the
+ *            blocks. Empty for a dangling net.
+ * @param blocks The serialized wire-end blocks, in stable-id order;
+ *            block {@code i} declares local id {@code attach.size() +
+ *            i}.
+ */
+public record AddWire(List<ElementId> attach, List<String> blocks)
+		implements CircuitOp {
+
+	/**
+	 * Defensive copy: the record's lists are immutable whatever the
+	 * caller passed (issue #94 discipline).
+	 */
+	public AddWire {
+
+		attach = List.copyOf(attach);
+		blocks = List.copyOf(blocks);
+	} // end of compact constructor
+
+	/**
+	 * The vetted form of the op: the resolved anchors and parsed end
+	 * blocks validation produced.
+	 *
+	 * @param anchors The resolved anchor elements, in attach order.
+	 * @param specs The parsed end blocks, in block order.
+	 */
+	private record Plan(List<Element> anchors,
+			List<NetBlocks.EndSpec> specs) {
+	} // end of Plan record
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		Plan plan = validate(circuit);
+		int base = attach.size();
+
+		// construct the ends the way the loader does: coordinates and
+		// stable id from the block, the fixed wire-end size, and a
+		// fixPosition to sync the non-snap position (WireEnd.init)
+		List<WireEnd> ends =
+				new ArrayList<WireEnd>(plan.specs().size());
+		for (NetBlocks.EndSpec spec : plan.specs()) {
+			WireEnd end = new WireEnd(circuit);
+			end.setValue("x", spec.x());
+			end.setValue("y", spec.y());
+			end.setValue("width", Geometry.POINT_DIAMETER);
+			end.setValue("height", Geometry.POINT_DIAMETER);
+			end.setValue("sid", spec.sid().toString());
+			end.fixPosition();
+			ends.add(end);
+		}
+
+		// attach puts (validation proved each exists and is free)
+		for (int i = 0; i < ends.size(); i += 1) {
+			NetBlocks.EndSpec spec = plan.specs().get(i);
+			if (spec.attach() < 0) {
+				continue;
+			}
+			Put p = Objects.requireNonNull(plan.anchors()
+					.get(spec.attach())
+					.getPut(Objects.requireNonNull(spec.putName())));
+			p.setAttached(ends.get(i));
+			ends.get(i).setPut(p);
+		}
+
+		// create wires in block order, each end's refs in save order -
+		// the exact construction order WireEnd.init and finishLoad use,
+		// so the rebuilt wires-per-end ordering (and with it every
+		// future save's ref lines) matches a loaded circuit's
+		for (int i = 0; i < ends.size(); i += 1) {
+			WireEnd end = ends.get(i);
+			NetBlocks.EndSpec spec = plan.specs().get(i);
+			for (int ref : spec.wireRefs()) {
+				WireEnd other = ends.get(ref - base);
+				if (wireBetween(end, other) != null) {
+					continue;
+				}
+				Wire wire = new Wire(end, other);
+				end.addWire(wire);
+				other.addWire(wire);
+				circuit.addElement(wire);
+				String probe = spec.probes().get(ref);
+				if (probe != null) {
+					wire.attachProbe(probe);
+				}
+			}
+			circuit.addElement(end);
+		}
+
+		// build the wire net, mirroring Circuit.finishLoad's partition
+		Map<WireEnd, NetBlocks.EndSpec> specOf =
+				new HashMap<WireEnd, NetBlocks.EndSpec>();
+		for (int i = 0; i < ends.size(); i += 1) {
+			specOf.put(ends.get(i), plan.specs().get(i));
+		}
+		LinkedList<WireEnd> visit = new LinkedList<WireEnd>();
+		visit.add(ends.get(0));
+		WireNet net = new WireNet();
+		Set<WireEnd> visited = new HashSet<WireEnd>();
+		while (!visit.isEmpty()) {
+			WireEnd vend = visit.remove();
+			visited.add(vend);
+			net.add(vend);
+			vend.setNet(net);
+			if (Objects.requireNonNull(specOf.get(vend)).triState()) {
+				net.loadTriState();
+			}
+			Put vendPut = vend.getPut();
+			if (vendPut != null) {
+				net.setBits(vendPut.getBits());
+				if (vendPut instanceof Output) {
+					net.setInput();
+				}
+			}
+			for (Wire wire : vend.getWires()) {
+				WireEnd otherEnd = wire.getOtherEnd(vend);
+				if (!visited.contains(otherEnd)) {
+					visit.add(otherEnd);
+					net.add(wire);
+					wire.setNet(net);
+				}
+			}
+		}
+
+		// a tri-state net re-arms the tri-state property of the input
+		// pins it drives, mirroring the editor's connect() - and exactly
+		// undoing what removing the net cleared
+		if (net.isTriState()) {
+			for (WireEnd end : ends) {
+				Put p = end.getPut();
+				if (p instanceof Input
+						&& p.getElement() instanceof TriProp pin) {
+					pin.setTriState(true);
+				}
+			}
+		}
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		Plan plan = validate(before);
+		return new RemoveWire(plan.specs().get(0).sid());
+	} // end of invert method
+
+	/**
+	 * Vet the whole op against the target circuit without touching it.
+	 *
+	 * @param target The circuit the op would mutate.
+	 *
+	 * @return the resolved anchors and parsed blocks.
+	 *
+	 * @throws OpRejected if any check fails; the target is untouched
+	 *             either way.
+	 */
+	private Plan validate(Circuit target) throws OpRejected {
+
+		if (blocks.isEmpty()) {
+			throw new OpRejected(
+					"a wire add needs at least one wire-end block");
+		}
+
+		// anchors: existing put-bearing elements, each listed once, in
+		// stable-id order (the canonical order the inverse writes)
+		List<Element> anchors = new ArrayList<Element>(attach.size());
+		for (int i = 0; i < attach.size(); i += 1) {
+			if (i > 0 && attach.get(i - 1)
+					.compareTo(attach.get(i)) >= 0) {
+				throw new OpRejected("attachment anchors must be listed "
+						+ "once each, in stable-id order");
+			}
+			Element el = Ops.resolve(target, attach.get(i));
+			if (el instanceof Wire || el instanceof WireEnd) {
+				throw new OpRejected("an attachment anchor must be a "
+						+ "put-bearing element, not a wire");
+			}
+			anchors.add(el);
+		}
+
+		int base = attach.size();
+		List<NetBlocks.EndSpec> specs =
+				new ArrayList<NetBlocks.EndSpec>(blocks.size());
+		for (int i = 0; i < blocks.size(); i += 1) {
+			specs.add(NetBlocks.parseEnd(blocks.get(i), base,
+					blocks.size(), i));
+		}
+
+		// end stable ids: canonical order (which also rules out
+		// duplicates) and fresh in the target circuit
+		for (int i = 1; i < specs.size(); i += 1) {
+			if (specs.get(i - 1).sid()
+					.compareTo(specs.get(i).sid()) >= 0) {
+				throw new OpRejected("wire-end blocks must arrive in "
+						+ "stable-id order");
+			}
+		}
+		for (NetBlocks.EndSpec spec : specs) {
+			for (Element existing : target.getElements()) {
+				if (existing.getStableId().equals(spec.sid())) {
+					throw new OpRejected("the circuit already has an "
+							+ "element with stable id '" + spec.sid()
+							+ "'");
+				}
+			}
+		}
+
+		// every wire (and its probe) must be listed from both ends
+		for (int i = 0; i < specs.size(); i += 1) {
+			int self = base + i;
+			NetBlocks.EndSpec spec = specs.get(i);
+			for (int ref : spec.wireRefs()) {
+				NetBlocks.EndSpec other = specs.get(ref - base);
+				if (!other.wireRefs().contains(self)) {
+					throw new OpRejected("a wire must be listed from "
+							+ "both of its ends");
+				}
+				if (!Objects.equals(spec.probes().get(ref),
+						other.probes().get(self))) {
+					throw new OpRejected("a probed wire must carry the "
+							+ "same probe on both of its ends");
+				}
+			}
+		}
+
+		// exactly one connected net (a multi-net add is several ops),
+		// which also makes any end a valid address for the inverse
+		Set<Integer> reached = new HashSet<Integer>();
+		LinkedList<Integer> frontier = new LinkedList<Integer>();
+		frontier.add(0);
+		reached.add(0);
+		while (!frontier.isEmpty()) {
+			int i = frontier.remove();
+			for (int ref : specs.get(i).wireRefs()) {
+				if (reached.add(ref - base)) {
+					frontier.add(ref - base);
+				}
+			}
+		}
+		if (reached.size() != specs.size()) {
+			throw new OpRejected(
+					"the blocks must form one connected net");
+		}
+
+		// the net's tri-state flag is per net, so every end must agree
+		for (NetBlocks.EndSpec spec : specs) {
+			if (spec.triState() != specs.get(0).triState()) {
+				throw new OpRejected("every end of a net must agree on "
+						+ "the net's tri-state flag");
+			}
+		}
+
+		// attachments: the named put must exist, be free, and be
+		// claimed by at most one arriving end; every anchor carried
+		// must actually anchor something
+		boolean[] anchorUsed = new boolean[base];
+		Set<Put> claimed = new HashSet<Put>();
+		for (NetBlocks.EndSpec spec : specs) {
+			if (spec.attach() < 0) {
+				continue;
+			}
+			anchorUsed[spec.attach()] = true;
+			Element anchor = anchors.get(spec.attach());
+			Put p = anchor
+					.getPut(Objects.requireNonNull(spec.putName()));
+			if (p == null) {
+				throw new OpRejected("element '"
+						+ anchor.getStableId() + "' has no put named '"
+						+ spec.putName() + "'");
+			}
+			if (p.isAttached()) {
+				throw new OpRejected("put '" + spec.putName()
+						+ "' of element '" + anchor.getStableId()
+						+ "' already has a wire attached");
+			}
+			if (!claimed.add(p)) {
+				throw new OpRejected("two ends attach to put '"
+						+ spec.putName() + "' of element '"
+						+ anchor.getStableId() + "'");
+			}
+		}
+		for (int i = 0; i < base; i += 1) {
+			if (!anchorUsed[i]) {
+				throw new OpRejected("anchor '" + attach.get(i)
+						+ "' is carried but never attached to");
+			}
+		}
+
+		return new Plan(anchors, specs);
+	} // end of validate method
+
+	/**
+	 * The wire between two ends, if one exists already.
+	 *
+	 * @param a One end.
+	 * @param b The other end.
+	 *
+	 * @return the wire, or null if the ends are not directly wired.
+	 */
+	private static @Nullable Wire wireBetween(WireEnd a, WireEnd b) {
+
+		for (Wire w : a.getWires()) {
+			if (w.getOtherEnd(a) == b) {
+				return w;
+			}
+		}
+		return null;
+	} // end of wireBetween method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP AddWire");
+		for (ElementId id : attach) {
+			Ops.saveString(output, "id", id.toString());
+		}
+		for (String block : blocks) {
+			Ops.saveString(output, "block", block);
+		}
+		output.println("END");
+	} // end of save method
+
+} // end of AddWire record

--- a/src/jls/collab/op/CircuitOp.java
+++ b/src/jls/collab/op/CircuitOp.java
@@ -34,7 +34,7 @@ import jls.Circuit;
 public sealed interface CircuitOp
 		permits ToggleWatched, AttachProbe, RemoveProbe, RotateElement,
 				FlipElement, MoveElements, AddElements, RemoveElements,
-				SetElementConfig {
+				SetElementConfig, AddWire, RemoveWire {
 
 	/**
 	 * Validate this op against the circuit and perform it. Validation

--- a/src/jls/collab/op/CircuitOpReader.java
+++ b/src/jls/collab/op/CircuitOpReader.java
@@ -163,6 +163,17 @@ public final class CircuitOpReader {
 					&& name == null && dx == null && dy == null
 					&& cw == null);
 			return new SetElementConfig(ids.get(0), blocks.get(0));
+		case "AddWire":
+			// the ids are the net's attachment anchors; a dangling net
+			// legitimately carries none
+			requireFields(kind, !blocks.isEmpty() && name == null
+					&& dx == null && dy == null && cw == null);
+			return new AddWire(ids, blocks);
+		case "RemoveWire":
+			requireFields(kind, ids.size() == 1 && blocks.isEmpty()
+					&& name == null && dx == null && dy == null
+					&& cw == null);
+			return new RemoveWire(ids.get(0));
 		default:
 			throw new OpRejected("unknown op kind '" + clip(kind) + "'");
 		}

--- a/src/jls/collab/op/NetBlocks.java
+++ b/src/jls/collab/op/NetBlocks.java
@@ -1,0 +1,376 @@
+package jls.collab.op;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.LogicElement;
+import jls.elem.Put;
+import jls.elem.WireEnd;
+
+/**
+ * The wire-net transplant helper (issue #167): serialize a whole wire
+ * net as the exact per-end blocks {@code WireEnd.save} writes, and
+ * parse such blocks back strictly. The wiring sibling of
+ * {@link ElementBlocks} - a net travels as the byte form its own save
+ * method produces, reconstructed by replaying the file loader's exact
+ * algorithm, so a transplanted net is indistinguishable from a loaded
+ * one.
+ *
+ * A wire-end block references other elements by the save format's
+ * file-local {@code int} ids, which mean nothing outside a whole-file
+ * save. A net serialization therefore renumbers locally: the elements
+ * the net attaches to (by one of their puts) get local ids
+ * {@code 0..k-1} in stable-id order, and the net's own ends get local
+ * ids {@code k..k+n-1} in stable-id order. The attachment anchors
+ * travel alongside the blocks as stable ids ({@link AddWire#attach}),
+ * index-aligned with those local ids, so the blocks stay byte-exact
+ * while every cross-reference outside the net is stable (issue #165).
+ */
+final class NetBlocks {
+
+	/**
+	 * One parsed wire-end block: everything {@code WireEnd.save} writes,
+	 * with references still in the op's local numbering.
+	 *
+	 * @param sid The end's declared stable id.
+	 * @param x The end's x-coordinate.
+	 * @param y The end's y-coordinate.
+	 * @param triState Whether the end's net is tri-state.
+	 * @param attach The local id of the element a put of which this end
+	 *            attaches to, or -1 when unattached.
+	 * @param putName The name of the put attached to, or null when
+	 *            unattached.
+	 * @param wireRefs The local ids of the ends this end is wired to, in
+	 *            the block's (save) order.
+	 * @param probes Probe names keyed by the other end's local id, for
+	 *            the wires that carry probes.
+	 */
+	record EndSpec(ElementId sid, int x, int y, boolean triState,
+			int attach, @Nullable String putName, List<Integer> wireRefs,
+			Map<Integer, String> probes) {
+	} // end of EndSpec record
+
+	/**
+	 * Prevents instantiation; this class holds only static helpers.
+	 */
+	private NetBlocks() {
+
+	} // end of constructor
+
+	/**
+	 * Serialize a whole wire net as an {@link AddWire} op: the inverse
+	 * of {@link RemoveWire}. The given ends must be every end of one
+	 * net, already sorted by stable id.
+	 *
+	 * The save-time {@code int} ids of the ends and of the elements the
+	 * net attaches to are renumbered into the op's local numbering
+	 * while the blocks are written, then restored to their prior
+	 * values. The restore matters: although every circuit save
+	 * reassigns all of these ids, HDL export consumes them directly
+	 * for element ordering and synthesized net names, so serializing a
+	 * net must leave no observable trace.
+	 *
+	 * @param ends The net's wire ends, in stable-id order.
+	 *
+	 * @return the op that reconstructs the net byte-exactly.
+	 */
+	static AddWire toAddWire(List<WireEnd> ends) {
+
+		List<Element> targets = new ArrayList<Element>();
+		for (WireEnd end : ends) {
+			Put p = end.getPut();
+			LogicElement owner = p == null ? null : p.getElement();
+			if (owner != null && !targets.contains(owner)) {
+				targets.add(owner);
+			}
+		}
+		targets.sort(Comparator.comparing(Element::getStableId));
+		List<Element> renumbered =
+				new ArrayList<Element>(targets.size() + ends.size());
+		renumbered.addAll(targets);
+		renumbered.addAll(ends);
+		int[] priorIds = new int[renumbered.size()];
+		for (int i = 0; i < renumbered.size(); i += 1) {
+			priorIds[i] = renumbered.get(i).getID();
+		}
+		try {
+			List<ElementId> attach =
+					new ArrayList<ElementId>(targets.size());
+			for (int i = 0; i < targets.size(); i += 1) {
+				targets.get(i).setID(i);
+				attach.add(targets.get(i).getStableId());
+			}
+			int base = targets.size();
+			for (int i = 0; i < ends.size(); i += 1) {
+				ends.get(i).setID(base + i);
+			}
+			List<String> blocks = new ArrayList<String>(ends.size());
+			for (WireEnd end : ends) {
+				blocks.add(ElementBlocks.saveBlock(end));
+			}
+			return new AddWire(attach, blocks);
+		} finally {
+			for (int i = 0; i < renumbered.size(); i += 1) {
+				renumbered.get(i).setID(priorIds[i]);
+			}
+		}
+	} // end of toAddWire method
+
+	/**
+	 * Parse one wire-end block strictly: exactly the line sequence
+	 * {@code WireEnd.save} writes, in its order, and nothing else.
+	 * Anything a save could not have produced - unknown or reordered
+	 * lines, an uneditable end, an end with no wires, references outside
+	 * the op's local numbering - is a rejection, never a repair.
+	 *
+	 * @param block The block text, from {@code ELEMENT WireEnd} through
+	 *            {@code END}.
+	 * @param attachCount How many attachment anchors the op carries
+	 *            (local ids {@code 0..attachCount-1}).
+	 * @param endCount How many end blocks the op carries (local ids
+	 *            {@code attachCount..attachCount+endCount-1}).
+	 * @param index This block's position among the op's blocks.
+	 *
+	 * @return the parsed end.
+	 *
+	 * @throws OpRejected if the block is not exactly a well-formed
+	 *             wire-end save block.
+	 */
+	static EndSpec parseEnd(String block, int attachCount, int endCount,
+			int index) throws OpRejected {
+
+		if (block.length() > ElementBlocks.MAX_BLOCK) {
+			throw new OpRejected("a wire-end block exceeds "
+					+ ElementBlocks.MAX_BLOCK + " characters");
+		}
+		String[] lines = block.split("\n", -1);
+		// saveBlock output ends every line, END included, with '\n'
+		if (lines.length < 7 || !lines[lines.length - 1].isEmpty()
+				|| !lines[lines.length - 2].equals("END")) {
+			throw new OpRejected("a wire-end block must end with an END "
+					+ "line");
+		}
+		int endLine = lines.length - 2;
+		int at = 0;
+		if (!lines[at].equals("ELEMENT WireEnd")) {
+			throw new OpRejected("a wire-end block must start with an "
+					+ "'ELEMENT WireEnd' line");
+		}
+		at += 1;
+		int id = intLine(lines[at], " int id ");
+		at += 1;
+		if (id != attachCount + index) {
+			throw new OpRejected("wire-end block " + index + " declares "
+					+ "local id " + id + ", not its position in the op's "
+					+ "numbering");
+		}
+		int x = intLine(lines[at], " int x ");
+		at += 1;
+		int y = intLine(lines[at], " int y ");
+		at += 1;
+		if (x < 0 || y < 0) {
+			throw new OpRejected(
+					"a wire end would arrive off the canvas");
+		}
+		ElementId sid = parseSid(stringLine(lines[at], " String sid "));
+		at += 1;
+		boolean triState = false;
+		if (at < endLine && lines[at].equals(" int tristate 1")) {
+			triState = true;
+			at += 1;
+		}
+		int attach = -1;
+		String putName = null;
+		if (at < endLine && lines[at].startsWith(" String put ")) {
+			putName = stringLine(lines[at], " String put ");
+			at += 1;
+			if (putName.isEmpty()) {
+				throw new OpRejected(
+						"an attachment needs a non-empty put name");
+			}
+			if (at >= endLine) {
+				throw new OpRejected("a put line must be followed by its "
+						+ "'ref attach' line");
+			}
+			attach = intLine(lines[at], " ref attach ");
+			at += 1;
+			if (attach < 0 || attach >= attachCount) {
+				throw new OpRejected("a wire end attaches to anchor "
+						+ attach + ", which the op does not carry");
+			}
+		}
+		List<Integer> wireRefs = new ArrayList<Integer>();
+		Map<Integer, String> probes = new LinkedHashMap<Integer, String>();
+		while (at < endLine) {
+			int ref = intLine(lines[at], " ref wire ");
+			at += 1;
+			if (ref < attachCount || ref >= attachCount + endCount) {
+				throw new OpRejected("a wire references end " + ref
+						+ ", which the op does not carry");
+			}
+			if (ref == id) {
+				throw new OpRejected("a wire end may not be wired to "
+						+ "itself");
+			}
+			if (wireRefs.contains(ref)) {
+				throw new OpRejected("a wire end lists end " + ref
+						+ " twice");
+			}
+			wireRefs.add(ref);
+			if (at < endLine && lines[at].startsWith(" probe ")) {
+				String rest = lines[at].substring(7);
+				int space = rest.indexOf(' ');
+				if (space <= 0) {
+					throw new OpRejected("a probe line must carry the "
+							+ "other end's id and a quoted name");
+				}
+				int probeRef = parseInt(rest.substring(0, space),
+						"probe");
+				if (probeRef != ref) {
+					throw new OpRejected("a probe line must follow the "
+							+ "'ref wire' line of the wire it is on");
+				}
+				String name = unquote(rest.substring(space + 1), "probe");
+				if (name.isEmpty()) {
+					throw new OpRejected(
+							"a probe needs a non-empty name");
+				}
+				probes.put(ref, name);
+				at += 1;
+			}
+		}
+		if (wireRefs.isEmpty()) {
+			throw new OpRejected("a wire end needs at least one wire");
+		}
+		return new EndSpec(sid, x, y, triState, attach, putName,
+				wireRefs, probes);
+	} // end of parseEnd method
+
+	/**
+	 * Parse a stable id, converting the unchecked parse failure into a
+	 * rejection.
+	 *
+	 * @param text The id's string form.
+	 *
+	 * @return the id.
+	 *
+	 * @throws OpRejected if malformed.
+	 */
+	private static ElementId parseSid(String text) throws OpRejected {
+
+		try {
+			return ElementId.parse(text);
+		} catch (IllegalArgumentException ex) {
+			throw new OpRejected(ex.getMessage() == null ? ex.toString()
+					: ex.getMessage());
+		}
+	} // end of parseSid method
+
+	/**
+	 * Require one exact int-valued line.
+	 *
+	 * @param line The line.
+	 * @param prefix The exact prefix the line must have.
+	 *
+	 * @return the int value after the prefix.
+	 *
+	 * @throws OpRejected if the line has a different shape.
+	 */
+	private static int intLine(String line, String prefix)
+			throws OpRejected {
+
+		if (!line.startsWith(prefix)) {
+			throw new OpRejected("expected a '" + prefix.trim()
+					+ "' line in a wire-end block, found '" + clip(line)
+					+ "'");
+		}
+		return parseInt(line.substring(prefix.length()), prefix.trim());
+	} // end of intLine method
+
+	/**
+	 * Parse one strict int value.
+	 *
+	 * @param text The value text.
+	 * @param what The field, for the message.
+	 *
+	 * @return the value.
+	 *
+	 * @throws OpRejected if not an integer.
+	 */
+	private static int parseInt(String text, String what)
+			throws OpRejected {
+
+		try {
+			return Integer.parseInt(text);
+		} catch (NumberFormatException ex) {
+			throw new OpRejected("the value of '" + what + "' should be "
+					+ "an integer, but '" + clip(text) + "' is not");
+		}
+	} // end of parseInt method
+
+	/**
+	 * Require one exact quoted-string line.
+	 *
+	 * @param line The line.
+	 * @param prefix The exact prefix the line must have.
+	 *
+	 * @return the unquoted value.
+	 *
+	 * @throws OpRejected if the line has a different shape.
+	 */
+	private static String stringLine(String line, String prefix)
+			throws OpRejected {
+
+		if (!line.startsWith(prefix)) {
+			throw new OpRejected("expected a '" + prefix.trim()
+					+ "' line in a wire-end block, found '" + clip(line)
+					+ "'");
+		}
+		return unquote(line.substring(prefix.length()), prefix.trim());
+	} // end of stringLine method
+
+	/**
+	 * Unwrap one quoted value the way {@code WireEnd.save} writes it:
+	 * surrounding quotes around raw text with no interior quote (the
+	 * writer performs no escaping here, so a value a save could not have
+	 * produced is a rejection).
+	 *
+	 * @param raw The rest of the line, including the surrounding quotes.
+	 * @param what The field, for the message.
+	 *
+	 * @return the unquoted value.
+	 *
+	 * @throws OpRejected if not exactly one quoted value.
+	 */
+	private static String unquote(String raw, String what)
+			throws OpRejected {
+
+		if (raw.length() < 2 || raw.charAt(0) != '"'
+				|| raw.charAt(raw.length() - 1) != '"'
+				|| raw.substring(1, raw.length() - 1).indexOf('"') >= 0) {
+			throw new OpRejected("the value of '" + what + "' should be "
+					+ "a quoted string, but '" + clip(raw) + "' is not");
+		}
+		return raw.substring(1, raw.length() - 1);
+	} // end of unquote method
+
+	/**
+	 * Clip untrusted text for an error message.
+	 *
+	 * @param text The text.
+	 *
+	 * @return at most 60 characters of it.
+	 */
+	private static String clip(String text) {
+
+		return text.length() <= 60 ? text : text.substring(0, 60) + "…";
+	} // end of clip method
+
+} // end of NetBlocks class

--- a/src/jls/collab/op/RemoveElements.java
+++ b/src/jls/collab/op/RemoveElements.java
@@ -25,12 +25,12 @@ import jls.elem.WireEnd;
  * fallback.
  *
  * The group must be removable without touching wiring: wires and wire
- * ends are not removable here (they get their own op kinds), and an
- * element with a wire attached to any of its puts is rejected, because
- * detaching would mutate wire state this op's inverse could not
- * restore. The delete gesture's wired selections keep their inline path
- * (under the snapshot-undo safety net) until the wiring vocabulary
- * lands.
+ * ends are not removable here (they travel through {@link RemoveWire}),
+ * and an element with a wire attached to any of its puts is rejected,
+ * because detaching would mutate wire state this op's inverse could not
+ * restore. A wired selection is expressed as one {@link RemoveWire} per
+ * attached net followed by this op over the then-unwired elements - the
+ * two kinds compose, and each keeps its exact inverse.
  *
  * Removing a jump start cascades to its same-name jump ends in the
  * editor, so validation requires the group to be closed under that

--- a/src/jls/collab/op/RemoveWire.java
+++ b/src/jls/collab/op/RemoveWire.java
@@ -1,0 +1,141 @@
+package jls.collab.op;
+
+import java.awt.Graphics;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import jls.Circuit;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Output;
+import jls.elem.Put;
+import jls.elem.TriProp;
+import jls.elem.Wire;
+import jls.elem.WireEnd;
+
+/**
+ * Remove one whole wire net from a circuit (issue #167): every wire
+ * end, every segment, every probe, detaching every put the net is
+ * attached to - the same end state the editor's inline wire deletion
+ * reaches. The net is addressed by the stable id (issue #165) of any
+ * one of its wire ends. Inverse: an {@link AddWire} carrying the net's
+ * serialized wire-end blocks ({@link NetBlocks}) - a true, byte-exact
+ * restore, not a snapshot fallback, mirroring how
+ * {@link RemoveElements} inverts through {@link ElementBlocks}.
+ *
+ * Net granularity is deliberate: segments and ends are not
+ * independently addressable mutations, because removing a segment
+ * re-partitions and re-derives the surrounding net in ways only whole
+ * nets serialize exactly. A gesture that deletes one segment of a
+ * larger net will travel as this op followed by {@link AddWire} ops for
+ * the surviving pieces.
+ *
+ * Detaching a tri-state net from a tri-state-propagating element clears
+ * that element's tri-state property, exactly as the editor's inline
+ * detach does; the {@link AddWire} inverse re-arms it.
+ *
+ * @param id The stable id of any wire end of the net to remove.
+ */
+public record RemoveWire(ElementId id) implements CircuitOp {
+
+	@Override
+	public void apply(Circuit circuit, Graphics g) throws OpRejected {
+
+		List<WireEnd> ends = validate(circuit);
+
+		// every segment, from every end (each wire appears twice)
+		Set<Wire> wires = new LinkedHashSet<Wire>();
+		for (WireEnd end : ends) {
+			wires.addAll(end.getWires());
+		}
+
+		// detach puts first, mirroring WireEnd.remove(Wire, Circuit):
+		// an output just detaches, and a tri-state net clears the
+		// tri-state property of the elements it drove
+		for (WireEnd end : ends) {
+			Put p = end.getPut();
+			if (p == null) {
+				continue;
+			}
+			p.setAttached(null);
+			end.setPut(null);
+			if (!(p instanceof Output) && end.getNet().isTriState()
+					&& p.getElement() instanceof TriProp pin) {
+				pin.setTriState(false);
+			}
+		}
+
+		for (Wire wire : wires) {
+			circuit.remove(wire);
+		}
+		for (WireEnd end : ends) {
+			circuit.remove(end);
+		}
+	} // end of apply method
+
+	@Override
+	public CircuitOp invert(Circuit before) throws OpRejected {
+
+		return NetBlocks.toAddWire(validate(before));
+	} // end of invert method
+
+	/**
+	 * Resolve the addressed end and vet its whole net before anything
+	 * is removed.
+	 *
+	 * @param circuit The circuit the op would mutate.
+	 *
+	 * @return the net's wire ends, in stable-id order.
+	 *
+	 * @throws OpRejected if the id does not address a removable wire
+	 *             net; the circuit is untouched either way.
+	 */
+	private List<WireEnd> validate(Circuit circuit) throws OpRejected {
+
+		Element el = Ops.resolve(circuit, id);
+		if (!(el instanceof WireEnd end)) {
+			throw new OpRejected("element '" + id
+					+ "' is not a wire end");
+		}
+		List<WireEnd> ends;
+		try {
+			ends = new ArrayList<WireEnd>(end.getNet().getAllEnds());
+		} catch (IllegalStateException ex) {
+			throw new OpRejected("wire end '" + id
+					+ "' is not part of a completed wire net");
+		}
+		for (WireEnd e : ends) {
+			if (e.isUneditable()) {
+				throw new OpRejected("the net contains an uneditable "
+						+ "wire end and cannot be removed");
+			}
+			Put p = e.getPut();
+			if (p != null && p.getElement() == null) {
+				throw new OpRejected("the net is attached to an "
+						+ "in-progress connection and cannot be "
+						+ "removed");
+			}
+			for (Wire w : e.getWires()) {
+				if (w.isUneditable()) {
+					throw new OpRejected("the net contains an "
+							+ "uneditable wire and cannot be removed");
+				}
+			}
+		}
+		ends.sort(Comparator.comparing(Element::getStableId));
+		return ends;
+	} // end of validate method
+
+	@Override
+	public void save(PrintWriter output) {
+
+		output.println("OP RemoveWire");
+		Ops.saveString(output, "id", id.toString());
+		output.println("END");
+	} // end of save method
+
+} // end of RemoveWire record

--- a/test/jls/collab/op/CircuitOpTest.java
+++ b/test/jls/collab/op/CircuitOpTest.java
@@ -14,7 +14,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Scanner;
 import java.util.function.Predicate;
 
@@ -119,6 +121,72 @@ class CircuitOpTest {
 				+ "ENDCIRCUIT\n");
 	}
 
+	/**
+	 * A one-segment wire net between an input pin and an output pin,
+	 * every element with a declared stable id. With {@code triState},
+	 * the driving pin and the net are tri-state.
+	 */
+	private static String wiredPairText(boolean triState) {
+		String tri = triState ? " int tristate 1\n" : "";
+		return "CIRCUIT wired\n"
+				+ "ELEMENT InputPin\n" + tri
+				+ " int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n" + tri
+				+ " String put \"output\"\n ref attach 0\n ref wire 3\n"
+				+ "END\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n" + tri
+				+ " String put \"input\"\n ref attach 1\n ref wire 2\n"
+				+ "END\nENDCIRCUIT\n";
+	}
+
+	/** The two pins of {@link #wiredPairText} without the net. */
+	private static String unwiredPairText() {
+		return "CIRCUIT wired\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\nENDCIRCUIT\n";
+	}
+
+	/**
+	 * A three-end net: an attached driving end that fans out to an
+	 * attached end (over a probed wire) and to a dangling end.
+	 */
+	private static String fanOutText() {
+		return "CIRCUIT fan\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n String put \"output\"\n"
+				+ " ref attach 0\n ref wire 3\n probe 3 \"tap\"\n"
+				+ " ref wire 4\nEND\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n String put \"input\"\n"
+				+ " ref attach 1\n ref wire 2\n probe 2 \"tap\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 4\n int x 180\n int y 240\n"
+				+ " String sid \"we:3\"\n ref wire 2\nEND\n"
+				+ "ENDCIRCUIT\n";
+	}
+
 	/** A donor element block: an unwired adder with a declared sid. */
 	private static String donorAdderBlock() throws Exception {
 		Circuit donor = loadText("CIRCUIT donor\nELEMENT Adder\n"
@@ -208,6 +276,64 @@ class CircuitOpTest {
 		inlineAdder.remove(inline);
 		assertEquals(save(inline), save(viaOp),
 				"op and inline removal must produce identical bytes");
+	}
+
+	/**
+	 * P1 for the wiring vocabulary's removal side: the op reaches the
+	 * exact end state of the editor's inline wire deletion (the popup
+	 * delete on a wire, which cascades to the ends and detaches the
+	 * puts).
+	 */
+	@Test
+	void removeWireMatchesInlineWireDelete() throws Exception {
+		Circuit viaOp = loadText(wiredPairText(false));
+		Circuit inline = loadText(wiredPairText(false));
+		Element end = find(viaOp, el -> el instanceof WireEnd);
+		new RemoveWire(end.getStableId()).apply(viaOp, graphics());
+		find(inline, el -> el instanceof Wire).remove(inline);
+		assertEquals(save(inline), save(viaOp),
+				"op and inline wire deletion must produce identical bytes");
+	}
+
+	/**
+	 * P1 for the wiring vocabulary's add side: applying an AddWire to
+	 * the unwired circuit produces the same bytes as loading the file
+	 * that already contains the net - an added net is indistinguishable
+	 * from a loaded one.
+	 */
+	@Test
+	void addWireMatchesTheLoadedForm() throws Exception {
+		Circuit wired = loadText(wiredPairText(false));
+		Element end = find(wired, el -> el instanceof WireEnd);
+		CircuitOp add = new RemoveWire(end.getStableId()).invert(wired);
+		Circuit unwired = loadText(unwiredPairText());
+		add.apply(unwired, graphics());
+		assertEquals(save(wired), save(unwired),
+				"an added net must byte-match the loaded net");
+	}
+
+	/**
+	 * The wired-selection restriction is lifted at the vocabulary
+	 * level: a wired delete travels as one RemoveWire per attached net
+	 * followed by RemoveElements over the then-unwired elements, and
+	 * the composition byte-matches the editor's inline selection
+	 * delete.
+	 */
+	@Test
+	void wiredDeleteComposesFromRemoveWireAndRemoveElements()
+			throws Exception {
+		Circuit viaOp = loadText(wiredPairText(false));
+		Circuit inline = loadText(wiredPairText(false));
+		Element end = find(viaOp, el -> el instanceof WireEnd);
+		new RemoveWire(end.getStableId()).apply(viaOp, graphics());
+		new RemoveElements(List.of(ElementId.parse("pin:1"),
+				ElementId.parse("pin:2"))).apply(viaOp, graphics());
+		find(inline, el -> el instanceof Wire).remove(inline);
+		byId(inline, ElementId.parse("pin:1")).remove(inline);
+		byId(inline, ElementId.parse("pin:2")).remove(inline);
+		assertEquals(save(inline), save(viaOp),
+				"the op composition must byte-match the inline "
+						+ "selection delete");
 	}
 
 	/**
@@ -335,6 +461,86 @@ class CircuitOpTest {
 				new AddElements(List.of(donorAdderBlock())));
 	}
 
+	/**
+	 * P2 for RemoveWire across net shapes: a plain attached segment, a
+	 * fan-out net with a probe and a dangling end, a tri-state net, and
+	 * a net from the wire-heavy file fixture.
+	 */
+	@Test
+	void removeWireInverseRestoresBytes() throws Exception {
+		for (String text : List.of(wiredPairText(false), fanOutText(),
+				wiredPairText(true))) {
+			Circuit circuit = loadText(text);
+			Element end = find(circuit, el -> el instanceof WireEnd);
+			assertInverseRestores(circuit,
+					new RemoveWire(end.getStableId()));
+		}
+		Circuit fork = load();
+		Element end = find(fork, el -> el instanceof WireEnd);
+		assertInverseRestores(fork, new RemoveWire(end.getStableId()));
+	}
+
+	/**
+	 * Computing a RemoveWire inverse must not disturb the live circuit:
+	 * the save-time {@code int} ids the net serializer renumbers while
+	 * writing its blocks are restored afterward. Those ids are not
+	 * purely transient - HDL export consumes them directly for element
+	 * ordering and synthesized net names - so an invert that leaks the
+	 * renumbering would change the HDL of an unchanged circuit. The
+	 * fork fixture is the fixture whose file ids do not coincide with
+	 * the serializer's local numbering.
+	 */
+	@Test
+	void removeWireInvertLeavesSaveTimeIdsUntouched() throws Exception {
+		Circuit fork = load();
+		Map<Element, Integer> before =
+				new IdentityHashMap<Element, Integer>();
+		for (Element el : fork.getElements()) {
+			before.put(el, el.getID());
+		}
+		Element end = find(fork, el -> el instanceof WireEnd);
+		new RemoveWire(end.getStableId()).invert(fork);
+		for (Element el : fork.getElements()) {
+			assertEquals(before.get(el), el.getID(),
+					"invert must leave every save-time id untouched");
+		}
+	}
+
+	@Test
+	void addWireInverseRestoresBytes() throws Exception {
+		Circuit circuit = loadText(fanOutText());
+		Element end = find(circuit, el -> el instanceof WireEnd);
+		CircuitOp remove = new RemoveWire(end.getStableId());
+		CircuitOp add = remove.invert(circuit);
+		remove.apply(circuit, graphics());
+		assertInverseRestores(circuit, add);
+	}
+
+	/** A net attached to nothing travels and inverts like any other. */
+	@Test
+	void danglingNetAddAndRemoveAreExactInverses() throws Exception {
+		Circuit circuit = loadAdder();
+		String b0 = "ELEMENT WireEnd\n int id 0\n int x 60\n int y 60\n"
+				+ " String sid \"wx:1\"\n ref wire 1\nEND\n";
+		String b1 = "ELEMENT WireEnd\n int id 1\n int x 120\n int y 60\n"
+				+ " String sid \"wx:2\"\n ref wire 0\nEND\n";
+		assertInverseRestores(circuit,
+				new AddWire(List.of(), List.of(b0, b1)));
+	}
+
+	@Test
+	void wiringInversesHoldOnARestoredCircuit() throws Exception {
+		// section 10 threat, wiring edition: the restored object graph
+		// rebuilds nets, puts, and probe maps from bytes
+		Circuit circuit = restored(loadText(fanOutText()));
+		Element end = find(circuit, el -> el instanceof WireEnd);
+		assertInverseRestores(circuit,
+				new RemoveWire(end.getStableId()));
+		Circuit tri = restored(loadText(wiredPairText(true)));
+		Element triEnd = find(tri, el -> el instanceof WireEnd);
+		assertInverseRestores(tri, new RemoveWire(triEnd.getStableId()));
+	}
+
 	@Test
 	void configReplaceInverseRestoresBytes() throws Exception {
 		Circuit circuit = loadAdder();
@@ -410,7 +616,18 @@ class CircuitOpTest {
 				new SetElementConfig(id, "ELEMENT Adder\n int id 0\n"
 						+ " int x 60\n int y 60\n String sid \"legacy:7\"\n"
 						+ " int bits 4\n String orient \"LEFT\"\n"
-						+ " int delay 10\nEND\n"));
+						+ " int delay 10\nEND\n"),
+				new AddWire(List.of(id, other), List.of(
+						"ELEMENT WireEnd\n int id 2\n int x 60\n"
+								+ " int y 60\n String sid \"wx:1\"\n"
+								+ " String put \"output\"\n ref attach 0\n"
+								+ " ref wire 3\n probe 3 \"tap\"\nEND\n",
+						"ELEMENT WireEnd\n int id 3\n int x 120\n"
+								+ " int y 60\n String sid \"wx:2\"\n"
+								+ " ref wire 2\n probe 2 \"tap\"\nEND\n")),
+				new AddWire(List.of(), List.of(
+						"ELEMENT WireEnd\nEND\n")),
+				new RemoveWire(id));
 		for (CircuitOp op : ops) {
 			String text = serialize(op);
 			CircuitOp parsed = CircuitOpReader.read(new Scanner(text));
@@ -479,6 +696,18 @@ class CircuitOpTest {
 				// reconfigure with a stray name field
 				"OP SetElementConfig\n String id \"legacy:1\"\n"
 						+ " String block \"a\"\n String name \"x\"\nEND\n",
+				// wire add without any blocks
+				"OP AddWire\nEND\n",
+				// wire add with a stray int field
+				"OP AddWire\n String block \"x\"\n int dx 1\nEND\n",
+				// wire removal without an id
+				"OP RemoveWire\nEND\n",
+				// wire removal with two ids
+				"OP RemoveWire\n String id \"legacy:1\"\n"
+						+ " String id \"legacy:2\"\nEND\n",
+				// wire removal with a stray block
+				"OP RemoveWire\n String id \"legacy:1\"\n"
+						+ " String block \"x\"\nEND\n",
 		};
 		for (String text : hostile) {
 			assertThrows(OpRejected.class,
@@ -691,6 +920,177 @@ class CircuitOpTest {
 						.apply(circuit, graphics()));
 		assertEquals(before, save(circuit),
 				"a rejected removal must not change the circuit");
+	}
+
+	@Test
+	void removeWireRejectionsLeaveTheCircuitUnchanged() throws Exception {
+		Circuit circuit = loadText(wiredPairText(false));
+		String before = save(circuit);
+
+		// unknown id, and an id that addresses a non-wire element
+		CircuitOp[] invalid = {
+				new RemoveWire(ElementId.parse("nosuch:1")),
+				new RemoveWire(ElementId.parse("pin:1")),
+		};
+		for (CircuitOp op : invalid) {
+			assertThrows(OpRejected.class,
+					() -> op.apply(circuit, graphics()),
+					() -> "accepted: " + op);
+			assertEquals(before, save(circuit),
+					"a rejected wire removal must not change the circuit");
+		}
+
+		// an uneditable net cannot be removed
+		Circuit locked = loadText("CIRCUIT locked\n"
+				+ "ELEMENT WireEnd\n int id 0\n int x 60\n int y 60\n"
+				+ " int fixed 1\n String sid \"we:1\"\n ref wire 1\nEND\n"
+				+ "ELEMENT WireEnd\n int id 1\n int x 120\n int y 60\n"
+				+ " int fixed 1\n String sid \"we:2\"\n ref wire 0\nEND\n"
+				+ "ENDCIRCUIT\n");
+		String lockedBefore = save(locked);
+		assertThrows(OpRejected.class,
+				() -> new RemoveWire(ElementId.parse("we:1"))
+						.apply(locked, graphics()));
+		assertEquals(lockedBefore, save(locked));
+	}
+
+	@Test
+	void addWireRejectionsLeaveTheCircuitUnchanged() throws Exception {
+		Circuit circuit = loadText(wiredPairText(false));
+		String before = save(circuit);
+		ElementId pin1 = ElementId.parse("pin:1");
+		ElementId pin2 = ElementId.parse("pin:2");
+		// a well-formed dangling pair, mutated below case by case
+		String b0 = "ELEMENT WireEnd\n int id 0\n int x 60\n int y 60\n"
+				+ " String sid \"wx:1\"\n ref wire 1\nEND\n";
+		String b1 = "ELEMENT WireEnd\n int id 1\n int x 120\n int y 60\n"
+				+ " String sid \"wx:2\"\n ref wire 0\nEND\n";
+		// a well-formed attached pair for the anchor and put cases
+		String a0 = "ELEMENT WireEnd\n int id 1\n int x 60\n int y 60\n"
+				+ " String sid \"wx:1\"\n String put \"output\"\n"
+				+ " ref attach 0\n ref wire 2\nEND\n";
+		String a1 = "ELEMENT WireEnd\n int id 2\n int x 120\n int y 60\n"
+				+ " String sid \"wx:2\"\n ref wire 1\nEND\n";
+
+		CircuitOp[] invalid = {
+				// no blocks at all
+				new AddWire(List.of(), List.of()),
+				// not a wire-end block
+				new AddWire(List.of(), List.of("garbage")),
+				new AddWire(List.of(), List.of(b0.replace(
+						"ELEMENT WireEnd", "ELEMENT Adder"), b1)),
+				// no declared stable id
+				new AddWire(List.of(), List.of(b0.replace(
+						" String sid \"wx:1\"\n", ""), b1)),
+				// a stable id the circuit already uses
+				new AddWire(List.of(), List.of(b0.replace(
+						"wx:1", "we:1"), b1)),
+				// duplicated end stable id (order check catches it)
+				new AddWire(List.of(),
+						List.of(b0, b1.replace("wx:2", "wx:1"))),
+				// blocks out of stable-id order
+				new AddWire(List.of(), List.of(b0.replace("wx:1", "wx:2"),
+						b1.replace("wx:2", "wx:1"))),
+				// an end wired to itself
+				new AddWire(List.of(), List.of(b0.replace(" ref wire 1",
+						" ref wire 0"), b1)),
+				// a wire reference outside the op
+				new AddWire(List.of(), List.of(b0.replace(" ref wire 1",
+						" ref wire 5"), b1)),
+				// an end with no wires at all
+				new AddWire(List.of(), List.of(b0.replace(
+						" ref wire 1\n", ""), b1)),
+				// a wire listed from only one of its ends
+				new AddWire(List.of(), List.of(
+						"ELEMENT WireEnd\n int id 0\n int x 60\n"
+								+ " int y 60\n String sid \"wx:1\"\n"
+								+ " ref wire 1\n ref wire 2\nEND\n",
+						"ELEMENT WireEnd\n int id 1\n int x 120\n"
+								+ " int y 60\n String sid \"wx:2\"\n"
+								+ " ref wire 0\nEND\n",
+						"ELEMENT WireEnd\n int id 2\n int x 180\n"
+								+ " int y 60\n String sid \"wx:3\"\n"
+								+ " ref wire 1\nEND\n")),
+				// two disconnected nets in one op
+				new AddWire(List.of(), List.of(
+						b0,
+						b1,
+						"ELEMENT WireEnd\n int id 2\n int x 180\n"
+								+ " int y 60\n String sid \"wx:3\"\n"
+								+ " ref wire 3\nEND\n",
+						"ELEMENT WireEnd\n int id 3\n int x 240\n"
+								+ " int y 60\n String sid \"wx:4\"\n"
+								+ " ref wire 2\nEND\n")),
+				// tri-state flags that disagree within the net
+				new AddWire(List.of(), List.of(b0.replace(
+						" String sid \"wx:1\"\n",
+						" String sid \"wx:1\"\n int tristate 1\n"), b1)),
+				// an end off the canvas
+				new AddWire(List.of(), List.of(b0.replace(" int x 60",
+						" int x -60"), b1)),
+				// an uneditable end (a save the ops never produce)
+				new AddWire(List.of(), List.of(b0.replace(
+						" String sid \"wx:1\"\n",
+						" String sid \"wx:1\"\n int fixed 1\n"), b1)),
+				// a local id that is not the block's position
+				new AddWire(List.of(),
+						List.of(b0.replace(" int id 0", " int id 7"), b1)),
+				// a probe listed from only one end of its wire
+				new AddWire(List.of(), List.of(b0.replace(" ref wire 1\n",
+						" ref wire 1\n probe 1 \"p\"\n"), b1)),
+				// a probe on a wire the end does not have
+				new AddWire(List.of(), List.of(b0.replace(" ref wire 1\n",
+						" ref wire 1\n probe 5 \"p\"\n"), b1)),
+				// an unknown attachment anchor
+				new AddWire(List.of(ElementId.parse("nosuch:1")),
+						List.of(a0, a1)),
+				// an anchor that is itself a wire end
+				new AddWire(List.of(ElementId.parse("we:1")),
+						List.of(a0, a1)),
+				// a put the anchor does not have
+				new AddWire(List.of(pin1), List.of(a0.replace(
+						"\"output\"", "\"nosuch\""), a1)),
+				// a put that already has a wire attached
+				new AddWire(List.of(pin1), List.of(a0, a1)),
+				// a put line without its ref attach line
+				new AddWire(List.of(pin1), List.of(
+						a0.replace(" ref attach 0\n", ""), a1)),
+		};
+		for (CircuitOp op : invalid) {
+			assertThrows(OpRejected.class,
+					() -> op.apply(circuit, graphics()),
+					() -> "accepted: " + op);
+			assertEquals(before, save(circuit),
+					"a rejected wire add must not change the circuit");
+		}
+
+		// two arriving ends claiming the same put (needs free puts)
+		Circuit unwired = loadText(unwiredPairText());
+		String unwiredBefore = save(unwired);
+		assertThrows(OpRejected.class, () -> new AddWire(List.of(pin1),
+				List.of(a0,
+						a1.replace(" String sid \"wx:2\"\n",
+								" String sid \"wx:2\"\n"
+										+ " String put \"output\"\n"
+										+ " ref attach 0\n")))
+												.apply(unwired, graphics()));
+		assertEquals(unwiredBefore, save(unwired),
+				"a rejected wire add must not change the circuit");
+
+		// an anchor carried but never attached to (needs a free put, so
+		// the attachment checks pass and the unused-anchor check fires)
+		assertThrows(OpRejected.class,
+				() -> new AddWire(List.of(pin1, pin2), List.of(
+						"ELEMENT WireEnd\n int id 2\n int x 60\n"
+								+ " int y 60\n String sid \"wx:1\"\n"
+								+ " String put \"output\"\n ref attach 0\n"
+								+ " ref wire 3\nEND\n",
+						"ELEMENT WireEnd\n int id 3\n int x 120\n"
+								+ " int y 60\n String sid \"wx:2\"\n"
+								+ " ref wire 2\nEND\n"))
+										.apply(unwired, graphics()));
+		assertEquals(unwiredBefore, save(unwired),
+				"a rejected wire add must not change the circuit");
 	}
 
 	@Test


### PR DESCRIPTION
Third slice of the operation layer (docs/operation-layer.md "what
lands next" item 1): the wiring vocabulary, at net granularity.

- NetBlocks: the wiring sibling of ElementBlocks. Serializes a whole
  wire net as the exact per-end blocks WireEnd.save writes, with
  cross-references renumbered into an op-local numbering (attachment
  anchors 0..k-1, ends k..k+n-1, both in stable-id order) and the
  anchors travelling alongside as stable ids (#165); parses such
  blocks back strictly (anything a save could not have produced is a
  rejection, never a repair). The renumbering is confined to the
  serialization itself: the elements' prior save-time ids are
  restored before toAddWire returns, since HDL export consumes those
  ids directly for element ordering and synthesized net names, so
  computing an inverse must leave no observable trace.
- AddWire(attach, blocks): reconstructs the net by replaying the file
  loader's exact algorithm (end construction, wire creation order,
  put attachment, probes, finishLoad's net partition), so an added
  net is indistinguishable from a loaded one. Atomic validation:
  exactly one connected net, fresh end sids, wires and probes listed
  from both ends, agreed tri-state flag, existing unattached anchor
  puts, every carried anchor used. A tri-state net re-arms the
  tri-state property of the input pins it drives, mirroring the
  editor's connect().
- RemoveWire(id): removes the whole net containing the addressed wire
  end, detaching every put exactly as the editor's inline wire
  deletion does (including clearing tri-state properties a tri-state
  net drove). Inverse: an AddWire carrying the net's blocks - a true,
  byte-exact restore, mirroring RemoveElements/ElementBlocks.
- CircuitOpReader: AddWire/RemoveWire cases under the existing
  strict/hostile-input discipline (AddWire reuses the repeatable id
  field as its anchor list and the repeatable block field for its
  wire-end blocks).
- The wired-selection restriction is lifted at the vocabulary level:
  a wired delete travels as one RemoveWire per attached net followed
  by RemoveElements over the then-unwired elements
  (wiredDeleteComposesFromRemoveWireAndRemoveElements pins the
  composition against the inline selection delete).

Tests (16 new/extended in CircuitOpTest): P1 parity against the
inline wire deletion and against the file loader's form of the same
net; P2 apply-then-inverse restores canonical bytes (#166 oracle) on
live and save/load-restored circuits, across plain, fan-out+probe,
tri-state, dangling, and file-fixture nets, plus a check that invert
restores every live element's save-time id (the review finding: the
serializer's renumbering used to leak into the circuit, which would
have changed HDL export output for an unchanged circuit); P3
save->read->save byte round-trips plus 5 hostile reader inputs and
26 apply-time rejection cases, each asserting the circuit's bytes
are untouched.

Gesture migration is explicitly the next slice; this one is additive
data-layer code plus tests, and docs/operation-layer.md's inventory
is updated to match.

Advances #167

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
