### PR TITLE
Give palette buttons and dialog fields stable component identity; acknowledge refused mid-placement palette clicks

### DIFF
--- a/docs/component-naming.md
+++ b/docs/component-naming.md
@@ -1,0 +1,73 @@
+# Stable Component Naming Scheme (issue #210)
+
+UI components that automation (the #91 harness) or assistive technology
+needs to resolve carry a stable Swing component name (`setName`). Names
+are the lookup contract: tests and tools resolve components with
+`getName()` matching instead of tooltip text, Swing class, or positional
+index. This document is the scheme's source of truth; the
+`jls.ui.ComponentIdentityTest` display test enforces it on the live app.
+
+## Element slugs
+
+Wherever a name refers to an element type, the *slug* is the element's
+`jls.elem.ElementRegistry` tag (issue #78's element table), lower-cased:
+`Adder` → `adder`, `AndGate` → `andgate`, `ShiftRegister` →
+`shiftregister`. Sourcing slugs from the registry keeps the names in
+sync with the element table; `SimpleEditor.paletteSlug` refuses to build
+the tool bar if a palette entry does not map to a registered tag.
+
+## Palette (tool bar) and mirror menu
+
+| Component | Name |
+| --- | --- |
+| Tool-bar palette button | `palette.<slug>` (e.g. `palette.adder`) |
+| Mirror item in the popup "elements" menu | `menu.elements.<slug>` |
+
+Both are assigned in `SimpleEditor.makeElement`. All 30 palette entries
+are named; the accessible *name* (the human-readable element label from
+the tooltip, added by #75) is unchanged.
+
+## Element create/modify dialogs
+
+Element dialogs extend `jls.edit.ElementFormDialog`, which owns the
+shared identity:
+
+| Component | Name |
+| --- | --- |
+| The OK button (every element dialog) | `dialog.ok` |
+| The Cancel button (every element dialog) | `dialog.cancel` |
+| A labelled form input | `dialog.<slug>.<field>` (e.g. `dialog.adder.bits`) |
+
+Form inputs are wired with the `ElementFormDialog.labelled(label, field,
+name)` helper, which in one call:
+
+- sets `JLabel.setLabelFor(field)` so a screen reader announces the
+  label when the field gains focus,
+- sets the field's component name for name-based lookup, and
+- sets the field's accessible name to the label text (minus any
+  trailing colon).
+
+`<field>` is a short camelCase description of the parameter
+(`bits`, `name`, `capacity`, `cycleTime`, `initialValue`, ...).
+Dialogs shared by several element types use the dialog's own slug
+rather than one element's tag: `dialog.gate.*` (the shared AND/OR/NAND/
+NOR/NOT/XOR/Extend form), `dialog.group.*` (Splitter/Binder),
+`dialog.pin.*` (input and output pins), `dialog.delaychange.*` (the
+change-timing form). Sub-forms extend the prefix with a segment, e.g.
+`dialog.statemachine.state.name` and
+`dialog.statemachine.transition.signal`.
+
+Unlabelled inputs (the SigGen and Text free-text areas, and the
+Memory built-in initial-contents area raised from the memory form) have
+no `labelFor` source, so they receive `setName` plus an explicit
+accessible name directly: `dialog.siggen.signals`, `dialog.text.text`,
+`dialog.memory.contents`.
+
+## Adding a new element
+
+1. Register the element in `ElementRegistry` (enforced by
+   `ElementRegistryTest`).
+2. `SimpleEditor.paletteSlug`: add the palette tooltip → tag case (the
+   tool bar fails fast at construction if you forget).
+3. In the element's dialog, wire every labelled input through
+   `labelled(...)` with a `dialog.<slug>.<field>` name.

--- a/src/jls/edit/AdderDialog.java
+++ b/src/jls/edit/AdderDialog.java
@@ -103,6 +103,7 @@ public final class AdderDialog implements ElementDialog {
 
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel bits = new JLabel("Input Bits: ", SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.adder.bits");
 			info.add(bits, BorderLayout.WEST);
 			info.add(bitsField, BorderLayout.CENTER);
 			info.add(bitsPad, BorderLayout.EAST);

--- a/src/jls/edit/ClockDialog.java
+++ b/src/jls/edit/ClockDialog.java
@@ -134,8 +134,10 @@ public final class ClockDialog implements ElementDialog {
 
 			JPanel labels = new JPanel(new GridLayout(3, 1, 1, 5));
 			JLabel ctime = new JLabel("Cycle Time: ", SwingConstants.RIGHT);
+			labelled(ctime, cycleTimeField, "dialog.clock.cycleTime");
 			labels.add(ctime);
 			JLabel otime = new JLabel("One Time: ", SwingConstants.RIGHT);
+			labelled(otime, oneTimeField, "dialog.clock.oneTime");
 			labels.add(otime);
 			info.add(labels, BorderLayout.WEST);
 

--- a/src/jls/edit/ConstantDialog.java
+++ b/src/jls/edit/ConstantDialog.java
@@ -145,6 +145,7 @@ public final class ConstantDialog implements ElementDialog {
 			// set up inputs
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel inputs = new JLabel("Value: ", SwingConstants.RIGHT);
+			labelled(inputs, valueField, "dialog.constant.value");
 			info.add(inputs, BorderLayout.WEST);
 			info.add(valueField, BorderLayout.CENTER);
 			info.add(valuePad, BorderLayout.EAST);
@@ -346,6 +347,7 @@ public final class ConstantDialog implements ElementDialog {
 			// set up input
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel inputs = new JLabel("Value: ", SwingConstants.RIGHT);
+			labelled(inputs, valueField, "dialog.constant.value");
 			info.add(inputs, BorderLayout.WEST);
 			info.add(valueField, BorderLayout.CENTER);
 			valueField.setText(c.getValue().toString(c.getBase()));

--- a/src/jls/edit/DecoderDialog.java
+++ b/src/jls/edit/DecoderDialog.java
@@ -108,6 +108,7 @@ public final class DecoderDialog implements ElementDialog {
 			// set up inputs
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel bits = new JLabel("Input Bits: ", SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.decoder.bits");
 			info.add(bits, BorderLayout.WEST);
 			info.add(bitsField, BorderLayout.CENTER);
 			info.add(bitsPad, BorderLayout.EAST);

--- a/src/jls/edit/DelayChangeDialog.java
+++ b/src/jls/edit/DelayChangeDialog.java
@@ -80,6 +80,7 @@ public final class DelayChangeDialog {
 			else {
 				delay = new JLabel("Propagation delay: ", SwingConstants.RIGHT);
 			}
+			labelled(delay, delayField, "dialog.delaychange.delay");
 			info.add(delay, BorderLayout.WEST);
 			info.add(delayField, BorderLayout.CENTER);
 			delayField.setText(el.getDelay() + "");

--- a/src/jls/edit/DelayGateDialog.java
+++ b/src/jls/edit/DelayGateDialog.java
@@ -119,12 +119,14 @@ public final class DelayGateDialog implements ElementDialog {
 			JPanel info = new JPanel(new GridLayout(2, 2));
 			JLabel inputs = new JLabel("Propagation Delay: ",
 					SwingConstants.RIGHT);
+			labelled(inputs, delayField, "dialog.delaygate.delay");
 			info.add(inputs);
 			JPanel in = new JPanel(new FlowLayout());
 			in.add(delayField);
 			in.add(delayPad);
 			info.add(in);
 			JLabel gates = new JLabel("Gates (bits): ", SwingConstants.RIGHT);
+			labelled(gates, gatesField, "dialog.delaygate.bits");
 			info.add(gates);
 			JPanel ga = new JPanel(new FlowLayout());
 			ga.add(gatesField);

--- a/src/jls/edit/DisplayDialog.java
+++ b/src/jls/edit/DisplayDialog.java
@@ -103,6 +103,7 @@ public final class DisplayDialog implements ElementDialog {
 			// set up bits panel
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel bits = new JLabel("Bits: ", SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.display.bits");
 			info.add(bits, BorderLayout.WEST);
 			info.add(bitsField, BorderLayout.CENTER);
 			info.add(bitsPad, BorderLayout.EAST);

--- a/src/jls/edit/ElementFormDialog.java
+++ b/src/jls/edit/ElementFormDialog.java
@@ -133,7 +133,41 @@ public abstract class ElementFormDialog extends JDialog {
 		errorLabel.setForeground(Color.red);
 		errorLabel.setAlignmentX(CENTER_ALIGNMENT);
 		errorLabel.setVisible(false);
+		// #210 stable identity: every element dialog's confirm/cancel
+		// buttons are resolvable by the same names (the buttons are shared
+		// base-class state, so the scheme is documented once in
+		// docs/component-naming.md).
+		ok.setName("dialog.ok");
+		cancel.setName("dialog.cancel");
 	} // end of constructor
+
+	/**
+	 * Associate a form label with its input and give the input a stable
+	 * identity (issue #210): {@code setLabelFor} makes assistive
+	 * technology announce the label when the field gains focus, the
+	 * component name enables name-based lookup by automation (the #91
+	 * harness) instead of positional heuristics, and the label text (sans
+	 * any trailing colon) becomes the field's accessible name. The naming
+	 * scheme is documented in docs/component-naming.md.
+	 *
+	 * @param label The label describing the input.
+	 * @param field The input the label describes.
+	 * @param name The stable component name (e.g. "dialog.adder.bits").
+	 */
+	protected final void labelled(JLabel label, JComponent field,
+			String name) {
+
+		label.setLabelFor(field);
+		field.setName(name);
+		String text = label.getText();
+		String accessible = text == null ? "" : text.strip();
+		if (accessible.endsWith(":")) {
+			accessible =
+					accessible.substring(0, accessible.length() - 1).strip();
+		}
+		field.getAccessibleContext().setAccessibleName(
+				accessible.isEmpty() ? name : accessible);
+	} // end of labelled method
 
 	/**
 	 * Append the error label and button row, install uniform key

--- a/src/jls/edit/GateDialog.java
+++ b/src/jls/edit/GateDialog.java
@@ -160,6 +160,7 @@ public final class GateDialog implements ElementDialog {
 			else {
 				info = new JPanel(new GridLayout(2,2));
 				JLabel inputs = new JLabel("Inputs: ",SwingConstants.RIGHT);
+				labelled(inputs, inputsField, "dialog.gate.inputs");
 				info.add(inputs);
 				JPanel in = new JPanel(new FlowLayout());
 				in.add(inputsField);
@@ -175,6 +176,7 @@ public final class GateDialog implements ElementDialog {
 				gates = new JLabel("Gates (bits): ",SwingConstants.RIGHT);
 			}
 
+			labelled(gates, gatesField, "dialog.gate.bits");
 			info.add(gates);
 			JPanel ga = new JPanel(new FlowLayout());
 			ga.add(gatesField);

--- a/src/jls/edit/GroupDialog.java
+++ b/src/jls/edit/GroupDialog.java
@@ -130,6 +130,7 @@ public final class GroupDialog implements ElementDialog {
 			else {
 				bits = new JLabel("Output Bits: ", SwingConstants.RIGHT);
 			}
+			labelled(bits, bitsField, "dialog.group.bits");
 			info.add(bits, BorderLayout.WEST);
 			info.add(bitsField, BorderLayout.CENTER);
 			info.add(bitsPad, BorderLayout.EAST);
@@ -327,6 +328,7 @@ public final class GroupDialog implements ElementDialog {
 
 			JPanel leftList = new JPanel(new BorderLayout());
 			JLabel left = new JLabel("choose from", SwingConstants.CENTER);
+			labelled(left, choose, "dialog.group.ranges");
 			leftList.add(left, BorderLayout.NORTH);
 			JScrollPane chpane = new JScrollPane(choose);
 			leftList.add(chpane, BorderLayout.CENTER);
@@ -339,6 +341,7 @@ public final class GroupDialog implements ElementDialog {
 
 			JPanel rightList = new JPanel(new BorderLayout());
 			JLabel right = new JLabel("chosen", SwingConstants.CENTER);
+			labelled(right, chosen, "dialog.group.chosen");
 			rightList.add(right, BorderLayout.NORTH);
 			chosen.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			JScrollPane rpane = new JScrollPane(chosen);

--- a/src/jls/edit/JumpEndDialog.java
+++ b/src/jls/edit/JumpEndDialog.java
@@ -154,6 +154,7 @@ public final class JumpEndDialog implements ElementDialog {
 			window.add(heading);
 
 			starts = new JList<String>(circuit.getJumpStartNames().toArray(new String[0]));
+			labelled(heading, starts, "dialog.jumpend.wireName");
 			starts.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 			starts.setVisibleRowCount(Math.min(circuit.getJumpStartNames().size(),10));
 			JScrollPane pane = new JScrollPane(starts);

--- a/src/jls/edit/JumpStartDialog.java
+++ b/src/jls/edit/JumpStartDialog.java
@@ -104,8 +104,10 @@ public final class JumpStartDialog implements ElementDialog {
 			JPanel info = new JPanel(new BorderLayout());
 			JPanel labels = new JPanel(new GridLayout(2,1,1,5));
 			JLabel name = new JLabel("Name: ",SwingConstants.RIGHT);
+			labelled(name, nameField, "dialog.jumpstart.name");
 			labels.add(name);
 			JLabel bits = new JLabel("Bits: ",SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.jumpstart.bits");
 			labels.add(bits);
 			info.add(labels,BorderLayout.WEST);
 

--- a/src/jls/edit/MemoryDialog.java
+++ b/src/jls/edit/MemoryDialog.java
@@ -186,10 +186,13 @@ public final class MemoryDialog implements ElementDialog {
 				JPanel info = new JPanel(new BorderLayout());
 				JPanel labels = new JPanel(new GridLayout(3,1,1,5));
 				JLabel name = new JLabel("Name: ",SwingConstants.RIGHT);
+				labelled(name, nameField, "dialog.memory.name");
 				labels.add(name);
 				JLabel bits = new JLabel("Bits/Word: ",SwingConstants.RIGHT);
+				labelled(bits, bitsField, "dialog.memory.bits");
 				labels.add(bits);
 				JLabel words = new JLabel("Capacity (words): ",SwingConstants.RIGHT);
+				labelled(words, capacityField, "dialog.memory.capacity");
 				labels.add(words);
 				info.add(labels,BorderLayout.WEST);
 
@@ -211,6 +214,7 @@ public final class MemoryDialog implements ElementDialog {
 			else {
 				JPanel info = new JPanel(new BorderLayout());
 				JLabel name = new JLabel("Name: ",SwingConstants.RIGHT);
+				labelled(name, nameField, "dialog.memory.name");
 				info.add(name,BorderLayout.WEST);
 				info.add(nameField,BorderLayout.CENTER);
 				window.add(info);
@@ -382,6 +386,12 @@ public final class MemoryDialog implements ElementDialog {
 				Container window = init.getContentPane();
 				window.setLayout(new BoxLayout(window,BoxLayout.Y_AXIS));
 				final JTextArea area = new JTextArea(tempInit,10,12);
+				// #210 stable identity: the built-in initial-contents area
+				// has no visible label, so it gets its name and accessible
+				// name directly
+				area.setName("dialog.memory.contents");
+				area.getAccessibleContext()
+						.setAccessibleName("Initial memory contents");
 				JScrollPane pane = new JScrollPane(area);
 				window.add(pane);
 

--- a/src/jls/edit/MuxDialog.java
+++ b/src/jls/edit/MuxDialog.java
@@ -131,6 +131,7 @@ public final class MuxDialog implements ElementDialog {
 			JPanel info = null;
 			info = new JPanel(new GridLayout(2, 2));
 			JLabel inputs = new JLabel("Inputs: ", SwingConstants.RIGHT);
+			labelled(inputs, inputsField, "dialog.mux.inputs");
 			info.add(inputs);
 			JPanel in = new JPanel(new FlowLayout());
 			in.add(inputsField);
@@ -139,6 +140,7 @@ public final class MuxDialog implements ElementDialog {
 
 			JLabel gates;
 			gates = new JLabel("Bits: ", SwingConstants.RIGHT);
+			labelled(gates, bitsField, "dialog.mux.bits");
 			info.add(gates);
 			JPanel ga = new JPanel(new FlowLayout());
 			ga.add(bitsField);

--- a/src/jls/edit/PinDialog.java
+++ b/src/jls/edit/PinDialog.java
@@ -114,8 +114,10 @@ public final class PinDialog implements ElementDialog {
 			JPanel info = new JPanel(new BorderLayout());
 			JPanel labels = new JPanel(new GridLayout(2, 1, 1, 5));
 			JLabel name = new JLabel("Name: ", SwingConstants.RIGHT);
+			labelled(name, nameField, "dialog.pin.name");
 			labels.add(name);
 			JLabel bits = new JLabel("Bits: ", SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.pin.bits");
 			labels.add(bits);
 			info.add(labels, BorderLayout.WEST);
 

--- a/src/jls/edit/RegisterDialog.java
+++ b/src/jls/edit/RegisterDialog.java
@@ -208,12 +208,15 @@ public final class RegisterDialog implements ElementDialog {
 			JPanel info = new JPanel(new BorderLayout());
 			JPanel labels = new JPanel(new GridLayout(rows,1,1,5));
 			JLabel name = new JLabel("Name: ",SwingConstants.RIGHT);
+			labelled(name, nameField, "dialog.register.name");
 			labels.add(name);
 			if (creating) {
 				JLabel bits = new JLabel("Bits: ",SwingConstants.RIGHT);
+				labelled(bits, bitsField, "dialog.register.bits");
 				labels.add(bits);
 			}
 			JLabel init = new JLabel("Initial value: ",SwingConstants.RIGHT);
+			labelled(init, valueField, "dialog.register.initialValue");
 			labels.add(init);
 			info.add(labels,BorderLayout.WEST);
 

--- a/src/jls/edit/ShiftRegisterDialog.java
+++ b/src/jls/edit/ShiftRegisterDialog.java
@@ -123,6 +123,7 @@ public final class ShiftRegisterDialog implements ElementDialog {
 			// set up input panel
 			JPanel info = new JPanel(new GridLayout(1, 2));
 			JLabel gates = new JLabel("Bits: ", SwingConstants.RIGHT);
+			labelled(gates, bitsField, "dialog.shiftregister.bits");
 			info.add(gates);
 			JPanel ga = new JPanel(new FlowLayout());
 			ga.add(bitsField);

--- a/src/jls/edit/SigGenDialog.java
+++ b/src/jls/edit/SigGenDialog.java
@@ -99,6 +99,11 @@ public final class SigGenDialog implements ElementDialog {
 			this.sg = sg;
 
 			Container window = getContentPane();
+			// #210 stable identity: the specification area has no visible
+			// label, so it gets its name and accessible name directly
+			textArea.setName("dialog.siggen.signals");
+			textArea.getAccessibleContext()
+					.setAccessibleName("Signal specification");
 			if (!creating) {
 				textArea.setText(sg.getSignals());
 			}

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -31,6 +31,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -87,6 +88,8 @@ import jls.elem.Decoder;
 import jls.elem.DelayGate;
 import jls.elem.Element;
 import jls.elem.ElementId;
+import jls.elem.ElementRegistry;
+import jls.elem.ElementType;
 import jls.elem.Extend;
 import jls.elem.Group;
 import jls.elem.Input;
@@ -2581,12 +2584,77 @@ public abstract class SimpleEditor extends JPanel {
 				// both the tool-bar button and its mirror "elements" menu item.
 				button.getAccessibleContext().setAccessibleName(tip);
 				item.getAccessibleContext().setAccessibleName(tip);
+				// #210 stable identity: name the palette button and its
+				// mirror menu item from the element's registry tag so
+				// automation (the #91 harness) and assistive technology can
+				// resolve them without tooltip/positional heuristics. The
+				// naming scheme is documented in docs/component-naming.md.
+				String slug = paletteSlug(tip);
+				button.setName("palette." + slug);
+				item.setName("menu.elements." + slug);
 				JMenu els = elements;
 				if (els == null)
 					throw new IllegalStateException("makeElement called before makeElements built the menu");
 				els.add(item);
 				return button;
 			} // end of makeElement method
+
+			/**
+			 * The stable component-name slug for a palette tool tip
+			 * (issue #210): the {@link ElementRegistry} tag of the element
+			 * the palette entry creates, lower-cased. Sourcing the slug
+			 * from the registry keeps the names in sync with the element
+			 * table (#78); an unknown tip is a programming error caught at
+			 * tool-bar construction time.
+			 *
+			 * @param tip The palette entry's tool tip.
+			 * @return the lower-cased registry tag for the element.
+			 */
+			private static String paletteSlug(String tip) {
+
+				String tag = switch (tip) {
+					case "AND gate" -> "AndGate";
+					case "OR gate" -> "OrGate";
+					case "NOT gate" -> "NotGate";
+					case "exclusive OR gate" -> "XorGate";
+					case "NAND gate" -> "NandGate";
+					case "NOR gate" -> "NorGate";
+					case "user defined signal delay" -> "DelayGate";
+					case "tri-state gate" -> "TriState";
+					case "name a wire" -> "JumpStart";
+					case "connect to a named wire" -> "JumpEnd";
+					case "input pin" -> "InputPin";
+					case "output pin" -> "OutputPin";
+					case "unbundle wires" -> "Splitter";
+					case "bundle wires" -> "Binder";
+					case "constant value" -> "Constant";
+					case "make N copies of the input" -> "Extend";
+					case "register (various triggering)" -> "Register";
+					case "memory, various types" -> "Memory";
+					case "multiplexor" -> "Mux";
+					case "decoder" -> "Decoder";
+					case "shift register (combinational shifter)" ->
+							"ShiftRegister";
+					case "adder" -> "Adder";
+					case "clock" -> "Clock";
+					case "pause simulator when asserted" -> "Pause";
+					case "stop simulator when asserted" -> "Stop";
+					case "generate test signals" -> "SigGen";
+					case "display circuit value" -> "Display";
+					case "state machine" -> "StateMachine";
+					case "truth table" -> "TruthTable";
+					case "text (for annotations)" -> "Text";
+					default -> throw new IllegalArgumentException(
+							"no element registry tag for palette tip '"
+									+ tip + "'");
+				};
+				ElementType type = ElementRegistry.forTag(tag);
+				if (type == null) {
+					throw new IllegalStateException("palette tip '" + tip
+							+ "' names unregistered element tag " + tag);
+				}
+				return type.tag().toLowerCase(Locale.ROOT);
+			} // end of paletteSlug method
 
 			/**
 			 * Get the tool bar.
@@ -5470,8 +5538,14 @@ public abstract class SimpleEditor extends JPanel {
 						if (!enabled)
 							return;
 
-						// if in the middle of an edit, do nothing
+						// if in the middle of an edit, refuse the new element
+						// but say so (#207 acknowledge-and-ignore): silently
+						// swallowing the palette click makes a stuck
+						// placement read as a frozen editor, so tell the
+						// user why nothing happened and how to proceed.
 						if (currentState != State.idle) {
+							info.setText(
+									"finish or cancel the current placement first");
 							return;
 						}
 

--- a/src/jls/edit/StateMachineDialog.java
+++ b/src/jls/edit/StateMachineDialog.java
@@ -381,7 +381,9 @@ public final class StateMachineDialog implements ElementDialog {
 			enlarge.setToolTipText("expand drawing area");
 
 			JPanel namePanel = new JPanel(new FlowLayout());
-			namePanel.add(new JLabel("Name: "));
+			JLabel machineName = new JLabel("Name: ");
+			labelled(machineName, nameField, "dialog.statemachine.name");
+			namePanel.add(machineName);
 			namePanel.add(nameField);
 			nameField.setText(machine.getName());
 			bottom.add(namePanel);
@@ -1314,7 +1316,9 @@ public final class StateMachineDialog implements ElementDialog {
 
 			// set up name field
 			JPanel name = new JPanel(new BorderLayout());
-			name.add(new JLabel("Name: ",SwingConstants.RIGHT),BorderLayout.WEST);
+			JLabel stateName = new JLabel("Name: ",SwingConstants.RIGHT);
+			labelled(stateName, nameField, "dialog.statemachine.state.name");
+			name.add(stateName,BorderLayout.WEST);
 			name.add(nameField,BorderLayout.CENTER);
 			nameField.setText(currentName);
 			window.add(name);
@@ -1441,7 +1445,10 @@ public final class StateMachineDialog implements ElementDialog {
 			// set up signal/value
 			JPanel sigval = new JPanel(new BorderLayout());
 			JPanel sig = new JPanel(new GridLayout(3,1));
-			sig.add(new JLabel("signal",SwingConstants.CENTER));
+			JLabel signalLabel = new JLabel("signal",SwingConstants.CENTER);
+			labelled(signalLabel, signalField,
+					"dialog.statemachine.transition.signal");
+			sig.add(signalLabel);
 			sig.add(signalField);
 			sig.add(new JLabel(" "));
 			sigval.add(sig,BorderLayout.WEST);
@@ -1449,10 +1456,16 @@ public final class StateMachineDialog implements ElementDialog {
 			JPanel misc = new JPanel(new GridLayout(3,1));
 			misc.add(new JLabel(" "));
 			misc.add(equalOrNot);
-			misc.add(new JLabel("bits: ", SwingConstants.RIGHT));
+			JLabel bitsLabel = new JLabel("bits: ", SwingConstants.RIGHT);
+			labelled(bitsLabel, bitsField,
+					"dialog.statemachine.transition.bits");
+			misc.add(bitsLabel);
 			other.add(misc,BorderLayout.WEST);
 			JPanel values = new JPanel(new GridLayout(3,1));
-			values.add(new JLabel("value",SwingConstants.CENTER));
+			JLabel valueLabel = new JLabel("value",SwingConstants.CENTER);
+			labelled(valueLabel, valueField,
+					"dialog.statemachine.transition.value");
+			values.add(valueLabel);
 			JPanel val = new JPanel(new BorderLayout());
 			val.add(valueField,BorderLayout.CENTER);
 			val.add(valuePad,BorderLayout.EAST);
@@ -1810,7 +1823,10 @@ public final class StateMachineDialog implements ElementDialog {
 			// set up signal/value
 			JPanel sigval = new JPanel(new BorderLayout());
 			JPanel sig = new JPanel(new GridLayout(3,1));
-			sig.add(new JLabel("signal",SwingConstants.CENTER));
+			JLabel signalLabel = new JLabel("signal",SwingConstants.CENTER);
+			labelled(signalLabel, signalField,
+					"dialog.statemachine.output.signal");
+			sig.add(signalLabel);
 			sig.add(signalField);
 			sig.add(new JLabel(" "));
 			sigval.add(sig,BorderLayout.WEST);
@@ -1818,10 +1834,16 @@ public final class StateMachineDialog implements ElementDialog {
 			JPanel misc = new JPanel(new GridLayout(3,1));
 			misc.add(new JLabel(" "));
 			misc.add(new JLabel("="));
-			misc.add(new JLabel("bits: ", SwingConstants.RIGHT));
+			JLabel bitsLabel = new JLabel("bits: ", SwingConstants.RIGHT);
+			labelled(bitsLabel, bitsField,
+					"dialog.statemachine.output.bits");
+			misc.add(bitsLabel);
 			other.add(misc,BorderLayout.WEST);
 			JPanel values = new JPanel(new GridLayout(3,1));
-			values.add(new JLabel("value",SwingConstants.CENTER));
+			JLabel valueLabel = new JLabel("value",SwingConstants.CENTER);
+			labelled(valueLabel, valueField,
+					"dialog.statemachine.output.value");
+			values.add(valueLabel);
 			JPanel val = new JPanel(new BorderLayout());
 			val.add(valueField,BorderLayout.CENTER);
 			val.add(valuePad,BorderLayout.EAST);

--- a/src/jls/edit/SubCircuitDialog.java
+++ b/src/jls/edit/SubCircuitDialog.java
@@ -91,6 +91,7 @@ public final class SubCircuitDialog implements ElementDialog {
 			// set up input
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel name = new JLabel("Name: ", SwingConstants.RIGHT);
+			labelled(name, nameField, "dialog.subcircuit.name");
 			info.add(name, BorderLayout.WEST);
 			info.add(nameField, BorderLayout.CENTER);
 			window.add(info);

--- a/src/jls/edit/TextDialog.java
+++ b/src/jls/edit/TextDialog.java
@@ -177,7 +177,9 @@ public final class TextDialog implements ElementDialog {
 			}
 			fonts = new JComboBox<String>(names);
 			fonts.setSelectedItem(fn);
-			details.add(new JLabel("Font:"));
+			JLabel fontLabel = new JLabel("Font:");
+			labelled(fontLabel, fonts, "dialog.text.font");
+			details.add(fontLabel);
 			details.add(fonts);
 
 			if (elem.getFontSize() == 0) {
@@ -188,7 +190,9 @@ public final class TextDialog implements ElementDialog {
 			}
 			fontSz.setSelectedItem(fs+"");
 			fontSz.setEditable(true);
-			details.add(new JLabel("Size:"));
+			JLabel sizeLabel = new JLabel("Size:");
+			labelled(sizeLabel, fontSz, "dialog.text.size");
+			details.add(sizeLabel);
 			details.add(fontSz);
 
 			if (elem.isBold()) {
@@ -211,6 +215,10 @@ public final class TextDialog implements ElementDialog {
 			italic.addActionListener(this);
 			colorButton.addActionListener(this);
 			window.add(details);
+			// #210 stable identity: the text area has no visible label, so
+			// it gets its name and accessible name directly
+			textArea.setName("dialog.text.text");
+			textArea.getAccessibleContext().setAccessibleName("Text");
 			if (!creating) {
 				textArea.setText(elem.getText());
 				int bi = 0;

--- a/src/jls/edit/TriStateDialog.java
+++ b/src/jls/edit/TriStateDialog.java
@@ -115,6 +115,7 @@ public final class TriStateDialog implements ElementDialog {
 
 			JPanel info = new JPanel(new BorderLayout());
 			JLabel bits = new JLabel("Gates (bits): ", SwingConstants.RIGHT);
+			labelled(bits, bitsField, "dialog.tristate.bits");
 			info.add(bits, BorderLayout.WEST);
 			info.add(bitsField, BorderLayout.CENTER);
 			info.add(bitsPad, BorderLayout.EAST);

--- a/src/jls/edit/TruthTableEditor.java
+++ b/src/jls/edit/TruthTableEditor.java
@@ -78,9 +78,15 @@ public final class TruthTableEditor extends ElementFormDialog
 		JPanel other = new JPanel(new BorderLayout());
 		JPanel info = new JPanel(new BorderLayout());
 		JPanel labels = new JPanel(new GridLayout(3,1));
-		labels.add(new JLabel("new input: ",SwingConstants.RIGHT));
-		labels.add(new JLabel("new output: ",SwingConstants.RIGHT));
-		labels.add(new JLabel("name: ",SwingConstants.RIGHT));
+		JLabel inputLabel = new JLabel("new input: ",SwingConstants.RIGHT);
+		labelled(inputLabel, inputField, "dialog.truthtable.newInput");
+		labels.add(inputLabel);
+		JLabel outputLabel = new JLabel("new output: ",SwingConstants.RIGHT);
+		labelled(outputLabel, outputField, "dialog.truthtable.newOutput");
+		labels.add(outputLabel);
+		JLabel nameLabel = new JLabel("name: ",SwingConstants.RIGHT);
+		labelled(nameLabel, nameField, "dialog.truthtable.name");
+		labels.add(nameLabel);
 		info.add(labels,BorderLayout.WEST);
 		JPanel inputs = new JPanel(new GridLayout(3,1));
 		inputs.add(inputField);

--- a/test/jls/ui/ComponentIdentityTest.java
+++ b/test/jls/ui/ComponentIdentityTest.java
@@ -1,0 +1,295 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.elem.Adder;
+
+/**
+ * Palette buttons, their mirror menu items, and element-dialog form
+ * fields are resolvable by stable component identity (issue #210): every
+ * palette button is named {@code palette.<slug>}, every mirror item in
+ * the popup "elements" menu is named {@code menu.elements.<slug>}, and
+ * element-dialog inputs carry {@code dialog.<slug>.<field>} names with a
+ * {@code JLabel.setLabelFor} association. The scheme is documented in
+ * {@code docs/component-naming.md}; the slugs come from the
+ * {@link jls.elem.ElementRegistry} tags.
+ *
+ * <p>Before the fix, all 30 palette buttons returned {@code null} from
+ * {@code getName()} (issue #210 P1: {@code palette icon buttons=30 with
+ * getName()!=null=0}), so name-based lookup found nothing and automation
+ * fell back to tooltip/class/positional heuristics.</p>
+ *
+ * <p>Tagged {@code display}: boots a real editor tool bar and opens a
+ * real element creation dialog, so it runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class ComponentIdentityTest {
+
+	@BeforeEach
+	void requireDisplay() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+	}
+
+	@AfterEach
+	void disposeStrayWindows() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	/**
+	 * Every palette button carries a distinct {@code palette.<slug>} name,
+	 * and a representative lookup by name (no tooltip, class, or index
+	 * heuristics) resolves the adder button.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void everyPaletteButtonIsResolvableByStableName() throws Exception {
+		try (EditorGestureSupport ui =
+				new EditorGestureSupport(new Circuit("identity"))) {
+			List<JButton> buttons = new ArrayList<>();
+			collectPaletteButtons(ui.editor, buttons);
+
+			Set<String> names = new HashSet<>();
+			for (JButton button : buttons) {
+				String name = button.getName();
+				if (name != null && name.startsWith("palette.")) {
+					assertTrue(names.add(name),
+							"palette button name '" + name + "' is unique");
+				} else {
+					// the only tooltip-bearing tool-bar button outside the
+					// palette scheme is the Import menu control
+					assertEquals("Import", button.getText(),
+							"tool-bar button (tooltip '"
+									+ button.getToolTipText()
+									+ "') lacks a palette.<slug> name");
+				}
+			}
+			// issue #210 P1/P2: 0 of 30 named before the fix, 30 after
+			assertEquals(30, names.size(),
+					"all 30 element palette buttons resolve by palette.<slug>"
+							+ " name (P1 was 0 of 30)");
+
+			// the #91-style lookup: resolve by name alone
+			JButton adder = findByName(ui.editor, "palette.adder");
+			assertNotNull(adder,
+					"findByName(\"palette.adder\") resolves the adder button");
+			assertEquals("adder", adder.getToolTipText(),
+					"the button named palette.adder is the adder palette entry");
+		}
+	}
+
+	/**
+	 * The mirror items in the popup "elements" menu carry
+	 * {@code menu.elements.<slug>} names, one per palette entry.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void mirrorElementsMenuItemsCarryStableNames() throws Exception {
+		try (EditorGestureSupport ui =
+				new EditorGestureSupport(new Circuit("identity-menu"))) {
+			// the "elements" menu lives in the canvas popup; raise it
+			ui.rightPress(300, 300);
+			JMenuItem elementsEntry = ui.popupItem("elements");
+			assertTrue(elementsEntry instanceof JMenu,
+					"the popup's \"elements\" entry is a submenu");
+			JMenu elements = (JMenu) elementsEntry;
+
+			List<String> names = new ArrayList<>();
+			SwingUtilities.invokeAndWait(() -> {
+				for (int i = 0; i < elements.getItemCount(); i++) {
+					JMenuItem item = elements.getItem(i);
+					if (item != null) {
+						names.add(item.getName());
+					}
+				}
+			});
+			assertEquals(30, names.size(),
+					"the elements menu mirrors the 30 palette entries");
+			Set<String> distinct = new HashSet<>();
+			for (String name : names) {
+				assertNotNull(name, "every mirror menu item has a name");
+				assertTrue(name.startsWith("menu.elements."),
+						"mirror item name '" + name
+								+ "' follows the menu.elements.<slug> scheme");
+				assertTrue(distinct.add(name),
+						"mirror item name '" + name + "' is unique");
+			}
+			assertTrue(names.contains("menu.elements.adder"),
+					"the adder mirror item is named menu.elements.adder");
+		}
+	}
+
+	/**
+	 * A representative element dialog (Create Adder) exposes its bits
+	 * field by the stable name {@code dialog.adder.bits}, associates the
+	 * "Input Bits" label with it via {@code labelFor}, and names its
+	 * OK/Cancel buttons {@code dialog.ok}/{@code dialog.cancel}.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void adderDialogFieldIsNamedAndLabelAssociated() throws Exception {
+		Circuit circuit = new Circuit("identity-dialog");
+		BufferedImage img = new BufferedImage(400, 300,
+				BufferedImage.TYPE_INT_RGB);
+
+		AtomicBoolean fieldNamed = new AtomicBoolean();
+		AtomicBoolean fieldLabelled = new AtomicBoolean();
+		AtomicBoolean okNamed = new AtomicBoolean();
+		AtomicBoolean cancelNamed = new AtomicBoolean();
+		CountDownLatch probed = new CountDownLatch(1);
+		CountDownLatch done = new CountDownLatch(1);
+
+		// prober: inspect the modal dialog while it is up, then close it
+		// through the cancel button it just resolved by name
+		Thread prober = new Thread(() -> {
+			while (probed.getCount() > 0) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (!(w instanceof JDialog) || !w.isVisible()) {
+							continue;
+						}
+						Component field =
+								findComponentByName(w, "dialog.adder.bits");
+						if (field == null) {
+							continue;
+						}
+						fieldNamed.set(field instanceof JTextField);
+						fieldLabelled.set(hasLabelFor(w, field));
+						Component ok = findComponentByName(w, "dialog.ok");
+						okNamed.set(ok instanceof JButton);
+						Component cancel =
+								findComponentByName(w, "dialog.cancel");
+						cancelNamed.set(cancel instanceof JButton);
+						probed.countDown();
+						if (cancel instanceof JButton cancelButton) {
+							cancelButton.doClick();
+						} else {
+							w.dispose();
+						}
+					}
+				});
+				try {
+					Thread.sleep(30);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "adder-dialog-prober");
+		prober.setDaemon(true);
+		prober.start();
+
+		SwingUtilities.invokeLater(() -> {
+			try {
+				jls.edit.ElementDialogs.setup(new Adder(circuit),
+						img.createGraphics(), new JPanel(), 100, 100);
+			} finally {
+				done.countDown();
+			}
+		});
+		assertTrue(done.await(60, TimeUnit.SECONDS),
+				"the Create Adder dialog came down");
+		assertTrue(probed.await(5, TimeUnit.SECONDS),
+				"the prober found a dialog exposing dialog.adder.bits");
+
+		assertTrue(fieldNamed.get(),
+				"dialog.adder.bits resolves to the bits text field");
+		assertTrue(fieldLabelled.get(),
+				"a JLabel in the dialog has labelFor pointing at the bits "
+						+ "field (screen readers announce it)");
+		assertTrue(okNamed.get(), "the OK button is named dialog.ok");
+		assertTrue(cancelNamed.get(),
+				"the Cancel button is named dialog.cancel");
+	}
+
+	/** Collect every tool-bar palette button (icon button with tooltip). */
+	private static void collectPaletteButtons(Container root,
+			List<JButton> out) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& button.getToolTipText() != null) {
+				out.add(button);
+			}
+			if (c instanceof Container inner) {
+				collectPaletteButtons(inner, out);
+			}
+		}
+	}
+
+	/** Resolve a button by component name, the #91 lookup idiom. */
+	private static JButton findByName(Container root, String name) {
+		Component c = findComponentByName(root, name);
+		return c instanceof JButton button ? button : null;
+	}
+
+	/** Depth-first component-name lookup. */
+	private static Component findComponentByName(Container root,
+			String name) {
+		for (Component c : root.getComponents()) {
+			if (name.equals(c.getName())) {
+				return c;
+			}
+			if (c instanceof Container inner) {
+				Component found = findComponentByName(inner, name);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/** Whether some JLabel in the tree points at the field via labelFor. */
+	private static boolean hasLabelFor(Container root, Component field) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JLabel label && label.getLabelFor() == field) {
+				return true;
+			}
+			if (c instanceof Container inner
+					&& hasLabelFor(inner, field)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/test/jls/ui/MidPlacementPaletteFeedbackTest.java
+++ b/test/jls/ui/MidPlacementPaletteFeedbackTest.java
@@ -1,0 +1,232 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import jls.Circuit;
+import jls.elem.AndGate;
+import jls.elem.Element;
+import jls.elem.OrGate;
+
+/**
+ * Selecting a palette element while another element is mid-placement is
+ * acknowledged instead of silently swallowed (issue #207). The editor's
+ * {@code setup()} refuses new elements while {@code currentState != idle}
+ * - defensible on its own, but before the fix the refusal had no
+ * observable effect, so a stuck placement made every further palette
+ * click read as a frozen editor. The adjudicated remedy is
+ * acknowledge-and-ignore: the refused click sets the info status label to
+ * "finish or cancel the current placement first" and the in-flight
+ * placement is left untouched.
+ *
+ * <p>Tagged {@code display}: needs a display for the gate creation
+ * dialog (accepted by a background thread with its defaults, the
+ * {@link KeyboardPlacementFaithfulTest} idiom) and font metrics, so it
+ * runs under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false).</p>
+ */
+@Tag("display")
+@Timeout(120)
+class MidPlacementPaletteFeedbackTest {
+
+	/** The #207 acknowledgement shown for a refused palette selection. */
+	private static final String ACKNOWLEDGEMENT =
+			"finish or cancel the current placement first";
+
+	private volatile boolean accepting;
+	private Thread acceptor;
+
+	@BeforeEach
+	void requireDisplayAndStartAcceptor() {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		accepting = true;
+		acceptor = new Thread(() -> {
+			while (accepting) {
+				SwingUtilities.invokeLater(() -> {
+					for (Window w : Window.getWindows()) {
+						if (w.isVisible() && w instanceof JDialog) {
+							JButton ok = findButtonByText(w, "OK");
+							if (ok != null) {
+								ok.doClick();
+							}
+						}
+					}
+				});
+				try {
+					Thread.sleep(30);
+				} catch (InterruptedException e) {
+					return;
+				}
+			}
+		}, "gate-dialog-acceptor");
+		acceptor.setDaemon(true);
+		acceptor.start();
+	}
+
+	@AfterEach
+	void stopAcceptorAndDisposeWindows() throws Exception {
+		stopAcceptor();
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				w.dispose();
+			}
+		});
+	}
+
+	private void stopAcceptor() throws Exception {
+		accepting = false;
+		if (acceptor != null) {
+			acceptor.join(1000);
+		}
+	}
+
+	/**
+	 * Enter the placing state with an OR gate, then click the AND gate
+	 * palette button: the click is refused (no AND gate, no new dialog)
+	 * but acknowledged in the info status label, so the editor no longer
+	 * reads as frozen (issue #207 P2; P1 observed neither dialog nor any
+	 * status text).
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void refusedPaletteClickWhilePlacingIsAcknowledgedInStatusLabel()
+			throws Exception {
+		Circuit circuit = new Circuit("mid-placement");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			// resolve both palette buttons by their #210 stable names
+			JButton orButton = findByName(ui.editor, "palette.orgate");
+			assertNotNull(orButton, "palette.orgate resolves");
+			JButton andButton = findByName(ui.editor, "palette.andgate");
+			assertNotNull(andButton, "palette.andgate resolves");
+
+			// choose the OR gate; the acceptor OKs its creation dialog and
+			// the editor enters the placing state (gate follows the cursor)
+			SwingUtilities.invokeAndWait(orButton::doClick);
+			ui.waitFor(() -> present(circuit, OrGate.class),
+					"OR gate created");
+			ui.waitFor(ui::canvasIsFocusOwner,
+					"choosing from the palette handed focus to the canvas");
+
+			// no acceptor from here on: were the refused click to open a
+			// dialog anyway (the regression), nothing would dismiss it and
+			// the doClick below would hang into the test timeout
+			stopAcceptor();
+
+			// mid-placement, click a different palette element
+			SwingUtilities.invokeAndWait(andButton::doClick);
+
+			// acknowledge-and-ignore: the info label explains the refusal...
+			ui.waitFor(() -> {
+				try {
+					return labelShowing(ui.editor, ACKNOWLEDGEMENT);
+				} catch (Exception e) {
+					throw new AssertionError(e);
+				}
+			}, "the info label acknowledges the refused palette click");
+
+			// ...and the selection was ignored: no AND gate, no new dialog,
+			// and the in-flight OR gate placement is untouched
+			assertFalse(present(circuit, AndGate.class),
+					"the refused selection created no AND gate");
+			assertFalse(anyDialogVisible(),
+					"the refused selection opened no dialog");
+			assertTrue(present(circuit, OrGate.class),
+					"the in-flight OR gate placement is untouched");
+		}
+	}
+
+	/** Whether a JLabel in the tree currently shows the given text. */
+	private static boolean labelShowing(Container root, String text)
+			throws Exception {
+		AtomicBoolean found = new AtomicBoolean();
+		SwingUtilities.invokeAndWait(
+				() -> found.set(findLabelWithText(root, text)));
+		return found.get();
+	}
+
+	private static boolean findLabelWithText(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JLabel label && text.equals(label.getText())) {
+				return true;
+			}
+			if (c instanceof Container inner
+					&& findLabelWithText(inner, text)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean anyDialogVisible() throws Exception {
+		AtomicBoolean visible = new AtomicBoolean();
+		SwingUtilities.invokeAndWait(() -> {
+			for (Window w : Window.getWindows()) {
+				if (w instanceof JDialog && w.isVisible()) {
+					visible.set(true);
+				}
+			}
+		});
+		return visible.get();
+	}
+
+	private static boolean present(Circuit circuit, Class<?> type) {
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static JButton findByName(Container root, String name) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button && name.equals(button.getName())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findByName(inner, name);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static JButton findButtonByText(Container root, String text) {
+		for (Component c : root.getComponents()) {
+			if (c instanceof JButton button
+					&& text.equals(button.getText())) {
+				return button;
+			}
+			if (c instanceof Container inner) {
+				JButton found = findButtonByText(inner, text);
+				if (found != null) {
+					return found;
+				}
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Closes #210, closes #207.

Issue #210 (stable component identity):
- SimpleEditor.makeElement names every palette button "palette.<slug>"
  and its mirror menu item "menu.elements.<slug>", with the slug derived
  from the element's ElementRegistry tag (lower-cased) via a new
  paletteSlug helper that fails fast on an unregistered palette tip.
  P1 re-observed at pickup: 0 of 30 palette buttons named; after the
  change all 30 resolve by name (asserted by the new test).
- ElementFormDialog gains a protected labelled(JLabel, JComponent,
  String) helper (setLabelFor + setName + accessible name from the
  label text) and names the shared OK/Cancel buttons "dialog.ok" /
  "dialog.cancel". The helper is applied to the labelled inputs of all
  ElementFormDialog subclasses (Adder, Clock, Constant create+modify,
  Decoder, DelayChange, DelayGate, Display, Gate, Group create+ranges,
  JumpEnd, JumpStart, Memory create+modify, Mux, Pin, Register,
  ShiftRegister, StateMachine machine/state/transition forms,
  SubCircuit, Text, TriState, TruthTableEditor); the unlabelled SigGen
  and Text free-text areas get names and accessible names directly.
- Naming scheme documented in docs/component-naming.md.

Issue #207 (silent mid-placement palette click):
- The setup() idle guard now implements the adjudicated
  acknowledge-and-ignore remedy: a palette selection refused because
  currentState != idle sets the info status label to "finish or cancel
  the current placement first" instead of vanishing without a trace.
  Normal placement from idle is unchanged. Decision recorded on the
  issue before implementation per its DoD.

Tests (@Tag("display"), Assumptions/xvfb pattern):
- jls.ui.ComponentIdentityTest: all 30 palette buttons resolvable by
  distinct palette.<slug> names, the popup "elements" mirror items by
  menu.elements.<slug>, and the Create Adder dialog exposes
  dialog.adder.bits with a labelFor association plus dialog.ok /
  dialog.cancel.
- jls.ui.MidPlacementPaletteFeedbackTest: enters the placing state,
  clicks another palette button, and asserts the acknowledgement text,
  no new element, no new dialog, and the in-flight placement untouched.

xvfb-run mvn -B verify -Djls.test.headless=false: BUILD SUCCESS
(headless + display suites, SpotBugs, Spotless all green).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
