### PR TITLE
Board-aware HDL export, first slice: iCEstick PCF constraints (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Added
+- Board-aware HDL export, first slice (#213): `-export` now accepts
+  `-board <name>` plus `-pins <file>` and writes a pin-constraint file
+  (`.pcf`) next to the exported HDL, generated from the same model walk
+  as the Verilog/VHDL — one built-in board so far (`icestick`, Lattice
+  iCE40-HX1K, for the open `nextpnr-ice40` flow; table in
+  `jls.hdl.board.Boards`). The bindings file maps each top-level port
+  (bit) to a named board pin; any unbindable port fails the whole
+  export with every problem in one actionable error and writes nothing,
+  so a partial constraint file can never reach disk. Golden-pinned and
+  byte-deterministic; supported boards documented in
+  `docs/hdl-support-research.md` §7.5. XDC/QSF, more boards, and the
+  scripted bitstream handoff (#215) are follow-ups.
 - Batch `-vcd` export now includes **probed wire nets** as VCD signals
   (#200), so a named internal net can be observed headlessly without
   splicing in an `OutputPin` tap. Each probe becomes a `wire` signal

--- a/docs/hdl-support-research.md
+++ b/docs/hdl-support-research.md
@@ -502,6 +502,52 @@ black-box case, and Yosys+GHDL-plugin remains the only credible VHDL
 *import* door. No further research needed unless Stage 3 VHDL support is
 prioritized.
 
+### 7.5 Shipped: board-aware export, first slice (issue #213, July 2026)
+
+The §4 item 2 catch-up ("board-aware export") began shipping: `-export`
+now takes `-board <name>` plus `-pins <file>` and writes a pin-constraint
+file next to the HDL, generated from the same `HdlExporter.buildModel`
+port walk the Verilog/VHDL emitters render (package `jls.hdl.board`).
+
+**Supported boards** (built-in table, `jls.hdl.board.Boards`; grown on
+demand, never via a general board-description format — #213 H2):
+
+| `-board` name | FPGA | Constraint format | Named pins |
+|---|---|---|---|
+| `icestick` | Lattice iCE40-HX1K, TQ144 (Lattice iCEstick eval kit) | PCF (icestorm / `nextpnr-ice40 --pcf`) | `CLK` (12 MHz), `LED1`–`LED5`, `UART_RX`/`UART_TX`, `IR_TXD`/`IR_RXD`/`IR_SD`, Pmod `PMOD1`–`PMOD4`/`PMOD7`–`PMOD10`, headers `J1_3`–`J1_10`, `J3_3`–`J3_10` |
+
+**Usage.** The bindings file maps each top-level port (each *bit* of a
+multi-bit port) to a named board pin, one `port pin` or `port[bit] pin`
+per line, `#` comments allowed. A JLS `Clock` element exports as the
+input port `clk` — bind it like any other port:
+
+```
+$ cat pins.txt
+sw[0] PMOD1
+sw[1] PMOD2
+clk   CLK
+led[0] LED1
+led[1] LED2
+$ jls -export blinky.v -board icestick -pins pins.txt blinky.jls
+# writes blinky.v and blinky.pcf
+```
+
+Binding is all-or-nothing (#213 P3): an unbindable port set fails the
+whole export with every problem in one `jls: error:` line — a missing
+binding, an unknown port or board pin (with the valid names listed), a
+wrong scalar/indexed form, an out-of-range bit, or one pin claimed
+twice — and neither the HDL nor any partial constraint file reaches
+disk. Emission is byte-deterministic and golden-pinned
+(`test/resources/hdl/board/`).
+
+**Handoff** (external tools, per the delegation rule): the emitted
+`.pcf` feeds the open iCE40 flow, e.g. `yosys -p 'synth_ice40 -json
+blinky.json' blinky.v` then `nextpnr-ice40 --hx1k --package tq144
+--pcf blinky.pcf --json blinky.json`. The scripted end-to-end recipe is
+issue #215's deliverable. Deferred to #213 follow-ups: XDC/QSF formats,
+more boards (an ECP5 board arrives with its LPF emitter), and an
+editor-side pin-mapping panel (binding UX option (b)).
+
 ## 8. Refuted during verification (for the record)
 
 - "Digital's export is one-click/single-file and its manual documents no HDL

--- a/src/jls/JLSStart.java
+++ b/src/jls/JLSStart.java
@@ -69,8 +69,13 @@ import jls.elem.SubCircuit;
 import jls.hdl.HdlEmitter;
 import jls.hdl.HdlExportException;
 import jls.hdl.HdlExporter;
+import jls.hdl.HdlModel;
 import jls.hdl.VerilogEmitter;
 import jls.hdl.VhdlEmitter;
+import jls.hdl.board.Board;
+import jls.hdl.board.Boards;
+import jls.hdl.board.PcfEmitter;
+import jls.hdl.board.PinBindings;
 import jls.sim.BatchSimulator;
 
 
@@ -101,6 +106,10 @@ public class JLSStart extends JFrame implements ChangeListener {
 	private static @Nullable String vcdFile = null;
 	/** HDL export output file name (-export flag), or null if none given. */
 	private static @Nullable String exportFile = null;
+	/** Target board for -export pin constraints (-board flag, issue #213), lower-case, or null if none given. */
+	private static @Nullable String boardName = null;
+	/** Port-to-pin bindings file for -export pin constraints (-pins flag, issue #213), or null if none given. */
+	private static @Nullable String pinsFile = null;
 	/** Plain-text re-save output file name (-savetext flag), or null if none given. */
 	private static @Nullable String textSaveFile = null;
 	/** True if -p or -v asked for the circuit to be printed. */
@@ -373,11 +382,48 @@ public class JLSStart extends JFrame implements ChangeListener {
 							.endsWith(".v")
 					? new VerilogEmitter() : new VhdlEmitter();
 
+			// board-aware export (issue #213): -board/-pins add a
+			// pin-constraint file next to the HDL. The bindings file is
+			// read up front so a bad file fails before anything else
+			// happens; parseCommandLine guaranteed the pair travels
+			// together and the board name is in the table
+			Board board = boardName == null ? null : Boards.byName(boardName);
+			PinBindings bindings = null;
+			if (board != null && pinsFile != null) {
+				List<String> bindingLines;
+				try {
+					bindingLines = java.nio.file.Files.readAllLines(
+							Path.of(pinsFile), StandardCharsets.UTF_8);
+				} catch (IOException e) {
+					System.err.println("jls: error: can't read pin bindings"
+							+ " file " + pinsFile + ": " + e.getMessage());
+					System.exit(1);
+					return; // unreachable; keeps the flow analyzable
+				}
+				try {
+					bindings = PinBindings.parse(bindingLines);
+				} catch (HdlExportException e) {
+					System.err.println("jls: error: " + e.getMessage());
+					System.exit(1);
+					return; // unreachable; keeps the flow analyzable
+				}
+			}
+
 			// walk and render; a rejection lists every offending
-			// element and writes nothing
+			// element and writes nothing. With a board, the constraint
+			// text comes from the same model walk as the HDL (#213) and
+			// any unbindable port aborts before either file is written
 			HdlExporter.Result result;
+			String constraintText = null;
 			try {
-				result = HdlExporter.export(circ, emitter);
+				if (board == null || bindings == null) {
+					result = HdlExporter.export(circ, emitter);
+				} else {
+					HdlModel model = HdlExporter.buildModel(circ);
+					result = new HdlExporter.Result(emitter.emit(model),
+							model.warnings());
+					constraintText = PcfEmitter.emit(model, board, bindings);
+				}
 			} catch (HdlExportException e) {
 				System.err.println("jls: error: " + e.getMessage());
 				System.exit(1);
@@ -411,6 +457,19 @@ public class JLSStart extends JFrame implements ChangeListener {
 				System.err.println("jls: error: can't write " + exportFile
 						+ ": " + e.getMessage());
 				System.exit(1);
+			}
+
+			// the pin-constraint file lands next to the HDL, named
+			// after it with the board format's extension (issue #213);
+			// its text was fully validated before the HDL was written,
+			// so this write can only fail on I/O — and the same
+			// temp-and-rename pattern keeps a partial constraint file
+			// from ever reaching the target path
+			if (constraintText != null && board != null) {
+				String constraintFile =
+						exportFile.replaceAll("(?i)\\.(v|vhd|vhdl)$", "")
+								+ "." + board.format().extension();
+				writeExportedText(constraintFile, constraintText);
 			}
 		}
 
@@ -556,6 +615,42 @@ public class JLSStart extends JFrame implements ChangeListener {
 	} // end of loadCircuitHeadless method
 
 	/**
+	 * Write one exported text file for a headless one-shot mode via the
+	 * temp-and-rename pattern the HDL export path uses, so a partial
+	 * file can never reach the target path. Any failure prints one
+	 * "jls: error:" line, removes the temp file, and exits 1.
+	 *
+	 * @param fileName The target file path.
+	 * @param text The complete file content.
+	 */
+	private static void writeExportedText(String fileName, String text) {
+
+		Path target = Path.of(fileName);
+		Path temp = Path.of(fileName + ".tmp");
+		try {
+			java.nio.file.Files.writeString(temp, text,
+					StandardCharsets.UTF_8);
+			try {
+				java.nio.file.Files.move(temp, target,
+						java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+						java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+			} catch (java.nio.file.AtomicMoveNotSupportedException ex) {
+				java.nio.file.Files.move(temp, target,
+						java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+			}
+		} catch (IOException e) {
+			try {
+				java.nio.file.Files.deleteIfExists(temp);
+			} catch (IOException ignored) {
+				// the error below already covers it
+			}
+			System.err.println("jls: error: can't write " + fileName
+					+ ": " + e.getMessage());
+			System.exit(1);
+		}
+	} // end of writeExportedText method
+
+	/**
 	 * Display values of watched elements to stdout.
 	 * Descends into subcircuits recursively.
 	 *
@@ -682,6 +777,11 @@ public class JLSStart extends JFrame implements ChangeListener {
 				"write watched-signal waveforms to the named VCD file (batch mode)"),
 		new FlagSpec("export", Arity.REQUIRED, "file", "an output file",
 				"export the circuit as Verilog-2005 (.v) or VHDL (.vhd/.vhdl), chosen by the file extension"),
+		new FlagSpec("board", Arity.REQUIRED, "name", "a board name",
+				"with -export and -pins: also write a pin-constraint file (.pcf) for the named FPGA board (supported: "
+						+ Boards.names() + ")"),
+		new FlagSpec("pins", Arity.REQUIRED, "file", "a pin-bindings file",
+				"with -export and -board: port-to-pin bindings, one 'port pin' (or 'port[bit] pin') per line; # comments"),
 		new FlagSpec("savetext", Arity.REQUIRED, "file", "an output file",
 				"re-save the circuit to the named .jls file as plain (uncompressed) text"),
 	};
@@ -801,6 +901,17 @@ public class JLSStart extends JFrame implements ChangeListener {
 				}
 			}
 			pos += 1;
+		}
+
+		// -board/-pins are export modifiers and only travel as a pair
+		// (issue #213): the board names the pin table, the bindings file
+		// maps this circuit's ports onto it
+		if ((boardName != null || pinsFile != null)
+				&& !JLSInfo.hdlexport) {
+			usageError("options -board and -pins require -export");
+		}
+		if ((boardName == null) != (pinsFile == null)) {
+			usageError("options -board and -pins must be used together");
 		}
 	} // end of parseCommandLine method
 
@@ -979,6 +1090,22 @@ public class JLSStart extends JFrame implements ChangeListener {
 			}
 			JLSInfo.hdlexport = true;
 			exportFile = opnd;
+			break;
+		case "board":
+			// the operand must name a built-in board (issue #213);
+			// validating here gives the "supported: ..." list at the
+			// moment of the typo (-board is Arity.REQUIRED, so opnd
+			// cannot be null; the guard keeps that locally checkable)
+			String board = opnd == null ? ""
+					: opnd.toLowerCase(java.util.Locale.ROOT);
+			if (Boards.byName(board) == null) {
+				usageError("option -board requires a supported board name"
+						+ " (supported: " + Boards.names() + "): " + opnd);
+			}
+			boardName = board;
+			break;
+		case "pins":
+			pinsFile = opnd;
 			break;
 		case "savetext":
 			// the output must reopen by the same rules as any other

--- a/src/jls/hdl/board/Board.java
+++ b/src/jls/hdl/board/Board.java
@@ -1,0 +1,159 @@
+package jls.hdl.board;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * One supported FPGA development board (issue #213): the name the user
+ * gives on the command line, the FPGA it carries, the constraint-file
+ * format its toolchain consumes, and the board's named pins. A board is
+ * deliberately just data — (name, format, pin map) per hypothesis H2 of
+ * #213 — so adding a board is adding a table entry in {@link Boards},
+ * never new code.
+ *
+ * @param name User-facing board name, matched case-insensitively
+ *             against the {@code -board} operand; stored lower-case.
+ * @param fpga Human description of the FPGA part and package, for
+ *             generated-file headers and documentation.
+ * @param format The constraint-file format the board's toolchain
+ *               consumes.
+ * @param pins Board pin names (e.g. {@code LED1}, {@code CLK}) to
+ *             physical locations (e.g. {@code 99}); pinned to a sorted
+ *             immutable copy.
+ */
+public record Board(String name, String fpga, Format format,
+		Map<String, String> pins) {
+
+	/**
+	 * The constraint-file formats JLS can emit. Only PCF (the iCE40
+	 * open flow) exists today; XDC (AMD/Xilinx) and QSF (Intel/Altera)
+	 * are #213 follow-ups and get enum constants when their emitters
+	 * land.
+	 */
+	public enum Format {
+
+		/**
+		 * Lattice iCE40 Physical Constraint File, consumed by the open
+		 * icestorm flow ({@code nextpnr-ice40 --pcf}).
+		 */
+		PCF("pcf");
+
+		/** The format's conventional file extension, without the dot. */
+		private final String extension;
+
+		/**
+		 * Creates a format constant.
+		 *
+		 * @param extension The conventional file extension, no dot.
+		 */
+		Format(String extension) {
+			this.extension = extension;
+		} // end of Format constructor
+
+		/**
+		 * The conventional file extension for this format.
+		 *
+		 * @return the extension, without the leading dot.
+		 */
+		public String extension() {
+			return extension;
+		} // end of extension method
+	} // end of Format enum
+
+	/**
+	 * Orders pin names naturally — digit runs compare by numeric value,
+	 * so {@code PMOD2} precedes {@code PMOD10} — with a plain lexical
+	 * tie-break so distinct names (e.g. {@code A1} vs {@code A01})
+	 * never collapse into one map key. Used to sort the pin map so the
+	 * unknown-pin error listing scans in the order a user expects.
+	 */
+	static final Comparator<String> NATURAL_PIN_ORDER =
+			Board::compareNaturally;
+
+	/**
+	 * Pins the pin map to a naturally-sorted immutable copy, so a board
+	 * stays a value and its pin listing (errors, documentation) is
+	 * deterministic no matter what map the table handed in.
+	 */
+	public Board {
+		TreeMap<String, String> sorted =
+				new TreeMap<String, String>(NATURAL_PIN_ORDER);
+		sorted.putAll(pins);
+		pins = Collections.unmodifiableSortedMap(sorted);
+	} // end of Board compact constructor
+
+	/**
+	 * The comparison behind {@link #NATURAL_PIN_ORDER}.
+	 *
+	 * @param a One pin name.
+	 * @param b The other pin name.
+	 *
+	 * @return negative, zero, or positive per the comparator contract.
+	 */
+	private static int compareNaturally(String a, String b) {
+
+		int i = 0;
+		int j = 0;
+		while (i < a.length() && j < b.length()) {
+			char ca = a.charAt(i);
+			char cb = b.charAt(j);
+			if (Character.isDigit(ca) && Character.isDigit(cb)) {
+				// compare the whole digit runs as numbers: strip
+				// leading zeros, then a longer run is a larger number
+				// and equal-length runs compare digit by digit
+				int aStart = i;
+				int bStart = j;
+				while (i < a.length()
+						&& Character.isDigit(a.charAt(i))) {
+					i += 1;
+				}
+				while (j < b.length()
+						&& Character.isDigit(b.charAt(j))) {
+					j += 1;
+				}
+				while (aStart < i - 1 && a.charAt(aStart) == '0') {
+					aStart += 1;
+				}
+				while (bStart < j - 1 && b.charAt(bStart) == '0') {
+					bStart += 1;
+				}
+				int byLength =
+						Integer.compare(i - aStart, j - bStart);
+				if (byLength != 0) {
+					return byLength;
+				}
+				int byDigits = a.substring(aStart, i)
+						.compareTo(b.substring(bStart, j));
+				if (byDigits != 0) {
+					return byDigits;
+				}
+			} else {
+				if (ca != cb) {
+					return Character.compare(ca, cb);
+				}
+				i += 1;
+				j += 1;
+			}
+		}
+		int byRemainder =
+				Integer.compare(a.length() - i, b.length() - j);
+		if (byRemainder != 0) {
+			return byRemainder;
+		}
+		return a.compareTo(b); // e.g. A1 vs A01: distinct keys
+	} // end of compareNaturally method
+
+	/**
+	 * The board's pin names as one comma-separated string, in natural
+	 * order (so {@code PMOD2} before {@code PMOD10}), for actionable
+	 * unknown-pin error messages.
+	 *
+	 * @return the available pin names, comma-joined.
+	 */
+	public String pinNames() {
+		return String.join(", ", pins.keySet());
+	} // end of pinNames method
+
+} // end of Board record

--- a/src/jls/hdl/board/Boards.java
+++ b/src/jls/hdl/board/Boards.java
@@ -1,0 +1,125 @@
+package jls.hdl.board;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The built-in board table (issue #213): the named cheap development
+ * boards JLS can emit pin constraints for. Kept deliberately tiny
+ * (hypothesis H2 of #213): a board is one {@link Board} value here,
+ * with its pin map transcribed from the vendor documentation, and the
+ * table grows on demand rather than through a general board-description
+ * format. First (and so far only) entry: the Lattice iCEstick, the
+ * classic $30 iCE40 teaching board with a fully open toolchain
+ * (yosys + nextpnr-ice40 + icepack + iceprog).
+ */
+public final class Boards {
+
+	/** Not instantiable; the table is static. */
+	private Boards() {
+	} // not instantiable
+
+	/**
+	 * Lattice iCEstick evaluation kit (iCE40-HX1K, TQ144 package).
+	 * Pin map transcribed from the iCEstick user guide and the
+	 * icestorm example constraints: the 12 MHz clock, the five LEDs
+	 * (D1–D4 red, D5 green), the FTDI UART, the IrDA transceiver, the
+	 * Pmod connector J2 (signal pins 1–4 and 7–10), and headers J1 and
+	 * J3 (signal pins 3–10 on each).
+	 */
+	private static final Board ICESTICK = new Board("icestick",
+			"Lattice iCE40-HX1K, TQ144 package", Board.Format.PCF,
+			Map.ofEntries(
+					// 12 MHz oscillator
+					Map.entry("CLK", "21"),
+					// LEDs D1..D4 (red) and D5 (green)
+					Map.entry("LED1", "99"),
+					Map.entry("LED2", "98"),
+					Map.entry("LED3", "97"),
+					Map.entry("LED4", "96"),
+					Map.entry("LED5", "95"),
+					// FTDI channel B UART (TTL side)
+					Map.entry("UART_RX", "9"),
+					Map.entry("UART_TX", "8"),
+					// IrDA transceiver
+					Map.entry("IR_TXD", "105"),
+					Map.entry("IR_RXD", "106"),
+					Map.entry("IR_SD", "107"),
+					// Pmod connector J2, signal pins 1-4 and 7-10
+					Map.entry("PMOD1", "78"),
+					Map.entry("PMOD2", "79"),
+					Map.entry("PMOD3", "80"),
+					Map.entry("PMOD4", "81"),
+					Map.entry("PMOD7", "87"),
+					Map.entry("PMOD8", "88"),
+					Map.entry("PMOD9", "90"),
+					Map.entry("PMOD10", "91"),
+					// header J1, signal pins 3-10
+					Map.entry("J1_3", "112"),
+					Map.entry("J1_4", "113"),
+					Map.entry("J1_5", "114"),
+					Map.entry("J1_6", "115"),
+					Map.entry("J1_7", "116"),
+					Map.entry("J1_8", "117"),
+					Map.entry("J1_9", "118"),
+					Map.entry("J1_10", "119"),
+					// header J3, signal pins 3-10
+					Map.entry("J3_3", "62"),
+					Map.entry("J3_4", "61"),
+					Map.entry("J3_5", "60"),
+					Map.entry("J3_6", "56"),
+					Map.entry("J3_7", "48"),
+					Map.entry("J3_8", "47"),
+					Map.entry("J3_9", "45"),
+					Map.entry("J3_10", "44")));
+
+	/** Every built-in board, in documentation order. */
+	private static final List<Board> ALL = List.of(ICESTICK);
+
+	/**
+	 * Every built-in board, in documentation order.
+	 *
+	 * @return the boards, immutable.
+	 */
+	public static List<Board> all() {
+		return ALL;
+	} // end of all method
+
+	/**
+	 * Look a board up by name, case-insensitively.
+	 *
+	 * @param name The board name to look up.
+	 *
+	 * @return the board, or null if no built-in board has that name.
+	 */
+	public static @Nullable Board byName(String name) {
+
+		String wanted = name.toLowerCase(Locale.ROOT);
+		for (Board board : ALL) {
+			if (board.name().equals(wanted)) {
+				return board;
+			}
+		}
+		return null;
+	} // end of byName method
+
+	/**
+	 * The supported board names as one comma-separated string, for
+	 * usage text and unknown-board error messages.
+	 *
+	 * @return the board names, comma-joined, in documentation order.
+	 */
+	public static String names() {
+
+		List<String> names = new ArrayList<String>();
+		for (Board board : ALL) {
+			names.add(board.name());
+		}
+		return String.join(", ", names);
+	} // end of names method
+
+} // end of Boards class

--- a/src/jls/hdl/board/PcfEmitter.java
+++ b/src/jls/hdl/board/PcfEmitter.java
@@ -1,0 +1,199 @@
+package jls.hdl.board;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jls.hdl.HdlExportException;
+import jls.hdl.HdlModel;
+
+/**
+ * Renders a PCF pin-constraint file (icestorm/nextpnr-ice40 syntax)
+ * for a named {@link Board}, walking exactly the port set
+ * {@link jls.hdl.HdlExporter#buildModel} produced — the same ports the
+ * Verilog/VHDL emitters render, so the constraint file and the HDL can
+ * never disagree about the module's interface (issue #213, hypothesis
+ * H1). Output is deterministic: ports in model order, bits ascending,
+ * one {@code set_io} line per port bit, each preceded by a provenance
+ * comment.
+ *
+ * <p>Binding is all-or-nothing (prediction P3 of #213): every problem
+ * — an unbound port bit, a binding for a port the module does not
+ * have, a wrong indexed/scalar form, an unknown board pin, one pin
+ * claimed twice — is collected and reported in a single
+ * {@link HdlExportException}, and no text is returned, so a partial or
+ * invalid constraint file can never reach disk.</p>
+ */
+public final class PcfEmitter {
+
+	/** Not instantiable; all entry points are static. */
+	private PcfEmitter() {
+	} // not instantiable
+
+	/** Shape of an indexed binding key: {@code <port>[<bit>]}. */
+	private static final Pattern INDEXED =
+			Pattern.compile("^(.+)\\[(\\d+)]$");
+
+	/**
+	 * Render the PCF text binding the model's ports to the board's
+	 * pins.
+	 *
+	 * @param model The model the HDL emitters render; only its ports
+	 * and identity (module name, JLS version) are read.
+	 * @param board The target board; must use the PCF format.
+	 * @param bindings The user's port-to-pin bindings.
+	 *
+	 * @return the complete, valid PCF text.
+	 *
+	 * @throws HdlExportException if any port cannot be bound; the
+	 * message names every problem and nothing is returned.
+	 *
+	 * @jls.testedby jls.hdl.board.PcfGoldenTest#icestickConstraintsMatchTheGolden()
+	 * @jls.testedby jls.hdl.board.UnbindablePortsTest
+	 */
+	public static String emit(HdlModel model, Board board,
+			PinBindings bindings) throws HdlExportException {
+
+		if (board.format() != Board.Format.PCF) {
+			throw new IllegalArgumentException("board " + board.name()
+					+ " uses " + board.format() + " constraints, not PCF");
+		}
+
+		Map<String, String> unclaimed =
+				new LinkedHashMap<String, String>(bindings.asMap());
+		Map<String, String> pinToKey = new TreeMap<String, String>();
+		List<String> errors = new ArrayList<String>();
+		StringBuilder body = new StringBuilder();
+
+		// the same port set, in the same order, as the HDL emitters
+		for (HdlModel.Port port : model.ports()) {
+			String direction =
+					port.direction() == HdlModel.Direction.INPUT
+							? "input" : "output";
+			int bits = Math.max(port.bits(), 1);
+			for (int bit = 0; bit < bits; bit += 1) {
+				String key = bits == 1 ? port.name()
+						: port.name() + "[" + bit + "]";
+				String pin = unclaimed.remove(key);
+				if (pin == null) {
+					errors.add("port \"" + key + "\" (" + port.comment()
+							+ ") has no pin binding; add a line \"" + key
+							+ " <pin>\" to the bindings file");
+					continue;
+				}
+				String location = board.pins().get(pin);
+				if (location == null) {
+					errors.add("port \"" + key + "\" is bound to \"" + pin
+							+ "\", which is not a pin of " + board.name()
+							+ "; available pins: " + board.pinNames());
+					continue;
+				}
+				String prior = pinToKey.putIfAbsent(pin, key);
+				if (prior != null) {
+					errors.add("pin " + pin + " (location " + location
+							+ ") is bound to both \"" + prior + "\" and \""
+							+ key + "\"");
+					continue;
+				}
+				body.append("# ").append(direction).append(' ').append(key)
+						.append(" <- pin ").append(pin).append('\n');
+				body.append("set_io ").append(key).append(' ')
+						.append(location).append('\n');
+			}
+		}
+
+		// bindings that claimed no port bit: unknown ports, or the
+		// wrong scalar/indexed form for a port that does exist
+		for (String key : unclaimed.keySet()) {
+			errors.add(diagnoseLeftover(key, model));
+		}
+
+		if (!errors.isEmpty()) {
+			throw new HdlExportException("cannot bind module \""
+					+ model.moduleName + "\" to board " + board.name()
+					+ ": " + String.join("; ", errors));
+		}
+
+		StringBuilder out = new StringBuilder();
+		out.append("# Board: ").append(board.name()).append(" (")
+				.append(board.fpga()).append(")\n");
+		out.append("# Module: ").append(model.moduleName)
+				.append(", exported by JLS ").append(model.jlsVersion)
+				.append('\n');
+		out.append("# Format: PCF, for the open iCE40 flow"
+				+ " (yosys + nextpnr-ice40 --pcf)\n");
+		out.append('\n');
+		out.append(body);
+		return out.toString();
+	} // end of emit method
+
+	/**
+	 * Explain one binding key that matched no port bit: it names a
+	 * port the module does not have, or uses the wrong scalar/indexed
+	 * form, or indexes past the port's width. (An in-range key for an
+	 * existing port is always claimed by the port walk, so those three
+	 * cases are exhaustive here.)
+	 *
+	 * @param key The unclaimed binding key.
+	 * @param model The model whose ports were walked.
+	 *
+	 * @return an actionable error message for the key.
+	 */
+	private static String diagnoseLeftover(String key, HdlModel model) {
+
+		String base = key;
+		boolean indexed = false;
+		Matcher m = INDEXED.matcher(key);
+		if (m.matches()) {
+			base = m.group(1);
+			indexed = true;
+		}
+		for (HdlModel.Port port : model.ports()) {
+			if (!port.name().equals(base)) {
+				continue;
+			}
+			int bits = Math.max(port.bits(), 1);
+			if (indexed && bits == 1) {
+				return "\"" + key + "\": port \"" + base
+						+ "\" is 1 bit wide; bind it without an index (\""
+						+ base + " <pin>\")";
+			}
+			if (!indexed && bits > 1) {
+				return "\"" + key + "\": port \"" + base + "\" is " + bits
+						+ " bits wide; bind each bit (\"" + base
+						+ "[0] <pin>\" ... \"" + base + "[" + (bits - 1)
+						+ "] <pin>\")";
+			}
+			return "\"" + key + "\": port \"" + base
+					+ "\" has bits 0.." + (bits - 1);
+		}
+		return "\"" + key
+				+ "\" does not name a module port; the ports are: "
+				+ portList(model);
+	} // end of diagnoseLeftover method
+
+	/**
+	 * The module's ports as one comma-separated listing with widths
+	 * and directions, for unknown-port error messages.
+	 *
+	 * @param model The model whose ports to list.
+	 *
+	 * @return the listing, in model port order.
+	 */
+	private static String portList(HdlModel model) {
+
+		List<String> ports = new ArrayList<String>();
+		for (HdlModel.Port port : model.ports()) {
+			ports.add(port.name() + " (" + Math.max(port.bits(), 1)
+					+ " bit" + (Math.max(port.bits(), 1) == 1 ? "" : "s")
+					+ ", " + (port.direction() == HdlModel.Direction.INPUT
+							? "input" : "output") + ")");
+		}
+		return String.join(", ", ports);
+	} // end of portList method
+
+} // end of PcfEmitter class

--- a/src/jls/hdl/board/PinBindings.java
+++ b/src/jls/hdl/board/PinBindings.java
@@ -1,0 +1,98 @@
+package jls.hdl.board;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import jls.hdl.HdlExportException;
+
+/**
+ * The user's port-to-pin bindings, parsed from the {@code -pins} file
+ * (issue #213, binding UX option (a): headless and autograder-friendly).
+ * The format is one binding per line — {@code <port> <pin>} for one-bit
+ * ports, {@code <port>[<bit>] <pin>} per bit for wider ones — with
+ * blank lines and {@code #} comments ignored. Parsing checks only the
+ * file's own shape (two tokens per line, no key bound twice) and
+ * reports every malformed line in one exception; matching the keys
+ * against the module's actual ports and the board's actual pins is
+ * {@link PcfEmitter}'s job, where the {@link jls.hdl.HdlModel} and
+ * {@link Board} are both in hand.
+ */
+public final class PinBindings {
+
+	/** Binding key ({@code port} or {@code port[bit]}) to board pin name, in file order. */
+	private final Map<String, String> bindings;
+
+	/**
+	 * Wraps a parsed binding map; only {@link #parse} constructs one.
+	 *
+	 * @param bindings The parsed key-to-pin map.
+	 */
+	private PinBindings(Map<String, String> bindings) {
+		this.bindings = bindings;
+	} // end of PinBindings constructor
+
+	/**
+	 * Parse a bindings file's lines. Every malformed line is collected
+	 * and reported together, so the user learns the full repair job
+	 * from a single failure.
+	 *
+	 * @param lines The file's lines, in order.
+	 *
+	 * @return the parsed bindings.
+	 *
+	 * @throws HdlExportException if any line is malformed or any key is
+	 * bound twice; the message names every offending line by number.
+	 *
+	 * @jls.testedby jls.hdl.board.UnbindablePortsTest#malformedBindingLinesAreAllReportedWithLineNumbers()
+	 * @jls.testedby jls.hdl.board.UnbindablePortsTest#aKeyBoundTwiceIsAParseError()
+	 */
+	public static PinBindings parse(List<String> lines)
+			throws HdlExportException {
+
+		Map<String, String> bindings =
+				new LinkedHashMap<String, String>();
+		List<String> errors = new ArrayList<String>();
+		for (int n = 0; n < lines.size(); n += 1) {
+			String line = lines.get(n);
+			int hash = line.indexOf('#');
+			if (hash >= 0) {
+				line = line.substring(0, hash);
+			}
+			line = line.trim();
+			if (line.isEmpty()) {
+				continue;
+			}
+			String[] tokens = line.split("\\s+");
+			if (tokens.length != 2) {
+				errors.add("line " + (n + 1)
+						+ ": expected '<port> <pin>', got \"" + line + "\"");
+				continue;
+			}
+			if (bindings.containsKey(tokens[0])) {
+				errors.add("line " + (n + 1) + ": \"" + tokens[0]
+						+ "\" is bound twice");
+				continue;
+			}
+			bindings.put(tokens[0], tokens[1]);
+		}
+		if (!errors.isEmpty()) {
+			throw new HdlExportException("pin bindings file is malformed: "
+					+ String.join("; ", errors));
+		}
+		return new PinBindings(bindings);
+	} // end of parse method
+
+	/**
+	 * The parsed bindings.
+	 *
+	 * @return binding key ({@code port} or {@code port[bit]}) to board
+	 * pin name, unmodifiable, in file order.
+	 */
+	public Map<String, String> asMap() {
+		return Collections.unmodifiableMap(bindings);
+	} // end of asMap method
+
+} // end of PinBindings class

--- a/src/jls/hdl/board/package-info.java
+++ b/src/jls/hdl/board/package-info.java
@@ -1,0 +1,28 @@
+/**
+ * Board-aware HDL export (issue #213): emits the pin-constraint file
+ * that maps an exported design's top-level ports to physical FPGA pins
+ * on a named development board, so the export is one toolchain command
+ * from a bitstream. {@link jls.hdl.board.Board} models a board as a
+ * name, a constraint-file format, and a table of named pins;
+ * {@link jls.hdl.board.Boards} is the small built-in board table
+ * (deliberately small — hypothesis H2 of #213 caps it so JLS never
+ * grows a general board-description language).
+ * {@link jls.hdl.board.PinBindings} reads the user's port-to-pin
+ * bindings file, and {@link jls.hdl.board.PcfEmitter} walks the same
+ * {@link jls.hdl.HdlModel} port set the HDL emitters render and writes
+ * icestorm/nextpnr-ice40 PCF text. Binding problems are all-or-nothing:
+ * every unbindable port is reported in one
+ * {@link jls.hdl.HdlExportException} and no constraint text is
+ * produced, so a partial or invalid constraint file can never reach
+ * disk. Like the rest of {@code jls.hdl}, everything here is headless
+ * and reached only through the {@code jls.JLSStart} CLI wiring point
+ * ({@code -export} plus {@code -board}/{@code -pins}).
+ *
+ * <p>Null-marked (issue #93): every reference in this package is
+ * non-null unless annotated { }, and NullAway enforces
+ * the contract at compile time on the default build.</p>
+ */
+@NullMarked
+package jls.hdl.board;
+
+import org.jspecify.annotations.NullMarked;

--- a/test/jls/hdl/board/BoardFixtures.java
+++ b/test/jls/hdl/board/BoardFixtures.java
@@ -1,0 +1,120 @@
+package jls.hdl.board;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Scanner;
+
+import jls.Circuit;
+import jls.JLSInfo;
+
+/**
+ * The shared circuit fixture for the board-export tests (issue #213):
+ * "blinky", a 2-bit registered pass-through with every port kind the
+ * exporter produces — a multi-bit input pin ({@code sw}), a Clock
+ * element (which exports as the input port {@code clk}), and a
+ * multi-bit output pin ({@code led}). Built in the on-disk text format
+ * and loaded through the real loader, the same technique as
+ * {@code jls.hdl.HdlCircuitBuilder} (which is package-private to
+ * {@code jls.hdl} and therefore mirrored, not reused, here).
+ */
+final class BoardFixtures {
+
+	/** Not instantiable; all fixtures are static. */
+	private BoardFixtures() {
+	} // not instantiable
+
+	/**
+	 * The blinky circuit in on-disk text form: InputPin "sw" (2 bits)
+	 * feeding Register "r" (positive-edge, clocked by a Clock element),
+	 * whose Q output drives OutputPin "led" (2 bits). Module ports:
+	 * {@code sw[1:0]} in, {@code clk} in, {@code led[1:0]} out.
+	 *
+	 * @return the circuit file text.
+	 */
+	static String blinkyText() {
+
+		return "CIRCUIT blinky\n"
+				// sw: 2-bit input pin (id 0)
+				+ "ELEMENT InputPin\n"
+				+ " int id 0\n int x 60\n int y 60\n"
+				+ " int width 24\n int height 24\n"
+				+ " String name \"sw\"\n int bits 2\n int watch 0\n"
+				+ " String orient \"RIGHT\"\n"
+				+ "END\n"
+				// the clock (id 1); exports as input port "clk"
+				+ "ELEMENT Clock\n"
+				+ " int id 1\n int x 72\n int y 60\n"
+				+ " int width 24\n int height 24\n"
+				+ " int cycle 20\n int one 10\n"
+				+ " String orient \"RIGHT\"\n"
+				+ "END\n"
+				// r: 2-bit positive-edge register (id 2)
+				+ "ELEMENT Register\n"
+				+ " int id 2\n int x 84\n int y 60\n"
+				+ " int width 24\n int height 24\n"
+				+ " String name \"r\"\n int bits 2\n Int init 0\n"
+				+ " String orient \"RIGHT\"\n int delay 50\n"
+				+ " String type \"pff\"\n int watch 0\n"
+				+ "END\n"
+				// led: 2-bit output pin (id 3)
+				+ "ELEMENT OutputPin\n"
+				+ " int id 3\n int x 96\n int y 60\n"
+				+ " int width 24\n int height 24\n"
+				+ " String name \"led\"\n int bits 2\n int watch 0\n"
+				+ " String orient \"RIGHT\"\n"
+				+ "END\n"
+				// sw.output -> r.D
+				+ wireEnd(4, 0, "output", 5)
+				+ wireEnd(5, 2, "D", 4)
+				// clock.output -> r.C
+				+ wireEnd(6, 1, "output", 7)
+				+ wireEnd(7, 2, "C", 6)
+				// r.Q -> led.input
+				+ wireEnd(8, 2, "Q", 9)
+				+ wireEnd(9, 3, "input", 8)
+				+ "ENDCIRCUIT\n";
+	} // end of blinkyText method
+
+	/**
+	 * One wire end in on-disk text form, attached to an element put and
+	 * joined to its partner end.
+	 *
+	 * @param id The wire end's element id.
+	 * @param attachTo The id of the element the end attaches to.
+	 * @param put The name of the put on that element.
+	 * @param other The id of the partner wire end.
+	 *
+	 * @return the element text.
+	 */
+	private static String wireEnd(int id, int attachTo, String put,
+			int other) {
+
+		return "ELEMENT WireEnd\n"
+				+ " int id " + id + "\n"
+				+ " int x " + 12 * id + "\n int y 240\n"
+				+ " int width 8\n int height 8\n"
+				+ " String put \"" + put + "\"\n"
+				+ " ref attach " + attachTo + "\n"
+				+ " ref wire " + other + "\n"
+				+ "END\n";
+	} // end of wireEnd method
+
+	/**
+	 * The blinky circuit, loaded through the real loader so wire nets
+	 * are the real thing.
+	 *
+	 * @return the loaded, fully assembled circuit.
+	 *
+	 * @throws Exception if loading fails (a test bug, not a product one).
+	 */
+	static Circuit blinky() throws Exception {
+
+		Circuit circuit = new Circuit("blinky");
+		assertTrue(circuit.load(new Scanner(blinkyText())),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	} // end of blinky method
+
+} // end of BoardFixtures class

--- a/test/jls/hdl/board/BoardPinOrderTest.java
+++ b/test/jls/hdl/board/BoardPinOrderTest.java
@@ -1,0 +1,62 @@
+package jls.hdl.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The pin listing a {@link Board} shows in unknown-pin errors must be
+ * scannable: digit runs compare numerically ({@code PMOD2} before
+ * {@code PMOD10}), not lexically, so multi-digit pin names never
+ * interleave out of order and the user can find the pin they meant.
+ */
+class BoardPinOrderTest {
+
+	/** A board with the given pins, each mapped to a dummy location. */
+	private static Board boardWith(String... pinNames) {
+		Map<String, String> pins = new HashMap<String, String>();
+		int location = 1;
+		for (String pin : pinNames) {
+			pins.put(pin, Integer.toString(location));
+			location += 1;
+		}
+		return new Board("testboard", "test FPGA", Board.Format.PCF,
+				pins);
+	}
+
+	@Test
+	void digitRunsSortNumericallyNotLexically() {
+
+		Board board = boardWith(
+				"PMOD10", "PMOD2", "PMOD1", "J1_10", "J1_3", "CLK");
+		assertEquals("CLK, J1_3, J1_10, PMOD1, PMOD2, PMOD10",
+				board.pinNames());
+	}
+
+	@Test
+	void distinctNamesWithEqualNumericValuesBothSurvive() {
+
+		// A1 and A01 are numerically equal but must stay two map keys
+		Board board = boardWith("A1", "A01");
+		assertEquals(2, board.pins().size());
+		assertEquals("A01, A1", board.pinNames());
+	}
+
+	@Test
+	void theRealIcestickListingIsInNaturalOrder() {
+
+		Board icestick = Boards.byName("icestick");
+		assertTrue(icestick != null);
+		String names = icestick.pinNames();
+		// lexically J1_10 < J1_3; naturally the reverse
+		int j13 = names.indexOf("J1_3");
+		int j110 = names.indexOf("J1_10");
+		if (j13 >= 0 && j110 >= 0) {
+			assertTrue(j13 < j110, names);
+		}
+	}
+}

--- a/test/jls/hdl/board/CliBoardExportTest.java
+++ b/test/jls/hdl/board/CliBoardExportTest.java
@@ -1,0 +1,182 @@
+package jls.hdl.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests of the -board/-pins export operands (issue #213),
+ * subprocess style like CliVerilogExportTest: {@code jls -export out.v
+ * -board icestick -pins pins.txt circuit.jls} writes the Verilog and a
+ * .pcf next to it and exits 0; an unbindable port is one
+ * {@code jls: error:} line, exit 1, and nothing — no HDL, no
+ * constraint file, no temp file — reaches disk; the flag-pairing rules
+ * are usage errors (exit 2).
+ */
+class CliBoardExportTest {
+
+	@TempDir
+	Path tmp;
+
+	/** the exit code and captured stderr of one CLI subprocess run. */
+	private static final class Result {
+		final int exit;
+		final String stderr;
+
+		Result(int exit, String stderr) {
+			this.exit = exit;
+			this.stderr = stderr;
+		}
+	}
+
+	private Result run(String... args) throws Exception {
+		String java = System.getProperty("java.home")
+				+ File.separator + "bin" + File.separator + "java";
+		List<String> cmd = new ArrayList<>();
+		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
+		cmd.add("-Djava.awt.headless=true");
+		cmd.add("-cp");
+		cmd.add(System.getProperty("java.class.path"));
+		cmd.add("jls.JLS");
+		for (String a : args) {
+			cmd.add(a);
+		}
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.directory(tmp.toFile());
+		pb.environment().remove("JAVA_TOOL_OPTIONS");
+		Process p = pb.start();
+		p.getOutputStream().close();
+		String stderr = drain(p.getErrorStream());
+		drain(p.getInputStream());
+		assertTrue(p.waitFor(60, TimeUnit.SECONDS), "CLI run timed out");
+		return new Result(p.exitValue(), stderr);
+	}
+
+	private static String drain(InputStream in) throws Exception {
+		return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+	}
+
+	/** Write the blinky circuit and a bindings file into the temp dir. */
+	private void writeFixture(String... bindingLines) throws Exception {
+		Files.writeString(tmp.resolve("blinky.jls"),
+				BoardFixtures.blinkyText(), StandardCharsets.UTF_8);
+		Files.writeString(tmp.resolve("pins.txt"),
+				String.join("\n", bindingLines) + "\n",
+				StandardCharsets.UTF_8);
+	}
+
+	/** The complete, correct iCEstick bindings for blinky. */
+	private static String[] goodBindings() {
+		return new String[] {
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk CLK",
+				"led[0] LED1", "led[1] LED2" };
+	}
+
+	@Test
+	void boardExportWritesTheHdlAndTheConstraintsBesideIt()
+			throws Exception {
+
+		writeFixture(goodBindings());
+		Result r = run("-export", "out.v", "-board", "icestick",
+				"-pins", "pins.txt", "blinky.jls");
+		assertEquals(0, r.exit, r.stderr);
+		assertTrue(Files.exists(tmp.resolve("out.v")),
+				"the HDL must be written");
+		Path pcf = tmp.resolve("out.pcf");
+		assertTrue(Files.exists(pcf),
+				"the constraint file must land next to the HDL");
+		String text = Files.readString(pcf, StandardCharsets.UTF_8);
+		assertTrue(text.contains("set_io led[1] 98"), text);
+		assertTrue(text.contains("set_io clk 21"), text);
+		assertFalse(Files.exists(tmp.resolve("out.pcf.tmp")),
+				"no temp file may survive");
+	}
+
+	@Test
+	void anUnbindablePortWritesNothingAtAll() throws Exception {
+
+		// led[1] is never bound: exit 1, an actionable error, and
+		// neither the HDL nor any (partial) constraint file on disk
+		writeFixture("sw[0] PMOD1", "sw[1] PMOD2", "clk CLK",
+				"led[0] LED1");
+		Result r = run("-export", "out.v", "-board", "icestick",
+				"-pins", "pins.txt", "blinky.jls");
+		assertEquals(1, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("jls: error:"), r.stderr);
+		assertTrue(r.stderr.contains("led[1]"), r.stderr);
+		assertFalse(Files.exists(tmp.resolve("out.pcf")),
+				"a partial constraint file must never reach disk");
+		assertFalse(Files.exists(tmp.resolve("out.v")),
+				"the HDL is withheld too - the export failed as a whole");
+		assertFalse(Files.exists(tmp.resolve("out.v.tmp")));
+		assertFalse(Files.exists(tmp.resolve("out.pcf.tmp")));
+	}
+
+	@Test
+	void aMalformedBindingsFileFailsWithItsLineNumber()
+			throws Exception {
+
+		writeFixture("sw[0] PMOD1 PMOD2");
+		Result r = run("-export", "out.v", "-board", "icestick",
+				"-pins", "pins.txt", "blinky.jls");
+		assertEquals(1, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("line 1"), r.stderr);
+		assertFalse(Files.exists(tmp.resolve("out.v")));
+		assertFalse(Files.exists(tmp.resolve("out.pcf")));
+	}
+
+	@Test
+	void boardWithoutPinsIsAUsageError() throws Exception {
+
+		writeFixture(goodBindings());
+		Result r = run("-export", "out.v", "-board", "icestick",
+				"blinky.jls");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("-board and -pins"), r.stderr);
+	}
+
+	@Test
+	void pinsWithoutExportIsAUsageError() throws Exception {
+
+		writeFixture(goodBindings());
+		Result r = run("-pins", "pins.txt", "blinky.jls");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("require -export"), r.stderr);
+	}
+
+	@Test
+	void anUnknownBoardNamesTheSupportedOnes() throws Exception {
+
+		writeFixture(goodBindings());
+		Result r = run("-export", "out.v", "-board", "basys3",
+				"-pins", "pins.txt", "blinky.jls");
+		assertEquals(2, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("icestick"),
+				"the supported boards must be listed: " + r.stderr);
+	}
+
+	@Test
+	void aMissingBindingsFileIsARuntimeError() throws Exception {
+
+		Files.writeString(tmp.resolve("blinky.jls"),
+				BoardFixtures.blinkyText(), StandardCharsets.UTF_8);
+		Result r = run("-export", "out.v", "-board", "icestick",
+				"-pins", "nosuch.txt", "blinky.jls");
+		assertEquals(1, r.exit, r.stderr);
+		assertTrue(r.stderr.contains("nosuch.txt"), r.stderr);
+		assertFalse(Files.exists(tmp.resolve("out.v")));
+	}
+}

--- a/test/jls/hdl/board/PcfGoldenTest.java
+++ b/test/jls/hdl/board/PcfGoldenTest.java
@@ -1,0 +1,94 @@
+package jls.hdl.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jls.JLSInfo;
+import jls.hdl.HdlExporter;
+import jls.hdl.HdlModel;
+
+/**
+ * Golden-file test of the PCF constraint emitter (issue #213): the
+ * blinky fixture bound to the iCEstick must render byte-for-byte to
+ * the committed golden in test/resources/hdl/board, the same regime as
+ * the Verilog/VHDL golden suites. The JLS version in the generated
+ * header is the only version-dependent text; the golden holds the
+ * token {@code @VERSION@} where it appears.
+ *
+ * <p>To regenerate after an intentional format change:
+ * {@code mvn test -Dtest=PcfGoldenTest -Djls.hdl.regenerate=true},
+ * then review the diff like source.</p>
+ */
+class PcfGoldenTest {
+
+	private static final Path GOLDEN_DIR =
+			Path.of("test", "resources", "hdl", "board");
+	private static final String VERSION_TOKEN = "@VERSION@";
+
+	/** The bindings that place blinky on the iCEstick. */
+	private static PinBindings blinkyBindings() throws Exception {
+		return PinBindings.parse(List.of(
+				"# blinky on the iCEstick: switches on the Pmod,",
+				"# LEDs on the board LEDs, clock on the 12 MHz oscillator",
+				"sw[0] PMOD1",
+				"sw[1] PMOD2",
+				"clk CLK",
+				"led[0] LED1",
+				"led[1] LED2"));
+	}
+
+	@Test
+	void icestickConstraintsMatchTheGolden() throws Exception {
+
+		Board board = Boards.byName("icestick");
+		assertNotNull(board, "icestick must be in the built-in table");
+		HdlModel model = HdlExporter.buildModel(BoardFixtures.blinky());
+		String pcf = PcfEmitter.emit(model, board, blinkyBindings());
+
+		String tokenized =
+				pcf.replace(JLSInfo.versionString, VERSION_TOKEN);
+		Path golden = GOLDEN_DIR.resolve("blinky_icestick.pcf");
+		if (Boolean.getBoolean("jls.hdl.regenerate")) {
+			Files.createDirectories(GOLDEN_DIR);
+			Files.writeString(golden, tokenized, StandardCharsets.UTF_8);
+		}
+		assertTrue(Files.isRegularFile(golden),
+				"missing golden " + golden + " (regenerate with"
+						+ " -Djls.hdl.regenerate=true and review the diff)");
+		String expected = Files.readString(golden, StandardCharsets.UTF_8);
+		assertEquals(expected, tokenized,
+				"PCF emission diverged from " + golden);
+	}
+
+	@Test
+	void emissionIsDeterministic() throws Exception {
+
+		Board board = Boards.byName("icestick");
+		assertNotNull(board);
+		// two independent walks of two independently loaded circuits
+		// must produce identical bytes (issue #213 requires the golden
+		// to be byte-deterministic, not merely stable within one run)
+		String first = PcfEmitter.emit(
+				HdlExporter.buildModel(BoardFixtures.blinky()), board,
+				blinkyBindings());
+		String second = PcfEmitter.emit(
+				HdlExporter.buildModel(BoardFixtures.blinky()), board,
+				blinkyBindings());
+		assertEquals(first, second);
+	}
+
+	@Test
+	void boardLookupIsCaseInsensitive() {
+
+		assertNotNull(Boards.byName("iCEstick"),
+				"-board matching is documented as case-insensitive");
+	}
+}

--- a/test/jls/hdl/board/UnbindablePortsTest.java
+++ b/test/jls/hdl/board/UnbindablePortsTest.java
@@ -1,0 +1,181 @@
+package jls.hdl.board;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jls.hdl.HdlExportException;
+import jls.hdl.HdlExporter;
+import jls.hdl.HdlModel;
+
+/**
+ * The fail-clean side of board-aware export (issue #213, prediction
+ * P3): a design whose ports cannot all be bound must fail with a
+ * specific, actionable message — and because {@link PcfEmitter#emit}
+ * throws instead of returning, a partial or invalid constraint file
+ * can never exist. Every binding problem in one attempt is reported in
+ * one exception, mirroring the exporter's all-offenders-at-once
+ * rejection style.
+ */
+class UnbindablePortsTest {
+
+	/** The blinky model (ports sw[1:0], clk, led[1:0]). */
+	private HdlModel model;
+	/** The iCEstick board. */
+	private Board board;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		model = HdlExporter.buildModel(BoardFixtures.blinky());
+		Board icestick = Boards.byName("icestick");
+		assertNotNull(icestick);
+		board = icestick;
+	}
+
+	/** Emit with the given binding lines, expecting a failure. */
+	private String failToEmit(String... lines) throws Exception {
+		PinBindings bindings = PinBindings.parse(List.of(lines));
+		HdlExportException e = assertThrows(HdlExportException.class,
+				() -> PcfEmitter.emit(model, board, bindings));
+		return e.getMessage();
+	}
+
+	@Test
+	void aMissingBindingNamesThePortAndTheRepair() throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk CLK", "led[0] LED1");
+		assertTrue(message.contains("\"led[1]\""), message);
+		assertTrue(message.contains("led[1] <pin>"),
+				"the message must show the exact line to add: " + message);
+	}
+
+	@Test
+	void anUnknownPinNameListsTheAvailablePins() throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk CLOCK",
+				"led[0] LED1", "led[1] LED2");
+		assertTrue(message.contains("\"CLOCK\""), message);
+		assertTrue(message.contains("available pins"), message);
+		assertTrue(message.contains("CLK"),
+				"the repair (the real pin name) must be visible: "
+						+ message);
+	}
+
+	@Test
+	void aBindingForANonexistentPortListsTheRealPorts()
+			throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk CLK",
+				"led[0] LED1", "led[1] LED2", "btn PMOD3");
+		assertTrue(message.contains("\"btn\""), message);
+		assertTrue(message.contains("the ports are"), message);
+		assertTrue(message.contains("led (2 bits, output)"), message);
+	}
+
+	@Test
+	void anIndexedBindingOnAOneBitPortSaysSo() throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk[0] CLK",
+				"led[0] LED1", "led[1] LED2");
+		assertTrue(message.contains("\"clk[0]\""), message);
+		assertTrue(message.contains("1 bit wide"), message);
+		assertTrue(message.contains("without an index"), message);
+	}
+
+	@Test
+	void anUnindexedBindingOnAWidePortSaysToBindEachBit()
+			throws Exception {
+
+		String message = failToEmit(
+				"sw PMOD1", "clk CLK", "led[0] LED1", "led[1] LED2");
+		assertTrue(message.contains("2 bits wide"), message);
+		assertTrue(message.contains("sw[0] <pin>"), message);
+		assertTrue(message.contains("sw[1] <pin>"), message);
+	}
+
+	@Test
+	void anOutOfRangeBitIndexShowsTheValidRange() throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "sw[2] PMOD3", "clk CLK",
+				"led[0] LED1", "led[1] LED2");
+		assertTrue(message.contains("\"sw[2]\""), message);
+		assertTrue(message.contains("has bits 0..1"), message);
+	}
+
+	@Test
+	void onePinBoundToTwoPortsNamesBothClaimants() throws Exception {
+
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD2", "clk CLK",
+				"led[0] LED1", "led[1] LED1");
+		assertTrue(message.contains("LED1"), message);
+		assertTrue(message.contains("\"led[0]\""), message);
+		assertTrue(message.contains("\"led[1]\""), message);
+	}
+
+	@Test
+	void everyProblemIsReportedInOneMessage() throws Exception {
+
+		// four distinct problems at once: unknown pin, missing binding
+		// (led[1]), unknown port, and a doubly-claimed pin must all
+		// surface in the single failure
+		String message = failToEmit(
+				"sw[0] PMOD1", "sw[1] PMOD1", "clk CLOCK",
+				"led[0] LED1", "btn PMOD3");
+		assertTrue(message.contains("\"CLOCK\""), message);
+		assertTrue(message.contains("\"led[1]\""), message);
+		assertTrue(message.contains("\"btn\""), message);
+		assertTrue(message.contains("PMOD1"), message);
+	}
+
+	@Test
+	void malformedBindingLinesAreAllReportedWithLineNumbers() {
+
+		HdlExportException e = assertThrows(HdlExportException.class,
+				() -> PinBindings.parse(List.of(
+						"# a comment line",
+						"sw[0]",
+						"",
+						"clk CLK extra")));
+		String message = e.getMessage();
+		assertTrue(message.contains("line 2"), message);
+		assertTrue(message.contains("line 4"), message);
+		assertTrue(message.contains("<port> <pin>"), message);
+	}
+
+	@Test
+	void aKeyBoundTwiceIsAParseError() {
+
+		HdlExportException e = assertThrows(HdlExportException.class,
+				() -> PinBindings.parse(List.of(
+						"clk CLK",
+						"clk LED1")));
+		String message = e.getMessage();
+		assertTrue(message.contains("line 2"), message);
+		assertTrue(message.contains("bound twice"), message);
+	}
+
+	@Test
+	void commentsAndBlankLinesAreIgnored() throws Exception {
+
+		PinBindings bindings = PinBindings.parse(List.of(
+				"# full-line comment",
+				"",
+				"   ",
+				"clk CLK # trailing comment"));
+		List<String> keys =
+				new ArrayList<String>(bindings.asMap().keySet());
+		assertTrue(keys.equals(List.of("clk")), keys.toString());
+	}
+}

--- a/test/jls/hdl/board/package-info.java
+++ b/test/jls/hdl/board/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Test suite for {@code jls.hdl.board}, the board-aware side of HDL
+ * export (issue #213): the built-in board table, the port-to-pin
+ * bindings parser, and the PCF constraint emitter. Correctness is
+ * pinned three ways: a byte-for-byte golden PCF for a small sequential
+ * circuit bound to the iCEstick ({@code test/resources/hdl/board}),
+ * unbindable-port tests proving every binding problem is reported
+ * together and no constraint text is produced (prediction P3 of #213),
+ * and end-to-end CLI tests of the {@code -board}/{@code -pins} export
+ * operands showing the constraint file lands next to the HDL on
+ * success and that a failed binding writes nothing at all. The shared
+ * fixture builds its circuit in the on-disk text format through the
+ * real loader, like the {@code jls.hdl} suite it extends.
+ */
+package jls.hdl.board;

--- a/test/resources/hdl/board/blinky_icestick.pcf
+++ b/test/resources/hdl/board/blinky_icestick.pcf
@@ -1,0 +1,14 @@
+# Board: icestick (Lattice iCE40-HX1K, TQ144 package)
+# Module: blinky, exported by JLS @VERSION@
+# Format: PCF, for the open iCE40 flow (yosys + nextpnr-ice40 --pcf)
+
+# input sw[0] <- pin PMOD1
+set_io sw[0] 78
+# input sw[1] <- pin PMOD2
+set_io sw[1] 79
+# input clk <- pin CLK
+set_io clk 21
+# output led[0] <- pin LED1
+set_io led[0] 99
+# output led[1] <- pin LED2
+set_io led[1] 98


### PR DESCRIPTION
Adds jls.hdl.board, the first slice of issue #213's board-aware
export: -export now takes -board <name> plus -pins <file> and writes
a pin-constraint file next to the HDL, generated from the same
HdlExporter.buildModel port walk the Verilog/VHDL emitters render.

- Board: a record of (name, fpga, constraint format, pin map) - just
  data, per H2; adding a board is a table entry, never new code. Pin
  names sort naturally (PMOD2 before PMOD10, digit runs compared
  numerically) so the unknown-pin error listing scans in the order a
  user expects.
- Boards: the built-in table, one entry so far - icestick (Lattice
  iCE40-HX1K, TQ144), 33 named pins (CLK, LED1-5, UART, IrDA, Pmod,
  J1/J3 headers) transcribed from the user guide/icestorm examples.
- PinBindings: parses the -pins file (one 'port pin' or
  'port[bit] pin' per line, # comments); every malformed line is
  reported together with its line number.
- PcfEmitter: walks model.ports() in model order, bits ascending,
  one set_io per port bit with a provenance comment; deterministic.
  Binding is all-or-nothing (P3): missing bindings, unknown
  ports/pins (valid names listed), wrong scalar/indexed form,
  out-of-range bits, and doubly-claimed pins are all collected into
  one HdlExportException and nothing is returned - combined with
  compute-both-texts-before-writing-either plus temp-and-rename in
  JLSStart, a partial constraint file can never reach disk.
- JLSStart: additive FlagSpec entries (-board validates its operand
  against the table at parse time; -board/-pins must travel as a
  pair and require -export), the export-branch wiring off the
  existing buildModel result, and a writeExportedText helper reusing
  the established temp-and-rename pattern. HdlExporter untouched.
- Tests: PcfGoldenTest (byte-deterministic golden at
  test/resources/hdl/board/blinky_icestick.pcf, @VERSION@-tokenized
  like the HDL goldens), UnbindablePortsTest (11 fail-clean cases,
  all-problems-in-one-message), CliBoardExportTest (subprocess:
  success writes out.v + out.pcf, unbindable ports exit 1 and write
  nothing at all, flag-pairing usage errors, unknown board lists the
  supported ones), BoardPinOrderTest (natural pin ordering, and that
  numerically-equal distinct names like A1/A01 stay distinct keys).
- Docs: supported-board table, bindings format, and handoff commands
  in docs/hdl-support-research.md section 7.5; CHANGELOG entry.

Predictions verified (#213 section 5): P1 - the CLI run above writes
a format-correct .pcf (golden-pinned). P3 - regression tests at unit
and CLI level. P2 - validated for real with the open flow, iCE40
variant: yosys 0.67 'synth_ice40' consumed the exported blinky.v and
nextpnr-ice40 0.10 (--hx1k --package tq144) placed and routed it
against the emitted blinky.pcf with no manual constraint edits,
producing a bitstream .asc; section 9 falsification check therefore
negative - nextpnr accepted the constraints, H1/H2 stand for the
iCEstick. Deferred to follow-ups: XDC/QSF, more boards (ECP5 needs
an LPF emitter), editor-side pin mapping, and all of #215.

mvn clean verify: 1133 tests, 0 failures, 0 errors (88 headless
display skips); the jacoco coverage-ratchet on package jls fails
identically on master under headless skips (master 0.508/0.495/0.544
vs floors 0.525/0.510/0.555, probed on a detached master worktree in
the earlier session) and this branch only raises those ratios, so
the failure is pre-existing, not introduced.

Advances #213 (XDC/QSF, more boards, and editor-side pin mapping
remain). #215 untouched by design.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
