### PR TITLE
Document VCD->GTKWave/Surfer handoff and add batch-CLI autograde bridge example (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ install onto, or if you already have a Java runtime (JDK/JRE 25 or newer):
 - **Command-line options:** `java -jar jls-<version>.jar -h` prints the full
   list, including batch mode (`-b`), test-input files (`-t`), simulation time
   limits (`-d`), VCD waveform export (`-vcd`, for GTKWave/Surfer and
-  autograders), image export (`-i`, PNG named after the circuit file by
+  autograders — worked recipe and example bridge in
+  [`docs/vcd-interop.md`](docs/vcd-interop.md)),
+  image export (`-i`, PNG named after the circuit file by
   default, or pass an output path such as `-i out.jpg` for JPEG or
   `-i out.svg` for resolution-independent SVG — the right format for
   slides, lab reports and hosted docs),
@@ -331,6 +333,9 @@ extension.
   triggering, tri-state/HiZ.
 - [docs/batch-interface.md](docs/batch-interface.md) — normative spec
   of the batch/grading interface: `-t` grammar, output format, VCD.
+- [docs/vcd-interop.md](docs/vcd-interop.md) — informative recipe for
+  consuming batch outputs: VCD → GTKWave/Surfer, and the autograde
+  bridge pattern with a runnable example.
 - [docs/file-format.md](docs/file-format.md) — normative spec of the
   `.jls` save format: containers, grammar, element tags, versioning.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to build, test, and submit

--- a/docs/batch-interface.md
+++ b/docs/batch-interface.md
@@ -214,6 +214,8 @@ and standard VCD parsers. Emitter: `BatchSimulator.toVcd` /
 `BatchSimulator.writeVcd` (`src/jls/sim/BatchSimulator.java`). The
 output is deterministic: two identical runs produce identical bytes,
 and the golden tests compare byte-for-byte.
+(A step-by-step viewer/autograder recipe — informative, not part of
+this contract — is in [`vcd-interop.md`](vcd-interop.md).)
 
 ### 4.1 Signal set
 

--- a/docs/vcd-interop.md
+++ b/docs/vcd-interop.md
@@ -1,0 +1,118 @@
+# VCD Interop: Waveform Viewers and Autograding
+
+**Status: informative guide** (issue #216). The normative contract —
+the `-t` grammar, the stdout report format, and the VCD profile — lives
+in [`batch-interface.md`](batch-interface.md); nothing here adds to or
+changes it. This page is the worked recipe: produce a VCD from a batch
+run, open it in GTKWave or Surfer, and build an autograder on the batch
+CLI.
+
+## What JLS offers (and what it does not)
+
+- **Offered:** a conformant waveform export — `-vcd` writes IEEE
+  1364-2001 section 18 VCD, deterministic byte-for-byte and verified in
+  CI by a spec-derived parser (`test/jls/VcdExportGoldenTest.java`) —
+  plus a **stable batch contract** for stdout, exit codes, and the VCD
+  profile ([`batch-interface.md`](batch-interface.md), a documented
+  stability promise).
+- **Not offered: live co-simulation.** JLS runs a batch simulation to
+  completion; external tools consume the finished outputs. A live
+  co-simulation transport (cocotb/VPI/DPI style, an external testbench
+  stepping JLS interactively) was evaluated and **rejected** — see
+  issue [#63](https://github.com/anadon/JLS/issues/63). Graders must
+  not depend on interacting with a running simulation.
+
+## 1. Produce a VCD from a batch run
+
+Any circuit with at least one **watched** element (or probed net, see
+[`batch-interface.md`](batch-interface.md) 4.1) works. This recipe uses
+the committed fixture `test/fixtures/fork-4.6-shiftregister.jls`
+(three barrel shifters computing 181 shifted by 2 into watched pins
+`ll`, `lr`, `ar`).
+
+JLS requires the circuit file's name (minus `.jls`) to start with a
+letter and contain only letters, digits, and underscores, so copy the
+hyphenated fixture under a conforming name first:
+
+```sh
+cp test/fixtures/fork-4.6-shiftregister.jls shiftdemo.jls
+jls -b -vcd out.vcd shiftdemo.jls
+```
+
+(No installed `jls`? `java -jar jls-<version>.jar -b -vcd out.vcd
+shiftdemo.jls` and the `ghcr.io/anadon/jls` container are equivalent —
+see the README.)
+
+Exit status 0, and stdout reports the watched pins per the contract:
+
+```
+Simulation: No More Activity at 25
+Output Pin ar: 0xED (237 unsigned, -19 signed)
+Output Pin ll: 0xD4 (212 unsigned, -44 signed)
+Output Pin lr: 0x2D (45 unsigned, 45 signed)
+```
+
+`out.vcd` now holds the value-change history of every watched signal.
+For clocked circuits add `-d limit` (simulation time cap) and `-t
+vectors.txt` (input stimulus); to watch elements without editing the
+circuit, use a `-s` parameter file with `ELEMENT <name> WATCHED true`.
+
+## 2. Open the waveform in GTKWave
+
+```sh
+gtkwave out.vcd
+```
+
+In the left-hand SST (Signal Search Tree) pane, click the `shiftdemo`
+scope; the signals `ar[7:0]`, `ll[7:0]`, `lr[7:0]` appear in the pane
+below it. Select them and press **Append** (or **Insert**) to add them
+to the wave view, then **Time → Zoom → Zoom Best Fit** to frame the
+run. One VCD time unit is one JLS simulation time unit (the `1 ns`
+timescale is nominal, [`batch-interface.md`](batch-interface.md) 4.2).
+
+## 3. Open the waveform in Surfer
+
+```sh
+surfer out.vcd
+```
+
+Surfer loads the file directly: expand the `shiftdemo` scope in the
+sidebar and click each signal to add it to the view. (Without a local
+install, <https://app.surfer-project.org> opens the same VCD in the
+browser.) Multi-bit signals default to hex display; right-click a
+signal to switch to unsigned/signed decimal or binary.
+
+## 4. Autograde over the batch CLI
+
+The supported grading pattern is a plain subprocess bridge:
+
+1. run `jls -b [-t vectors.txt] [-d limit] [-s params.txt] -vcd out.vcd
+   circuit.jls`;
+2. treat the **exit status** as the failure signal
+   ([`batch-interface.md`](batch-interface.md) 1);
+3. grade either or both stable surfaces: the watched-element **stdout
+   report** (sections 3.2–3.4) and the **VCD** (section 4 — final
+   values, or full timing if the grade depends on *when* signals
+   change).
+
+A runnable example lives at
+[`examples/autograde/autograde.py`](../examples/autograde/autograde.py):
+it runs the batch CLI on the fixture above, parses the emitted VCD with
+a dependency-free parser, and asserts the expected `ll`/`lr`/`ar`
+values against both surfaces. Run it as
+
+```sh
+python3 examples/autograde/autograde.py                # jls from PATH
+python3 examples/autograde/autograde.py -- java -jar jls-<version>.jar
+```
+
+CI keeps the bridge green against the fixture on every push
+(`test/jls/AutogradeBridgeExampleTest.java`, which skips when `python3`
+is absent).
+
+The example is deliberately **not co-simulation** (issue
+[#63](https://github.com/anadon/JLS/issues/63)): it never talks to a
+running simulation. If your grader needs a signal the VCD cannot show
+(an unwatchable internal net, say), that is a batch-observability gap
+owned by issue [#200](https://github.com/anadon/JLS/issues/200) — file
+it there rather than working around it with GUI automation.

--- a/examples/autograde/autograde.py
+++ b/examples/autograde/autograde.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Example autograde bridge over the JLS batch CLI (issue #216).
+
+This script demonstrates the supported grading pattern documented in
+docs/vcd-interop.md: run ``jls -b -vcd out.vcd circuit.jls`` as a
+subprocess, then grade two stable surfaces of the run:
+
+  1. the watched-element stdout report (docs/batch-interface.md
+     section 3 -- a documented stability contract), and
+  2. the emitted IEEE 1364-2001 section 18 VCD waveform
+     (docs/batch-interface.md section 4), parsed here with a
+     deliberately minimal, dependency-free parser.
+
+This is **not co-simulation**: JLS runs to completion on its own and
+this script inspects the finished outputs. A live co-simulation
+transport (cocotb/VPI/DPI style, stepping JLS from an external
+testbench) was evaluated and rejected -- see issue #63. Do not build
+graders that expect to interact with a running JLS simulation.
+
+Usage:
+
+    python3 examples/autograde/autograde.py
+        (runs the ``jls`` command found on PATH)
+
+    python3 examples/autograde/autograde.py -- <jls command tokens...>
+        (e.g. ``-- java -jar jls-5.0.5.jar`` or, as the CI test
+        test/jls/AutogradeBridgeExampleTest.java does,
+        ``-- java -cp <classpath> jls.JLS``)
+
+The graded fixture is test/fixtures/fork-4.6-shiftregister.jls: three
+combinational barrel shifters computing 181 shifted by 2, with watched
+output pins ll (logical left), lr (logical right) and ar (arithmetic
+right). Exit status: 0 when every check passes, 1 on a grading
+failure, 2 on a usage/setup error.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Expected final values of the watched pins (the same oracle values
+# test/jls/ShiftRegisterTest.java pins): 181 = 0b10110101, shifted by 2.
+EXPECTED_FINALS = {
+    "ll": 0b11010100,  # logical left
+    "lr": 0b00101101,  # logical right
+    "ar": 0b11101101,  # arithmetic right (sign fill)
+}
+
+# The stdout report is a stability contract (batch-interface.md 3.2/3.4):
+# "Output Pin <name>: 0xH (U unsigned, S signed)" in name order.
+EXPECTED_STDOUT_LINES = [
+    "Output Pin ar: 0xED (237 unsigned, -19 signed)",
+    "Output Pin ll: 0xD4 (212 unsigned, -44 signed)",
+    "Output Pin lr: 0x2D (45 unsigned, 45 signed)",
+]
+
+
+def jls_command(argv):
+    """The JLS command tokens: everything after ``--``, default ``jls``."""
+    if "--" in argv:
+        tokens = argv[argv.index("--") + 1:]
+        if tokens:
+            return tokens
+    if argv and argv[0] in ("-h", "--help"):
+        print(__doc__)
+        raise SystemExit(0)
+    if argv:
+        print("usage: autograde.py [-- <jls command tokens...>]",
+              file=sys.stderr)
+        raise SystemExit(2)
+    return ["jls"]
+
+
+def parse_vcd_final_values(text):
+    """Final value of every signal in a JLS batch VCD, by signal name.
+
+    Minimal parser for the profile batch-interface.md section 4
+    specifies: ``$var`` declarations name the signals, then ``#<time>``
+    stamps interleave scalar changes (``0!``, ``1!``, ``z!``) and
+    vector changes (``b101101 #``). The last change per identifier
+    code wins. Values made only of 0/1 come back as ints; anything
+    containing HiZ stays a string (JLS never emits 'x').
+    """
+    names = {}   # identifier code -> declared signal name
+    finals = {}  # identifier code -> last value string
+    in_header = True
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if in_header:
+            if line.startswith("$var"):
+                # $var wire <bits> <code> <name> [msb:0] $end
+                parts = line.split()
+                names[parts[3]] = parts[4]
+            elif line.startswith("$enddefinitions"):
+                in_header = False
+            continue
+        if line.startswith("#") or line.startswith("$"):
+            continue  # timestamp, or $dumpvars/$end block markers
+        if line[0] in "bB":
+            value, code = line[1:].split()
+            finals[code] = value
+        else:
+            finals[line[1:]] = line[0]
+    result = {}
+    for code, value in finals.items():
+        name = names.get(code, code)
+        result[name] = int(value, 2) if set(value) <= {"0", "1"} else value
+    return result
+
+
+def main():
+    jls = jls_command(sys.argv[1:])
+    repo_root = Path(__file__).resolve().parents[2]
+    fixture = repo_root / "test" / "fixtures" / "fork-4.6-shiftregister.jls"
+    if not fixture.is_file():
+        print(f"FAIL (setup): fixture not found: {fixture}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # JLS requires the circuit file name (minus .jls) to start with
+        # a letter and contain only letters, digits and underscores, so
+        # copy the hyphenated fixture under a conforming name.
+        circuit = Path(tmp) / "shiftdemo.jls"
+        shutil.copyfile(fixture, circuit)
+        vcd_file = Path(tmp) / "out.vcd"
+
+        cmd = jls + ["-b", "-vcd", str(vcd_file), str(circuit)]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True,
+                                  timeout=120)
+        except FileNotFoundError:
+            print(f"FAIL (setup): cannot run {cmd[0]!r}; pass the JLS "
+                  "command after '--'", file=sys.stderr)
+            return 2
+
+        # Exit status is the failure signal (batch-interface.md 1).
+        if proc.returncode != 0:
+            print(f"FAIL: jls exited {proc.returncode}\n"
+                  f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+                  file=sys.stderr)
+            return 1
+
+        failures = []
+
+        # Surface 1: the watched-element stdout report.
+        for line in EXPECTED_STDOUT_LINES:
+            if line not in proc.stdout:
+                failures.append(f"stdout is missing {line!r}")
+
+        # Surface 2: final signal values from the VCD waveform.
+        finals = parse_vcd_final_values(vcd_file.read_text())
+        for name, want in sorted(EXPECTED_FINALS.items()):
+            got = finals.get(name)
+            if got != want:
+                failures.append(f"VCD signal {name}: expected {want!r}, "
+                                f"got {got!r}")
+
+        if failures:
+            print("FAIL:", file=sys.stderr)
+            for f in failures:
+                print(f"  - {f}", file=sys.stderr)
+            print(f"jls stdout was:\n{proc.stdout}", file=sys.stderr)
+            return 1
+
+    print("PASS: batch stdout and VCD final values match the oracle "
+          f"({', '.join(sorted(EXPECTED_FINALS))})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/jls/AutogradeBridgeExampleTest.java
+++ b/test/jls/AutogradeBridgeExampleTest.java
@@ -1,0 +1,99 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CI wiring for the example autograde bridge (issue #216):
+ * {@code examples/autograde/autograde.py} must grade the committed
+ * shift-register fixture green over the real batch CLI, exactly as
+ * docs/vcd-interop.md tells an instructor to run it. The bridge is a
+ * consume-the-outputs harness -- run {@code jls -b -vcd}, parse the
+ * stdout report and the VCD -- and deliberately not co-simulation
+ * (issue #63 rejected a live transport).
+ *
+ * <p>Toolchain gating follows the {@link jls.hdl.IverilogCompileTest}
+ * pattern: without {@code python3} on PATH the test SKIPS via a JUnit
+ * assumption, so the suite stays green on machines without Python;
+ * CI's Ubuntu runners have python3 and arm it.
+ */
+class AutogradeBridgeExampleTest {
+
+	@Test
+	void bridgeExampleGradesTheFixtureGreen() throws Exception {
+		String python = findOnPath("python3");
+		Assumptions.assumeTrue(python != null,
+				"python3 not installed; skipping autograde bridge example");
+
+		Path script = Path.of("examples", "autograde", "autograde.py");
+		assertTrue(Files.isRegularFile(script),
+				"example bridge missing: " + script);
+
+		String java = System.getProperty("java.home")
+				+ File.separator + "bin" + File.separator + "java";
+		List<String> cmd = new ArrayList<String>();
+		cmd.add(python);
+		cmd.add(script.toAbsolutePath().toString());
+		// everything after -- is the JLS command the bridge drives:
+		// this JVM's java + classpath, as the CLI suites spawn it
+		cmd.add("--");
+		cmd.add(java);
+		cmd.addAll(jls.CoverageAgent.jvmArgs());
+		cmd.add("-Djava.awt.headless=true");
+		cmd.add("-cp");
+		cmd.add(System.getProperty("java.class.path"));
+		cmd.add("jls.JLS");
+
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.redirectErrorStream(true);
+		pb.environment().remove("JAVA_TOOL_OPTIONS");
+		Process p = pb.start();
+		p.getOutputStream().close();
+		String output = new String(p.getInputStream().readAllBytes(),
+				StandardCharsets.UTF_8);
+		if (!p.waitFor(180, TimeUnit.SECONDS)) {
+			p.destroyForcibly();
+			throw new AssertionError("autograde bridge timed out:\n"
+					+ output);
+		}
+		assertEquals(0, p.exitValue(),
+				"autograde bridge failed:\n" + output);
+		assertTrue(output.contains("PASS"),
+				"bridge exited 0 without reporting PASS:\n" + output);
+	}
+
+	/** Locate a tool on PATH, or null (never installs anything). */
+	private static String findOnPath(String tool) {
+		String path = System.getenv("PATH");
+		if (path == null) {
+			return null;
+		}
+		for (String dir : path.split(File.pathSeparator)) {
+			if (dir.isEmpty()) {
+				continue;
+			}
+			Path candidate = Path.of(dir, tool);
+			try {
+				if (Files.isExecutable(candidate)
+						&& !Files.isDirectory(candidate)) {
+					return candidate.toString();
+				}
+			} catch (SecurityException ignored) {
+				// unreadable PATH entry: keep looking
+			}
+		}
+		return null;
+	}
+
+} // end of AutogradeBridgeExampleTest class


### PR DESCRIPTION
Issue #216 option (a): the VCD is already IEEE 1364-2001 section 18
conformant and CI-verified, and live co-simulation was rejected under
issue #63 -- what was missing is a followable downstream recipe and a
worked autograde bridge. This adds exactly that, with no change to the
VCD format or the batch contract:

- docs/vcd-interop.md: informative recipe -- produce a VCD with
  `jls -b -vcd` on the committed shift-register fixture (including the
  circuit-file-name rule that forces a rename of the hyphenated
  fixture), open it in GTKWave and Surfer with exact commands, and the
  autograde pattern over the batch CLI. States explicitly that JLS
  offers a conformant VCD plus a stable batch contract but NOT live
  co-simulation (#63), and routes observability gaps to #200.
- examples/autograde/autograde.py: runnable, dependency-free example
  bridge. Runs the batch CLI on test/fixtures/fork-4.6-shiftregister.jls
  and grades both stable surfaces: the watched-element stdout report
  (batch-interface.md section 3) and the emitted VCD (section 4),
  parsed by a minimal parser, against the same ll/lr/ar oracle values
  ShiftRegisterTest pins. Labelled not-co-sim in the docstring.
- test/jls/AutogradeBridgeExampleTest.java: CI wiring. Spawns the
  bridge with python3 against this JVM's java+classpath (the
  CliSmokeTest spawning idiom, coverage agent propagated) and skips
  via JUnit assumption when python3 is absent (the IverilogCompileTest
  toolchain-gating pattern); CI's runners have python3 and arm it.
- README.md: cross-links the recipe from the -vcd flag description and
  the Documentation list.
- docs/batch-interface.md: a single informative cross-link sentence in
  section 4 -- no contract change.

Verified: the bridge passes end-to-end against a locally built CLI
(PASS on both surfaces); AutogradeBridgeExampleTest, VcdExportGoldenTest,
CliSmokeTest, ArchitectureRulesTest, NullMarkedRatchetTest,
PackageInfoRatchetTest, CliFlagTableTest and spotless:check all green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPzW7ZT6hViZC6fjUndEFY


🤖 Generated with [Claude Code](https://claude.com/claude-code)
