### PR TITLE
Repair master test compile after the #238/#244 semantic merge conflict

### DIFF
--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -186,7 +186,9 @@ class MemoryModelTest {
 	@Test
 	void timingContractResetsToTheDefaultAccessTime() {
 		Memory mem = newMemory();
-		assertTrue(mem.hasTiming());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Timed,
+				"memory carries a timing contract");
 		assertTrue(mem.usesAccessTime(),
 				"memory is the one element with an access time");
 		assertEquals(100, mem.getDelay(), "documented default access time");
@@ -199,8 +201,11 @@ class MemoryModelTest {
 	@Test
 	void watchAndChangeContract() {
 		Memory mem = newMemory();
-		assertTrue(mem.canWatch());
-		assertTrue(mem.canChange());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Watchable,
+				"memory values can be watched");
+		assertTrue(asElement instanceof Editable,
+				"memory attributes can be edited");
 		assertFalse(mem.isWatched());
 		mem.setWatched(true);
 		assertTrue(mem.isWatched());

--- a/test/jls/elem/RegisterModelTest.java
+++ b/test/jls/elem/RegisterModelTest.java
@@ -124,7 +124,9 @@ class RegisterModelTest {
 	@Test
 	void timingContractResetsToTheDefaultDelay() {
 		Register reg = newRegister();
-		assertTrue(reg.hasTiming());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Timed,
+				"registers carry a timing contract");
 		assertEquals(50, reg.getDelay(), "documented default delay");
 		reg.setDelay(75);
 		assertEquals(75, reg.getDelay());
@@ -136,8 +138,11 @@ class RegisterModelTest {
 	void capabilityContract() {
 		Register reg = newRegister();
 		assertFalse(reg.canCopy(), "registers are named, so not copyable");
-		assertTrue(reg.canChange());
-		assertTrue(reg.canWatch());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Editable,
+				"register attributes can be edited");
+		assertTrue(asElement instanceof Watchable,
+				"register values can be watched");
 		assertFalse(reg.isWatched());
 		reg.setWatched(true);
 		assertTrue(reg.isWatched());
@@ -346,11 +351,12 @@ class RegisterModelTest {
 
 		@Override
 		public void post(jls.sim.SimEvent event) {
-			// only the register's own output-driving posts (non-null
-			// todo): input-change notifications also name the register
-			// as callback but carry a null todo
+			// only the register's own output-driving posts (NewValue):
+			// input-change notifications also name the register as
+			// callback but carry a PinChanged payload
 			if (event.getCallBack() instanceof Register
-					&& event.getTodo() != null) {
+					&& event.getTodo()
+							instanceof jls.sim.SimEvent.NewValue) {
 				registerPosts += 1;
 			}
 			super.post(event);

--- a/test/jls/elem/SubCircuitModelTest.java
+++ b/test/jls/elem/SubCircuitModelTest.java
@@ -150,7 +150,9 @@ class SubCircuitModelTest {
 	@Test
 	void canChangeAndDelayResetAreDelegatedSafely() {
 		SubCircuit sub = loneSub();
-		assertTrue(sub.canChange());
+		Element asElement = sub;
+		assertTrue(asElement instanceof Editable,
+				"subcircuits can be edited");
 		// the passthrough inner circuit has no timed elements; the
 		// delegation must still walk it without faulting
 		sub.resetPropDelay();


### PR DESCRIPTION
PRs #238 (capability interfaces) and #244 (model-coverage suites) were
each green against pre-merge master but conflict semantically: #238
deleted the boolean capability stubs (hasTiming/canWatch/canChange)
that #244's new model suites call, and #237's sealed SimEvent payloads
broke RegisterModelTest's counting simulator, which relied on the old
null-todo convention to tell pin-change notifications apart from
output posts. Master has failed test-compile since the #244 merge
(334827d); CI on master is red.

- Replace the deleted predicate calls with the instanceof
  Timed/Watchable/Editable idiom (widened to Element, matching
  CapabilityInterfaceTest).
- Count register output posts by payload type (NewValue) instead of
  todo != null.

Test-only change; all 52 model-suite tests pass headless.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
