### PR TITLE
Generate the editor palette from a PaletteEntry table (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Added
+- The editor palette is now generated from a declarative table (#78):
+  `jls.edit.PaletteEntry` (icon, fallback text, tooltip, toolbar
+  group, help topic per element — the GUI half of the two-layer
+  descriptor split whose core half is `jls.elem.ElementType`) and
+  `jls.edit.Palette` (all 30 entries in the 8 historical toolbar
+  groups, each group carrying its grid shape).
+  `SimpleEditor.makeElements` builds the toolbar and "elements" menu
+  from the table, so adding an element to the palette is one registry
+  row plus one palette row instead of a hand-rolled button block, and
+  the new headless `PaletteContractTest` makes a registered element
+  type without a palette row — or with a missing icon, duplicate
+  tooltip, blank help topic, or overfull group grid — a build
+  failure. The toolbar the user sees is unchanged (the Import button
+  stays hand-coded; `SubCircuit`, `WireEnd`, and `TestGen` are the
+  documented non-palette types).
 - Board-aware HDL export, first slice (#213): `-export` now accepts
   `-board <name>` plus `-pins <file>` and writes a pin-constraint file
   (`.pcf`) next to the exported HDL, generated from the same model walk

--- a/src/jls/edit/Palette.java
+++ b/src/jls/edit/Palette.java
@@ -1,0 +1,260 @@
+package jls.edit;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jls.elem.ElementRegistry;
+import jls.elem.ElementType;
+
+/**
+ * The static, ordered palette table (issue #78): every element a user
+ * can create from the editor toolbar and "elements" menu, one
+ * {@link PaletteEntry} per type, grouped exactly the way the historical
+ * hand-coded toolbar grouped them. {@code SimpleEditor.makeElements}
+ * generates the toolbar from this table, so adding an element to the
+ * palette is one row here instead of a hand-rolled button block - and
+ * the authoring contract ({@code PaletteContractTest}) makes a
+ * registered element type without a palette row a build failure.
+ *
+ * The only toolbar control not in this table is the Import button: it
+ * shows the menu of open subcircuits instead of placing a registered
+ * element type, so it stays hand-coded in
+ * {@code SimpleEditor.makeElements} (and {@code SubCircuit} is a
+ * documented non-palette type, along with the never-placed
+ * {@code WireEnd} and the batch-only {@code TestGen}).
+ */
+public final class Palette {
+
+	/**
+	 * One toolbar group: a run of consecutive palette entries rendered
+	 * as a {@code GridLayout} panel of the declared shape, in the order
+	 * the groups appear on the toolbar. The standalone group's buttons
+	 * sit directly on the toolbar with no panel around them, preserving
+	 * the historical layout of the lone annotation-text button.
+	 */
+	public enum Group {
+
+		/** Logic gates, from AND through the tri-state gate. */
+		GATES(2, 4, false),
+
+		/** Wiring aids: named wires, pins, bundling, constants. */
+		WIRE_WORKS(2, 4, false),
+
+		/** Storage elements: register and memory. */
+		MEMORY(2, 1, false),
+
+		/** Combinational building blocks and the clock. */
+		COMBINATIONAL(2, 3, false),
+
+		/** Simulator control: pause and stop. */
+		TIMING(2, 1, false),
+
+		/** Test and observation: signal generator and display. */
+		TEST(2, 1, false),
+
+		/** Complex, dialog-driven elements. */
+		COMPLEX(2, 1, false),
+
+		/** The standalone annotation-text button. */
+		ANNOTATION(1, 1, true);
+
+		/** Rows of the group's GridLayout panel. */
+		private final int rows;
+
+		/** Columns of the group's GridLayout panel. */
+		private final int cols;
+
+		/** True if the group's buttons sit directly on the toolbar. */
+		private final boolean standalone;
+
+		/**
+		 * Create a group.
+		 *
+		 * @param rows Rows of the group's GridLayout panel.
+		 * @param cols Columns of the group's GridLayout panel.
+		 * @param standalone True if the group's buttons sit directly on
+		 *            the toolbar instead of inside a panel.
+		 */
+		Group(int rows, int cols, boolean standalone) {
+
+			this.rows = rows;
+			this.cols = cols;
+			this.standalone = standalone;
+		} // end of constructor
+
+		/**
+		 * Rows of the group's GridLayout panel.
+		 *
+		 * @return the row count.
+		 */
+		public int rows() {
+
+			return rows;
+		} // end of rows method
+
+		/**
+		 * Columns of the group's GridLayout panel.
+		 *
+		 * @return the column count.
+		 */
+		public int cols() {
+
+			return cols;
+		} // end of cols method
+
+		/**
+		 * Whether the group's buttons sit directly on the toolbar.
+		 *
+		 * @return true for the standalone group, false for panel groups.
+		 */
+		public boolean standalone() {
+
+			return standalone;
+		} // end of standalone method
+
+	} // end of Group enum
+
+	/**
+	 * Every palette entry, in exact toolbar order (left to right, and
+	 * within a group in GridLayout fill order: across the top row, then
+	 * across the bottom row). Entries of one group are consecutive.
+	 */
+	private static final List<PaletteEntry> ENTRIES = List.of(
+			entry(Group.GATES, "AndGate", "and", "AND",
+					"AND gate", "AND"),
+			entry(Group.GATES, "OrGate", "or", "OR",
+					"OR gate", "OR"),
+			entry(Group.GATES, "NotGate", "not", "NOT",
+					"NOT gate", "NOT"),
+			entry(Group.GATES, "XorGate", "xor", "XOR",
+					"exclusive OR gate", "XOR"),
+			entry(Group.GATES, "NandGate", "nand", "NAND",
+					"NAND gate", "NAND"),
+			entry(Group.GATES, "NorGate", "nor", "NOR",
+					"NOR gate", "NOR"),
+			entry(Group.GATES, "DelayGate", "delay", "DELAY",
+					"user defined signal delay", "DELAY"),
+			entry(Group.GATES, "TriState", "tristate", "TriState",
+					"tri-state gate", "TRISTATE"),
+			entry(Group.WIRE_WORKS, "JumpStart", "jumpstart", "START",
+					"name a wire", "start"),
+			entry(Group.WIRE_WORKS, "JumpEnd", "jumpend", "END",
+					"connect to a named wire", "end"),
+			entry(Group.WIRE_WORKS, "InputPin", "ipin", "I-PIN",
+					"input pin", "Input"),
+			entry(Group.WIRE_WORKS, "OutputPin", "opin", "O-PIN",
+					"output pin", "Output"),
+			entry(Group.WIRE_WORKS, "Splitter", "split", "SPLIT",
+					"unbundle wires", "unbundle"),
+			entry(Group.WIRE_WORKS, "Binder", "bind", "BIND",
+					"bundle wires", "bundle"),
+			entry(Group.WIRE_WORKS, "Constant", "const", "CONST",
+					"constant value", "const"),
+			entry(Group.WIRE_WORKS, "Extend", "extend", "1-to-N",
+					"make N copies of the input", "extend"),
+			entry(Group.MEMORY, "Register", "register", "REG",
+					"register (various triggering)", "register"),
+			entry(Group.MEMORY, "Memory", "memory", "MEMORY",
+					"memory, various types", "memory"),
+			entry(Group.COMBINATIONAL, "Mux", "mux", "MUX",
+					"multiplexor", "mux"),
+			entry(Group.COMBINATIONAL, "Decoder", "decoder", "DEC",
+					"decoder", "decoder"),
+			entry(Group.COMBINATIONAL, "ShiftRegister", "shiftregister",
+					"SHIFT", "shift register (combinational shifter)",
+					"shiftregister"),
+			entry(Group.COMBINATIONAL, "Adder", "adder", "ADDER",
+					"adder", "adder"),
+			entry(Group.COMBINATIONAL, "Clock", "clock", "CLOCK",
+					"clock", "clock"),
+			entry(Group.TIMING, "Pause", "pause", "PAUSE",
+					"pause simulator when asserted", "pause"),
+			entry(Group.TIMING, "Stop", "stop", "STOP",
+					"stop simulator when asserted", "stop"),
+			entry(Group.TEST, "SigGen", "siggen", "SIGGEN",
+					"generate test signals", "siggen"),
+			entry(Group.TEST, "Display", "display", "DISPLAY",
+					"display circuit value", "display"),
+			entry(Group.COMPLEX, "StateMachine", "statemachine",
+					"ST. MAC.", "state machine", "stmach"),
+			entry(Group.COMPLEX, "TruthTable", "truth", "Truth Table",
+					"truth table", "truth"),
+			entry(Group.ANNOTATION, "Text", "text", "TEXT",
+					"text (for annotations)", "text"));
+
+	/** The groups in toolbar order. */
+	private static final List<Group> GROUPS = List.of(Group.values());
+
+	/**
+	 * This class is a static table; it is never instantiated.
+	 */
+	private Palette() {
+
+	} // end of constructor
+
+	/**
+	 * Build one palette entry, resolving its tag through the
+	 * {@link ElementRegistry} so a palette row naming an unregistered
+	 * element tag fails at class-initialization time (the same guard the
+	 * hand-coded toolbar's slug lookup used to apply per button).
+	 *
+	 * @param group The toolbar group the entry belongs to.
+	 * @param tag The canonical registry tag of the element type.
+	 * @param iconName Base name of the icon gif.
+	 * @param fallbackText Button text shown when the icon is missing.
+	 * @param tooltip The tooltip and accessible display name.
+	 * @param helpTopic The {@code Map.jhm} topic documenting the element.
+	 * @return the new entry.
+	 */
+	private static PaletteEntry entry(Group group, String tag,
+			String iconName, String fallbackText, String tooltip,
+			String helpTopic) {
+
+		ElementType type = ElementRegistry.forTag(tag);
+		if (type == null) {
+			throw new IllegalStateException(
+					"palette entry names unregistered element tag " + tag);
+		}
+		return new PaletteEntry(type, group, iconName, fallbackText,
+				tooltip, helpTopic);
+	} // end of entry method
+
+	/**
+	 * Every palette entry, in exact toolbar order.
+	 *
+	 * @return the entries, unmodifiable.
+	 */
+	public static List<PaletteEntry> entries() {
+
+		return ENTRIES;
+	} // end of entries method
+
+	/**
+	 * The toolbar groups, in toolbar order.
+	 *
+	 * @return the groups, unmodifiable.
+	 */
+	public static List<Group> groups() {
+
+		return GROUPS;
+	} // end of groups method
+
+	/**
+	 * The palette entries of one group, in toolbar order.
+	 *
+	 * @param group The group to select.
+	 * @return that group's entries, unmodifiable.
+	 */
+	public static List<PaletteEntry> entries(Group group) {
+
+		List<PaletteEntry> selected = new ArrayList<>();
+		for (PaletteEntry entry : ENTRIES) {
+			if (entry.group() == group) {
+				selected.add(entry);
+			}
+		}
+		return Collections.unmodifiableList(selected);
+	} // end of entries method
+
+} // end of Palette class

--- a/src/jls/edit/PaletteEntry.java
+++ b/src/jls/edit/PaletteEntry.java
@@ -1,0 +1,160 @@
+package jls.edit;
+
+import jls.elem.ElementType;
+
+/**
+ * The GUI-side descriptor for one editor palette element (issue #78):
+ * the second half of the two-layer element descriptor split. The core
+ * half, {@link ElementType}, carries what loading, saving, and headless
+ * tooling need (tag, aliases, class, factory) and lives in
+ * {@code jls.elem}; this class carries only what the editor palette
+ * needs to present that type - the icon resource, the fallback button
+ * text shown when the icon is missing, the tooltip/display name, the
+ * toolbar group, and the help topic - and never leaks into the core.
+ *
+ * A palette entry deliberately carries no capability set: capabilities
+ * are the {@code instanceof} interfaces ({@code Rotatable},
+ * {@code Editable}, ...) pinned by {@code CapabilityInterfaceTest}, and
+ * duplicating them here would reintroduce the drift the interfaces
+ * removed.
+ *
+ * All entries live in the static {@link Palette} table, whose authoring
+ * contract ({@code PaletteContractTest}) enforces that the table stays
+ * total over the registered element types and that every icon, tooltip,
+ * and help topic is real.
+ */
+public final class PaletteEntry {
+
+	/** The core descriptor of the element type this entry creates. */
+	private final ElementType type;
+
+	/** The toolbar group this entry belongs to. */
+	private final Palette.Group group;
+
+	/** Base name of the icon (a gif in {@code jls/edit/images/}). */
+	private final String iconName;
+
+	/** Button text shown when the icon resource is missing. */
+	private final String fallbackText;
+
+	/** The tooltip, which is also the accessible display name. */
+	private final String tooltip;
+
+	/** The {@code Map.jhm} topic documenting this element. */
+	private final String helpTopic;
+
+	/**
+	 * Create a descriptor for one palette element. Package-private: the
+	 * {@link Palette} table is the only author of entries.
+	 *
+	 * @param type The core descriptor of the element type the entry
+	 *            creates.
+	 * @param group The toolbar group the entry belongs to.
+	 * @param iconName Base name of the icon gif in
+	 *            {@code jls/edit/images/}; must be non-blank.
+	 * @param fallbackText Button text shown when the icon resource is
+	 *            missing; must be non-blank.
+	 * @param tooltip The tooltip and accessible display name; must be
+	 *            non-blank.
+	 * @param helpTopic The {@code Map.jhm} topic documenting the
+	 *            element; must be non-blank.
+	 */
+	PaletteEntry(ElementType type, Palette.Group group, String iconName,
+			String fallbackText, String tooltip, String helpTopic) {
+
+		if (type == null) {
+			throw new IllegalArgumentException("no element type");
+		}
+		if (group == null) {
+			throw new IllegalArgumentException(
+					"no palette group for tag " + type.tag());
+		}
+		if (iconName == null || iconName.isBlank()) {
+			throw new IllegalArgumentException(
+					"blank icon name for tag " + type.tag());
+		}
+		if (fallbackText == null || fallbackText.isBlank()) {
+			throw new IllegalArgumentException(
+					"blank fallback text for tag " + type.tag());
+		}
+		if (tooltip == null || tooltip.isBlank()) {
+			throw new IllegalArgumentException(
+					"blank tooltip for tag " + type.tag());
+		}
+		if (helpTopic == null || helpTopic.isBlank()) {
+			throw new IllegalArgumentException(
+					"blank help topic for tag " + type.tag());
+		}
+		this.type = type;
+		this.group = group;
+		this.iconName = iconName;
+		this.fallbackText = fallbackText;
+		this.tooltip = tooltip;
+		this.helpTopic = helpTopic;
+	} // end of constructor
+
+	/**
+	 * The core descriptor of the element type this entry creates.
+	 *
+	 * @return the {@link ElementType}; its factory creates the element
+	 *         when the palette button is pressed.
+	 */
+	public ElementType type() {
+
+		return type;
+	} // end of type method
+
+	/**
+	 * The toolbar group this entry belongs to.
+	 *
+	 * @return the group whose GridLayout panel holds the entry's button.
+	 */
+	public Palette.Group group() {
+
+		return group;
+	} // end of group method
+
+	/**
+	 * The base name of the icon resource.
+	 *
+	 * @return the name of a gif in {@code jls/edit/images/}, without
+	 *         directory or extension.
+	 */
+	public String iconName() {
+
+		return iconName;
+	} // end of iconName method
+
+	/**
+	 * The button text shown when the icon resource is missing.
+	 *
+	 * @return the fallback text; empty text is never used, so a missing
+	 *         icon still leaves a usable, labeled button.
+	 */
+	public String fallbackText() {
+
+		return fallbackText;
+	} // end of fallbackText method
+
+	/**
+	 * The tooltip, which also serves as the accessible name of the
+	 * palette button and its mirror menu item (#75).
+	 *
+	 * @return the human-readable display name of the element.
+	 */
+	public String tooltip() {
+
+		return tooltip;
+	} // end of tooltip method
+
+	/**
+	 * The help topic documenting this element.
+	 *
+	 * @return a topic id present in {@code help/Map.jhm}.
+	 */
+	public String helpTopic() {
+
+		return helpTopic;
+	} // end of helpTopic method
+
+} // end of PaletteEntry class

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -79,53 +79,27 @@ import jls.collab.op.RemoveProbe;
 import jls.collab.op.RotateElement;
 import jls.collab.op.ToggleWatched;
 import jls.core.Geometry;
-import jls.elem.Adder;
-import jls.elem.AndGate;
-import jls.elem.Binder;
-import jls.elem.Clock;
-import jls.elem.Constant;
-import jls.elem.Decoder;
-import jls.elem.DelayGate;
 import jls.elem.Editable;
 import jls.elem.Element;
 import jls.elem.ElementId;
-import jls.elem.ElementRegistry;
-import jls.elem.ElementType;
-import jls.elem.Extend;
 import jls.elem.Group;
 import jls.elem.Input;
 import jls.elem.InputPin;
 import jls.elem.JumpEnd;
 import jls.elem.JumpStart;
-import jls.elem.Memory;
-import jls.elem.Mux;
-import jls.elem.NandGate;
-import jls.elem.NorGate;
-import jls.elem.NotGate;
-import jls.elem.OrGate;
 import jls.elem.Output;
 import jls.elem.OutputPin;
-import jls.elem.Pause;
 import jls.elem.Put;
 import jls.elem.QuickEditable;
-import jls.elem.Register;
 import jls.elem.Rotatable;
-import jls.elem.ShiftRegister;
 import jls.elem.SigGen;
-import jls.elem.Splitter;
-import jls.elem.StateMachine;
-import jls.elem.Stop;
 import jls.elem.SubCircuit;
-import jls.elem.Text;
 import jls.elem.Timed;
 import jls.elem.TriProp;
-import jls.elem.TriState;
-import jls.elem.TruthTable;
 import jls.elem.Watchable;
 import jls.elem.Wire;
 import jls.elem.WireEnd;
 import jls.elem.WireNet;
-import jls.elem.XorGate;
 import jls.sim.Simulator;
 
 /**
@@ -2028,6 +2002,15 @@ public abstract class SimpleEditor extends JPanel {
 
 			/**
 			 * Create element tool bar and menu.
+			 *
+			 * Both are generated from the {@link Palette} table (issue
+			 * #78): one button and one mirror menu item per
+			 * {@link PaletteEntry}, grouped into GridLayout panels of
+			 * each group's declared shape, reproducing the historical
+			 * hand-coded toolbar exactly. Only the Import button remains
+			 * hand-coded: it shows the menu of open subcircuits instead
+			 * of placing a registered element type, so it is not a
+			 * palette entry.
 			 */
 			public void makeElements() {
 
@@ -2035,501 +2018,26 @@ public abstract class SimpleEditor extends JPanel {
 				toolbar.setLayout(new BoxLayout(toolbar,BoxLayout.X_AXIS));
 				elements = new JMenu("elements");
 
-				JPanel gates = new JPanel(new GridLayout(2,4));
-
-				ImageIcon image = getImage("and");
-				String text = image == null ? "AND" : "";
-				Action act = new AbstractAction(text,image) {
-					/**
-					 * Create a new AND gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new AndGate(circuit),event.getSource() instanceof JButton);
+				for (Palette.Group group : Palette.groups()) {
+					if (group.standalone()) {
+						for (PaletteEntry entry : Palette.entries(group)) {
+							toolbar.add(makeElement(entry));
+						}
 					}
-				};
-				gates.add(makeElement(act,"AND gate"));
-
-				image = getImage("or");
-				text = image == null ? "OR" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new OR gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new OrGate(circuit),event.getSource() instanceof JButton);
+					else {
+						JPanel panel = new JPanel(
+								new GridLayout(group.rows(),group.cols()));
+						for (PaletteEntry entry : Palette.entries(group)) {
+							panel.add(makeElement(entry));
+						}
+						toolbar.add(panel);
 					}
-				};
-				gates.add(makeElement(act,"OR gate"));
+					toolbar.add(Box.createRigidArea(new Dimension(5,0)));
+				}
 
-				image = getImage("not");
-				text = image == null ? "NOT" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new NOT gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new NotGate(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"NOT gate"));
-
-				image = getImage("xor");
-				text = image == null ? "XOR" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new exclusive-OR gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new XorGate(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"exclusive OR gate"));
-
-				image = getImage("nand");
-				text = image == null ? "NAND" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new NAND gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new NandGate(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"NAND gate"));
-
-				image = getImage("nor");
-				text = image == null ? "NOR" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new NOR gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new NorGate(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"NOR gate"));
-
-				image = getImage("delay");
-				text = image == null ? "DELAY" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new delay gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new DelayGate(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"user defined signal delay"));
-
-				image = getImage("tristate");
-				text = image == null ? "TriState" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new tri-state gate and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new TriState(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				gates.add(makeElement(act,"tri-state gate"));
-
-				toolbar.add(gates);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				JPanel wireWorks = new JPanel(new GridLayout(2,4));
-
-				image = getImage("jumpstart");
-				text = image == null ? "START" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new named-wire (jump start) and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new JumpStart(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"name a wire"));
-
-				image = getImage("jumpend");
-				text = image == null ? "END" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new jump end and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new JumpEnd(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"connect to a named wire"));
-
-				image = getImage("ipin");
-				text = image == null ? "I-PIN" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new input pin and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new InputPin(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"input pin"));
-
-				image = getImage("opin");
-				text = image == null ? "O-PIN" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new output pin and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new OutputPin(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"output pin"));
-
-				image = getImage("split");
-				text = image == null ? "SPLIT" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new splitter and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Splitter(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"unbundle wires"));
-
-				image = getImage("bind");
-				text = image == null ? "BIND" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new binder and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Binder(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"bundle wires"));
-
-				image = getImage("const");
-				text = image == null ? "CONST" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new constant and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Constant(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"constant value"));
-
-				image = getImage("extend");
-				text = image == null ? "1-to-N" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new extend element and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Extend(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				wireWorks.add(makeElement(act,"make N copies of the input"));
-
-				toolbar.add(wireWorks);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				JPanel mem = new JPanel(new GridLayout(2,1));
-
-				image = getImage("register");
-				text = image == null ? "REG" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new register and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Register(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				mem.add(makeElement(act,"register (various triggering)"));
-
-				image = getImage("memory");
-				text = image == null ? "MEMORY" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new memory and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Memory(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				mem.add(makeElement(act,"memory, various types"));
-
-				toolbar.add(mem);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				JPanel comb = new JPanel(new GridLayout(2,3));
-
-				image = getImage("mux");
-				text = image == null ? "MUX" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new multiplexor and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Mux(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				comb.add(makeElement(act,"multiplexor"));
-
-				image = getImage("decoder");
-				text = image == null ? "DEC" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new decoder and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Decoder(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				comb.add(makeElement(act,"decoder"));
-
-				image = getImage("shiftregister");
-				text = image == null ? "SHIFT" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new shift register and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new ShiftRegister(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				comb.add(makeElement(act,"shift register (combinational shifter)"));
-
-				image = getImage("adder");
-				text = image == null ? "ADDER" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new adder and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Adder(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				comb.add(makeElement(act,"adder"));
-
-				image = getImage("clock");
-				text = image == null ? "CLOCK" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new clock and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Clock(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				comb.add(makeElement(act,"clock"));
-
-				toolbar.add(comb);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-				JPanel time = new JPanel(new GridLayout(2,1));
-
-				image = getImage("pause");
-				text = image == null ? "PAUSE" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new pause and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Pause(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				time.add(makeElement(act,"pause simulator when asserted"));
-
-				image = getImage("stop");
-				text = image == null ? "STOP" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new stop and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Stop(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				time.add(makeElement(act,"stop simulator when asserted"));
-
-				toolbar.add(time);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				JPanel test = new JPanel(new GridLayout(2,1));
-
-				image = getImage("siggen");
-				text = image == null ? "SIGGEN" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new signal generator and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new SigGen(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				test.add(makeElement(act,"generate test signals"));
-
-				image = getImage("display");
-				text = image == null ? "DISPLAY" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new display and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new jls.elem.Display(circuit),
-								event.getSource() instanceof JButton);
-					}
-				};
-				test.add(makeElement(act,"display circuit value"));
-
-				toolbar.add(test);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				JPanel complex = new JPanel(new GridLayout(2,1));
-
-				image = getImage("statemachine");
-				text = image == null ? "ST. MAC." : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new state machine and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new StateMachine(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				complex.add(makeElement(act,"state machine"));
-
-				image = getImage("truth");
-				text = image == null ? "Truth Table" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new truth table and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new TruthTable(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				complex.add(makeElement(act,"truth table"));
-
-				toolbar.add(complex);
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				image = getImage("text");
-				text = image == null ? "TEXT" : "";
-				act = new AbstractAction(text,image) {
-					/**
-					 * Create a new text element and begin placing it.
-					 *
-					 * @param event The triggering action event.
-					 */
-					@Override
-					public void actionPerformed(ActionEvent event) {
-						setup(new Text(circuit),event.getSource() instanceof JButton);
-					}
-				};
-				toolbar.add(makeElement(act,"text (for annotations)"));
-
-				toolbar.add(Box.createRigidArea(new Dimension(5,0)));
-
-				// import menu
+				// import menu (a bespoke button, not a palette entry: it
+				// imports an open subcircuit instead of placing a
+				// registered element type)
 				final JButton imp = new JButton("Import",getImage("down"));
 				imp.setToolTipText("import an open subcircuit");
 				imp.setBackground(Color.WHITE);
@@ -2552,7 +2060,7 @@ public abstract class SimpleEditor extends JPanel {
 					}
 				});
 
-			} // end of makeToolBar method
+			} // end of makeElements method
 
 			/**
 			 * Get image.
@@ -2568,14 +2076,35 @@ public abstract class SimpleEditor extends JPanel {
 			} // end of geImage method
 
 			/**
-			 * Make a single element for the toolbar and menu.
+			 * Make a single palette element for the toolbar and menu.
 			 *
-			 * @param action The action for this element.
-			 * @param tip The tool tip for this element.
+			 * The button and its mirror menu item share one action that
+			 * creates a blank element through the entry's registry
+			 * factory and begins placing it. The icon comes from the
+			 * entry's icon resource, with the entry's fallback text as
+			 * the button label when the resource is missing.
+			 *
+			 * @param entry The palette entry describing the element.
 			 * @return the toolbar button for the element.
 			 */
-			public JButton makeElement(Action action, String tip) {
+			public JButton makeElement(PaletteEntry entry) {
 
+				ImageIcon image = getImage(entry.iconName());
+				String text = image == null ? entry.fallbackText() : "";
+				Action action = new AbstractAction(text,image) {
+					/**
+					 * Create a new element of this entry's type and
+					 * begin placing it.
+					 *
+					 * @param event The triggering action event.
+					 */
+					@Override
+					public void actionPerformed(ActionEvent event) {
+						setup(entry.type().create(circuit),
+								event.getSource() instanceof JButton);
+					}
+				};
+				String tip = entry.tooltip();
 				JButton button = new JButton(action);
 				button.setMinimumSize(new Dimension(32,232));
 				button.setPreferredSize(new Dimension(32,32));
@@ -2596,7 +2125,7 @@ public abstract class SimpleEditor extends JPanel {
 				// automation (the #91 harness) and assistive technology can
 				// resolve them without tooltip/positional heuristics. The
 				// naming scheme is documented in docs/component-naming.md.
-				String slug = paletteSlug(tip);
+				String slug = entry.type().tag().toLowerCase(Locale.ROOT);
 				button.setName("palette." + slug);
 				item.setName("menu.elements." + slug);
 				JMenu els = elements;
@@ -2605,63 +2134,6 @@ public abstract class SimpleEditor extends JPanel {
 				els.add(item);
 				return button;
 			} // end of makeElement method
-
-			/**
-			 * The stable component-name slug for a palette tool tip
-			 * (issue #210): the {@link ElementRegistry} tag of the element
-			 * the palette entry creates, lower-cased. Sourcing the slug
-			 * from the registry keeps the names in sync with the element
-			 * table (#78); an unknown tip is a programming error caught at
-			 * tool-bar construction time.
-			 *
-			 * @param tip The palette entry's tool tip.
-			 * @return the lower-cased registry tag for the element.
-			 */
-			private static String paletteSlug(String tip) {
-
-				String tag = switch (tip) {
-					case "AND gate" -> "AndGate";
-					case "OR gate" -> "OrGate";
-					case "NOT gate" -> "NotGate";
-					case "exclusive OR gate" -> "XorGate";
-					case "NAND gate" -> "NandGate";
-					case "NOR gate" -> "NorGate";
-					case "user defined signal delay" -> "DelayGate";
-					case "tri-state gate" -> "TriState";
-					case "name a wire" -> "JumpStart";
-					case "connect to a named wire" -> "JumpEnd";
-					case "input pin" -> "InputPin";
-					case "output pin" -> "OutputPin";
-					case "unbundle wires" -> "Splitter";
-					case "bundle wires" -> "Binder";
-					case "constant value" -> "Constant";
-					case "make N copies of the input" -> "Extend";
-					case "register (various triggering)" -> "Register";
-					case "memory, various types" -> "Memory";
-					case "multiplexor" -> "Mux";
-					case "decoder" -> "Decoder";
-					case "shift register (combinational shifter)" ->
-							"ShiftRegister";
-					case "adder" -> "Adder";
-					case "clock" -> "Clock";
-					case "pause simulator when asserted" -> "Pause";
-					case "stop simulator when asserted" -> "Stop";
-					case "generate test signals" -> "SigGen";
-					case "display circuit value" -> "Display";
-					case "state machine" -> "StateMachine";
-					case "truth table" -> "TruthTable";
-					case "text (for annotations)" -> "Text";
-					default -> throw new IllegalArgumentException(
-							"no element registry tag for palette tip '"
-									+ tip + "'");
-				};
-				ElementType type = ElementRegistry.forTag(tag);
-				if (type == null) {
-					throw new IllegalStateException("palette tip '" + tip
-							+ "' names unregistered element tag " + tag);
-				}
-				return type.tag().toLowerCase(Locale.ROOT);
-			} // end of paletteSlug method
 
 			/**
 			 * Get the tool bar.

--- a/test/jls/HelpTopicsTest.java
+++ b/test/jls/HelpTopicsTest.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,6 +28,9 @@ import java.util.stream.Stream;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import org.junit.jupiter.api.Test;
+
+import jls.edit.Palette;
+import jls.edit.PaletteEntry;
 
 /**
  * The JavaHelp replacement (issue #11) is driven by two pieces of
@@ -138,15 +142,20 @@ class HelpTopicsTest {
 	}
 
 	/**
-	 * Every element type a user can create from the editor palette
-	 * (SimpleEditor.makeElements builds the toolbar and the "elements"
-	 * menu from exactly these, plus the Import button for SubCircuit),
+	 * Every element type a user can create from the editor palette,
 	 * mapped to the Map.jhm topic that documents it. This is the
 	 * completeness contract of issue #85: every palette element has a
-	 * help topic that resolves to a bundled page. A static list because
-	 * the element registry (#78) does not exist yet; when adding a
-	 * palette element, add its row here (the test fails until the topic
-	 * and page exist).
+	 * help topic that resolves to a bundled page. The inventory is
+	 * derived from the palette table itself (jls.edit.Palette, issue
+	 * #78 - the static list this method replaces predated the registry
+	 * and had to be maintained by hand), so a newly added palette entry
+	 * is covered automatically: the entry's declared help topic must
+	 * name a bundled page or this test fails.
+	 *
+	 * The one documented special case is SubCircuit: it is created
+	 * through the hand-coded Import button rather than a palette entry
+	 * (it imports an open circuit instead of placing a registered
+	 * element type), so its "import" topic row is added explicitly.
 	 *
 	 * Inventory note (issue #85): at the time this test was added the
 	 * audit's "21 element classes without help pages" was re-counted
@@ -155,38 +164,15 @@ class HelpTopicsTest {
 	 * puts/wires/dialog plumbing/truth-table display internals), so
 	 * this test pins completeness rather than repairing it.
 	 */
-	private static final Map<String,String> PALETTE_ELEMENT_TOPICS = Map.ofEntries(
-			Map.entry("AndGate", "AND"),
-			Map.entry("OrGate", "OR"),
-			Map.entry("NotGate", "NOT"),
-			Map.entry("XorGate", "XOR"),
-			Map.entry("NandGate", "NAND"),
-			Map.entry("NorGate", "NOR"),
-			Map.entry("DelayGate", "DELAY"),
-			Map.entry("TriState", "TRISTATE"),
-			Map.entry("JumpStart", "start"),
-			Map.entry("JumpEnd", "end"),
-			Map.entry("InputPin", "Input"),
-			Map.entry("OutputPin", "Output"),
-			Map.entry("Splitter", "unbundle"),
-			Map.entry("Binder", "bundle"),
-			Map.entry("Constant", "const"),
-			Map.entry("Extend", "extend"),
-			Map.entry("Register", "register"),
-			Map.entry("Memory", "memory"),
-			Map.entry("Mux", "mux"),
-			Map.entry("ShiftRegister", "shiftregister"),
-			Map.entry("Decoder", "decoder"),
-			Map.entry("Adder", "adder"),
-			Map.entry("Clock", "clock"),
-			Map.entry("Pause", "pause"),
-			Map.entry("Stop", "stop"),
-			Map.entry("SigGen", "siggen"),
-			Map.entry("Display", "display"),
-			Map.entry("StateMachine", "stmach"),
-			Map.entry("TruthTable", "truth"),
-			Map.entry("Text", "text"),
-			Map.entry("SubCircuit", "import"));
+	private static Map<String,String> paletteElementTopics() {
+		Map<String,String> topics = new TreeMap<String,String>();
+		for (PaletteEntry entry : Palette.entries())
+			topics.put(entry.type().tag(), entry.helpTopic());
+		// the Import button's special case: SubCircuit is user-creatable
+		// but not a palette entry
+		topics.put("SubCircuit", "import");
+		return topics;
+	}
 
 	/** Every palette element type must have a help topic that resolves
 	 *  to a bundled page (issue #85). Also sanity-checks the static
@@ -194,11 +180,12 @@ class HelpTopicsTest {
 	 *  renamed element cannot leave a stale row behind. */
 	@Test
 	void everyPaletteElementTypeHasAMappedHelpTopic() throws Exception {
+		Map<String,String> topics = paletteElementTopics();
 		Map<String,String> map = topicMap();
 		Set<String> resources = helpResources();
 		List<String> broken = new ArrayList<String>();
-		for (String type : new TreeSet<String>(PALETTE_ELEMENT_TOPICS.keySet())) {
-			String topic = PALETTE_ELEMENT_TOPICS.get(type);
+		for (String type : topics.keySet()) {
+			String topic = topics.get(type);
 			try {
 				Class.forName("jls.elem." + type);
 			}

--- a/test/jls/collab/op/ElementVocabularyTest.java
+++ b/test/jls/collab/op/ElementVocabularyTest.java
@@ -6,12 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -21,6 +19,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import jls.Circuit;
+import jls.edit.Palette;
+import jls.edit.PaletteEntry;
 import jls.elem.Element;
 
 /**
@@ -31,8 +31,8 @@ import jls.elem.Element;
  * peer-controlled string reaching reflective instantiation). So the
  * list is pinned against both independent sources of truth - the
  * save-format writer literals in {@code jls.elem} (what snapshots can
- * legitimately contain) and the palette contract in
- * {@code HelpTopicsTest} (what users can create) - and the rejection
+ * legitimately contain) and the palette table in
+ * {@code jls.edit.Palette} (what users can create, #78) - and the rejection
  * behavior is pinned as typed, total, and strictly tighter than the
  * file loader's reflective gate.
  */
@@ -107,27 +107,30 @@ class ElementVocabularyTest {
 
 	/**
 	 * The issue #170 registry cross-check: the vocabulary is the
-	 * palette-visible element set (the same list HelpTopicsTest pins
-	 * against the help system, read from there so the two cannot
-	 * drift) plus WireEnd, the one non-palette save token - wires are
-	 * save-file structure, not palette elements. A vocabulary that
-	 * admitted anything else would be admitting a class users cannot
-	 * create, which is exactly the helper-class hole.
+	 * palette-visible element set (read from the palette table itself,
+	 * {@code jls.edit.Palette} - the #78 descriptor table that
+	 * HelpTopicsTest also derives its inventory from, so the two cannot
+	 * drift) plus SubCircuit (user-creatable through the hand-coded
+	 * Import button rather than a palette entry) plus WireEnd, the one
+	 * non-palette save token - wires are save-file structure, not
+	 * palette elements. A vocabulary that admitted anything else would
+	 * be admitting a class users cannot create, which is exactly the
+	 * helper-class hole.
 	 */
 	@Test
-	void vocabularyIsThePaletteSetPlusWireEnd() throws Exception {
+	void vocabularyIsThePaletteSetPlusWireEnd() {
 
-		Field palette = Class.forName("jls.HelpTopicsTest")
-				.getDeclaredField("PALETTE_ELEMENT_TOPICS");
-		palette.setAccessible(true);
-		Set<String> expected = new TreeSet<>(
-				((Map<?, ?>) palette.get(null)).keySet().stream()
-						.map(Object::toString).toList());
+		Set<String> expected = new TreeSet<>();
+		for (PaletteEntry entry : Palette.entries()) {
+			expected.add(entry.type().tag());
+		}
+		expected.add("SubCircuit");
 		expected.add("WireEnd");
 
 		assertEquals(expected,
 				new TreeSet<>(ElementVocabulary.allowedTypes()),
-				"the vocabulary must be the palette set plus WireEnd");
+				"the vocabulary must be the palette set plus SubCircuit "
+						+ "and WireEnd");
 	}
 
 	/**

--- a/test/jls/edit/PaletteContractTest.java
+++ b/test/jls/edit/PaletteContractTest.java
@@ -1,0 +1,165 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+
+import jls.elem.ElementRegistry;
+import jls.elem.ElementType;
+
+/**
+ * The palette authoring contract (issue #78): the {@link Palette} table
+ * must stay a total, well-formed description of the editor toolbar, so
+ * that adding an element type is one registry row plus one palette row -
+ * and forgetting the palette row (or writing a bad one) is a build
+ * failure instead of an element that silently never appears in the GUI.
+ *
+ * Everything here is checked headlessly on the static table: totality
+ * against {@link ElementRegistry#all()} minus the documented non-palette
+ * set, icon resources on the classpath, tooltip/fallback-text uniqueness,
+ * grid capacity, and help-topic presence (the topics' resolution to
+ * bundled pages is {@code jls.HelpTopicsTest}'s job). GUI parity - the
+ * generated buttons carrying the {@code palette.<tag>} component names
+ * and behaving mid-placement - is pinned by the display-tagged
+ * {@code ComponentIdentityTest} and {@code MidPlacementPaletteFeedbackTest}.
+ */
+class PaletteContractTest {
+
+	/**
+	 * Registered element types that deliberately have no palette entry:
+	 * SubCircuit is created through the hand-coded Import button (it
+	 * imports an open circuit rather than placing a blank element),
+	 * WireEnd exists only as the endpoint of drawn wires, and TestGen is
+	 * the batch-mode stand-in for a signal generator. Every other
+	 * registered type must have exactly one palette row.
+	 */
+	private static final Set<String> NON_PALETTE_TAGS =
+			Set.of("SubCircuit", "WireEnd", "TestGen");
+
+	@Test
+	void paletteIsTotalOverTheElementRegistry() {
+
+		Set<String> expected = new TreeSet<String>();
+		for (ElementType type : ElementRegistry.all()) {
+			if (!NON_PALETTE_TAGS.contains(type.tag())) {
+				expected.add(type.tag());
+			}
+		}
+		Set<String> actual = new TreeSet<String>();
+		for (PaletteEntry entry : Palette.entries()) {
+			assertTrue(actual.add(entry.type().tag()),
+					"duplicate palette entry for tag " + entry.type().tag());
+		}
+		assertEquals(expected, actual,
+				"the palette must have exactly one entry per registered "
+						+ "element type outside the documented non-palette "
+						+ "set " + NON_PALETTE_TAGS + "; add the missing "
+						+ "Palette row (or remove the stale one)");
+	}
+
+	/**
+	 * Palette entries whose icon gif has never shipped: the toolbar has
+	 * always shown their fallback text instead (the missing-icon
+	 * fallback in {@code SimpleEditor.getImage} exists for exactly this
+	 * case - the issue #78 observation). Pinned here so the historical
+	 * gap stays visible without blocking the build; if the icon is ever
+	 * drawn, this set must shrink or the exactness check below fails.
+	 */
+	private static final Set<String> KNOWN_MISSING_ICONS =
+			Set.of("ShiftRegister");
+
+	@Test
+	void everyIconResourceExistsOnTheClasspath() {
+
+		Set<String> missing = new TreeSet<String>();
+		for (PaletteEntry entry : Palette.entries()) {
+			if (SimpleEditor.class.getResource(
+					"images/" + entry.iconName() + ".gif") == null) {
+				missing.add(entry.type().tag());
+			}
+		}
+		assertEquals(KNOWN_MISSING_ICONS, missing,
+				"every palette entry outside the documented "
+						+ "missing-icon set must name a bundled gif in "
+						+ "jls/edit/images/ (and a newly drawn icon must "
+						+ "leave the documented set)");
+	}
+
+	@Test
+	void tooltipsAreNonBlankAndUnique() {
+
+		Set<String> seen = new HashSet<String>();
+		for (PaletteEntry entry : Palette.entries()) {
+			assertFalse(entry.tooltip().isBlank(),
+					"blank tooltip for tag " + entry.type().tag());
+			assertTrue(seen.add(entry.tooltip()),
+					"duplicate tooltip '" + entry.tooltip()
+							+ "' (tag " + entry.type().tag() + ")");
+		}
+	}
+
+	@Test
+	void fallbackTextsAreNonBlankAndUnique() {
+
+		Set<String> seen = new HashSet<String>();
+		for (PaletteEntry entry : Palette.entries()) {
+			assertFalse(entry.fallbackText().isBlank(),
+					"blank fallback text for tag " + entry.type().tag());
+			assertTrue(seen.add(entry.fallbackText()),
+					"duplicate fallback text '" + entry.fallbackText()
+							+ "' (tag " + entry.type().tag() + ")");
+		}
+	}
+
+	@Test
+	void everyGroupIsNonEmptyAndFitsItsDeclaredGrid() {
+
+		for (Palette.Group group : Palette.groups()) {
+			List<PaletteEntry> entries = Palette.entries(group);
+			assertFalse(entries.isEmpty(),
+					"palette group " + group + " has no entries");
+			int capacity = group.rows() * group.cols();
+			assertTrue(entries.size() <= capacity,
+					"palette group " + group + " declares a "
+							+ group.rows() + "x" + group.cols()
+							+ " grid (" + capacity + " slots) but has "
+							+ entries.size() + " entries; grow the grid "
+							+ "or move an entry to another group");
+		}
+	}
+
+	@Test
+	void entriesComeInToolbarGroupOrder() {
+
+		// makeElements renders one group at a time, so the flat table
+		// must list each group's entries consecutively, in group order;
+		// interleaving would silently reorder the generated toolbar
+		// relative to the declared table.
+		List<PaletteEntry> regrouped = new ArrayList<PaletteEntry>();
+		for (Palette.Group group : Palette.groups()) {
+			regrouped.addAll(Palette.entries(group));
+		}
+		assertEquals(regrouped, Palette.entries(),
+				"Palette.entries() must list each group's entries "
+						+ "consecutively, in toolbar group order");
+	}
+
+	@Test
+	void everyHelpTopicIsNonBlank() {
+
+		// topic ids resolving to bundled pages is HelpTopicsTest's job;
+		// this pins that no entry is authored without one
+		for (PaletteEntry entry : Palette.entries()) {
+			assertFalse(entry.helpTopic().isBlank(),
+					"blank help topic for tag " + entry.type().tag());
+		}
+	}
+}

--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -186,7 +186,9 @@ class MemoryModelTest {
 	@Test
 	void timingContractResetsToTheDefaultAccessTime() {
 		Memory mem = newMemory();
-		assertTrue(mem.hasTiming());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Timed,
+				"memory carries a timing contract");
 		assertTrue(mem.usesAccessTime(),
 				"memory is the one element with an access time");
 		assertEquals(100, mem.getDelay(), "documented default access time");
@@ -199,8 +201,11 @@ class MemoryModelTest {
 	@Test
 	void watchAndChangeContract() {
 		Memory mem = newMemory();
-		assertTrue(mem.canWatch());
-		assertTrue(mem.canChange());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Watchable,
+				"memory values can be watched");
+		assertTrue(asElement instanceof Editable,
+				"memory attributes can be edited");
 		assertFalse(mem.isWatched());
 		mem.setWatched(true);
 		assertTrue(mem.isWatched());

--- a/test/jls/elem/RegisterModelTest.java
+++ b/test/jls/elem/RegisterModelTest.java
@@ -124,7 +124,9 @@ class RegisterModelTest {
 	@Test
 	void timingContractResetsToTheDefaultDelay() {
 		Register reg = newRegister();
-		assertTrue(reg.hasTiming());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Timed,
+				"registers carry a timing contract");
 		assertEquals(50, reg.getDelay(), "documented default delay");
 		reg.setDelay(75);
 		assertEquals(75, reg.getDelay());
@@ -136,8 +138,11 @@ class RegisterModelTest {
 	void capabilityContract() {
 		Register reg = newRegister();
 		assertFalse(reg.canCopy(), "registers are named, so not copyable");
-		assertTrue(reg.canChange());
-		assertTrue(reg.canWatch());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Editable,
+				"register attributes can be edited");
+		assertTrue(asElement instanceof Watchable,
+				"register values can be watched");
 		assertFalse(reg.isWatched());
 		reg.setWatched(true);
 		assertTrue(reg.isWatched());
@@ -346,11 +351,12 @@ class RegisterModelTest {
 
 		@Override
 		public void post(jls.sim.SimEvent event) {
-			// only the register's own output-driving posts (non-null
-			// todo): input-change notifications also name the register
-			// as callback but carry a null todo
+			// only the register's own output-driving posts (NewValue):
+			// input-change notifications also name the register as
+			// callback but carry a PinChanged payload
 			if (event.getCallBack() instanceof Register
-					&& event.getTodo() != null) {
+					&& event.getTodo()
+							instanceof jls.sim.SimEvent.NewValue) {
 				registerPosts += 1;
 			}
 			super.post(event);

--- a/test/jls/elem/SubCircuitModelTest.java
+++ b/test/jls/elem/SubCircuitModelTest.java
@@ -150,7 +150,9 @@ class SubCircuitModelTest {
 	@Test
 	void canChangeAndDelayResetAreDelegatedSafely() {
 		SubCircuit sub = loneSub();
-		assertTrue(sub.canChange());
+		Element asElement = sub;
+		assertTrue(asElement instanceof Editable,
+				"subcircuits can be edited");
 		// the passthrough inner circuit has no timed elements; the
 		// delegation must still walk it without faulting
 		sub.resetPropDelay();


### PR DESCRIPTION
Lands the GUI half of #78's two-layer element descriptor split: the
palette is now data, not code.

- `jls.edit.PaletteEntry`: GUI-side descriptor per palette element -
  `ElementType` reference (canonical tag), icon base name (gif in
  `jls/edit/images/`), fallback button text, tooltip/display name,
  toolbar group, and `Map.jhm` help topic. Deliberately carries no
  capability set (capabilities are the instanceof interfaces pinned by
  `CapabilityInterfaceTest`) and no core-side concerns (the recorded
  two-layer decision keeps GUI metadata out of `jls.elem`).
- `jls.edit.Palette`: the static ordered table of all 30 entries in the
  8 historical toolbar groups (gates 2x4, wire works 2x4, mem 2x1, comb
  2x3, time 2x1, test 2x1, complex 2x1, standalone Text), each group
  carrying its GridLayout shape. Rows resolve through
  `ElementRegistry.forTag`, so a palette row naming an unregistered tag
  fails at class-initialization time.
- `SimpleEditor.makeElements()` (~520 hand-rolled lines) is now one
  loop over `Palette.groups()`; `makeElement(PaletteEntry)` builds the
  shared action via `entry.type().create(circuit)` into the existing
  `setup(...)`, with icon/fallback-text, tooltip, accessible-name, and
  `palette.<tag>` / `menu.elements.<tag>` component-name behavior
  identical (docs/component-naming.md, #210). The 30-case
  tooltip-to-tag `paletteSlug` switch is deleted - the slug comes from
  `entry.type().tag()` directly. The Import button stays hand-coded
  (it shows the open-subcircuit menu rather than placing an element).
  26 now-unused `jls.elem` imports dropped.
- `HelpTopicsTest` now derives its palette inventory from
  `Palette.entries()` plus the documented SubCircuit->"import"
  Import-button special case, fulfilling its own "#78 does not exist
  yet" TODO.
- New headless `PaletteContractTest` pins the authoring contract:
  totality (palette tags == `ElementRegistry.all()` minus the
  documented `{SubCircuit, WireEnd, TestGen}` non-palette set, so a
  newly registered element without a palette row is a build failure),
  icon existence on the classpath, tooltip and fallback-text
  non-blankness/uniqueness, per-group grid capacity, contiguous
  group order, and help-topic presence.
- CHANGELOG entry under Unreleased/Added.

Reviewer notes:

- `test/jls/collab/op/ElementVocabularyTest` (not in the original
  slice file list) had to move with this change: its #170 cross-check
  read `HelpTopicsTest.PALETTE_ELEMENT_TOPICS` reflectively, and that
  static map is gone. It now reads `Palette.entries()` directly (plus
  explicit SubCircuit and WireEnd), which is the stronger, non-
  reflective pin the old comment wished for. Same expected set as
  before; no vocabulary change.
- `shiftregister.gif` has never existed in the tree - the toolbar has
  always shown the "SHIFT" fallback text (that gap is why
  `getImage` has a missing-icon fallback, the "#78 observation").
  `PaletteContractTest` pins it as the single documented
  `KNOWN_MISSING_ICONS` exception, exact-matched so drawing the icon
  later forces the exception's removal. Adding an icon now would have
  changed the visible toolbar, which this slice must not do.
- GUI parity is pinned by the display-tagged `ComponentIdentityTest`
  and `MidPlacementPaletteFeedbackTest` (skipped headless); runnable
  via `xvfb-run -a mvn -B verify -Djls.test.headless=false`.
- Coverage: coverage ratchet green; `jls.edit` is deliberately
  unfloored (see pom comment). Package instruction coverage is now
  24.80% (11359/45805): the rewrite removed ~490 permanently
  uncovered GUI lines from `SimpleEditor` and the new table classes
  are almost fully covered by the contract test (Palette 353/359
  instructions, Palette.Group 95/98, PaletteEntry 63/103).

Verification (headless, nix develop + mvn):

- Targeted: `mvn -B test
  -Dtest='PaletteContractTest,HelpTopicsTest,ElementRegistryTest,CapabilityInterfaceTest'`
  -> 23 tests, 0 failures (7 + 7 + 5 + 4).
- Full: `mvn -B clean verify` -> BUILD SUCCESS; 1192 tests run across
  both surefire executions, 0 failures, 0 errors, 92 skipped (87
  display-tagged headless skips + 5 tool-gated), jacoco
  coverage-ratchet check green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Bq6UGDVGMgiCZkzkUMBBS


🤖 Generated with [Claude Code](https://claude.com/claude-code)
