### PR TITLE
Add jls.module manifest record and Kahn dependency resolver (#220)

### DIFF
--- a/src/jls/module/Activation.java
+++ b/src/jls/module/Activation.java
@@ -1,0 +1,78 @@
+package jls.module;
+
+/**
+ * When a module's logic comes alive (issue #220, grand-architecture
+ * §4.2 rule 7): the default is a lazy trigger — a command, an event,
+ * or first demand — and only the true kernel core opts into
+ * {@link Eager} boot-time activation. This mirrors VS Code
+ * {@code activationEvents} and Emacs autoloads, and it is the literal
+ * meaning of issue #212's demand gate: a module registers a cheap shim
+ * and its real start runs on first use.
+ *
+ * <p>Data-only in this slice: the manifest records which trigger a
+ * module declares; the runner that honors the trigger arrives with the
+ * lifecycle slice.</p>
+ */
+public sealed interface Activation {
+
+	/**
+	 * Activate at boot, in topological order. Reserved for the true
+	 * kernel core (core model, configuration, look-and-feel).
+	 */
+	record Eager() implements Activation {
+	} // end of Eager record
+
+	/**
+	 * Activate the first time a named command is invoked.
+	 *
+	 * @param command The command identifier that triggers activation;
+	 *            must be non-blank.
+	 */
+	record OnCommand(String command) implements Activation {
+
+		/**
+		 * Reject blank command identifiers.
+		 *
+		 * @throws IllegalArgumentException if the command is blank.
+		 */
+		public OnCommand {
+
+			if (command.isBlank()) {
+				throw new IllegalArgumentException(
+						"blank activation command");
+			}
+		} // end of compact constructor
+
+	} // end of OnCommand record
+
+	/**
+	 * Activate the first time a named event fires.
+	 *
+	 * @param event The event identifier that triggers activation; must
+	 *            be non-blank.
+	 */
+	record OnEvent(String event) implements Activation {
+
+		/**
+		 * Reject blank event identifiers.
+		 *
+		 * @throws IllegalArgumentException if the event is blank.
+		 */
+		public OnEvent {
+
+			if (event.isBlank()) {
+				throw new IllegalArgumentException(
+						"blank activation event");
+			}
+		} // end of compact constructor
+
+	} // end of OnEvent record
+
+	/**
+	 * Activate on first real use of anything the module provides — the
+	 * most lazy trigger, and the default posture for non-core modules.
+	 */
+	record OnDemand() implements Activation {
+	} // end of OnDemand record
+
+} // end of Activation interface

--- a/src/jls/module/ModuleManifest.java
+++ b/src/jls/module/ModuleManifest.java
@@ -1,0 +1,125 @@
+package jls.module;
+
+import java.util.Set;
+
+/**
+ * The static descriptor of one module (issue #220, grand-architecture
+ * §4.1): everything the resolver needs to decide existence, ambiguity,
+ * and order, readable <em>without</em> running any module code — the
+ * universal precondition for topological ordering and lazy activation.
+ *
+ * <p>Two separate axes, deliberately (§4.2 rule 1): {@code requires}
+ * and {@code optional} answer <em>does it exist / is it a gate</em>;
+ * {@code after} and {@code before} answer <em>when do I run</em>. A
+ * {@code requires} edge implies an {@code after} edge, but an
+ * {@code after} edge alone pulls nothing in — systemd's
+ * {@code Requires=} vs {@code After=}.</p>
+ *
+ * <p>Capability tokens (§4.2 rule 3): a {@code requires} entry is
+ * satisfied by any module whose {@code provides} contains that token,
+ * or by a module whose concrete {@code id} matches it (Debian
+ * {@code Provides} / virtual packages). No version solver (§4.2 rule
+ * 4): one jar means one version of everything; {@code apiVersion} is a
+ * single integer checked only for external modules, where major means
+ * break.</p>
+ *
+ * @param id The stable unique module name; must be non-blank.
+ * @param apiVersion The single-integer SPI version this module was
+ *            built against (major = break; no ranges, no solver).
+ * @param provides Capability tokens this module publishes, in addition
+ *            to its concrete id; each must be non-blank.
+ * @param requires Hard dependencies (capability token or concrete id):
+ *            missing means the resolve fails loudly; each must be
+ *            non-blank and never the module's own id.
+ * @param optional Soft dependencies: use-if-present, never a gate, and
+ *            never a reason to load the target; each must be non-blank
+ *            and never the module's own id.
+ * @param after Ordering only — run after these, if present; pulls
+ *            nothing in; each must be non-blank and never the module's
+ *            own id.
+ * @param before Ordering only — run before these, if present; pulls
+ *            nothing in; each must be non-blank and never the module's
+ *            own id.
+ * @param activation The trigger on which this module's logic comes
+ *            alive (§4.2 rule 7).
+ */
+public record ModuleManifest(
+		String id,
+		int apiVersion,
+		Set<String> provides,
+		Set<String> requires,
+		Set<String> optional,
+		Set<String> after,
+		Set<String> before,
+		Activation activation) {
+
+	/**
+	 * Validate and defensively copy (issue #94 discipline): the record
+	 * holds immutable sets whatever the caller passed, every token is
+	 * non-blank, and no dependency or ordering axis names the module
+	 * itself.
+	 *
+	 * @throws IllegalArgumentException if the id or any token is
+	 *             blank, or if requires, optional, after, or before
+	 *             contains the module's own id.
+	 */
+	public ModuleManifest {
+
+		if (id.isBlank()) {
+			throw new IllegalArgumentException("blank module id");
+		}
+		provides = copyOf(provides, "provides", id);
+		requires = copyOf(requires, "requires", id);
+		optional = copyOf(optional, "optional", id);
+		after = copyOf(after, "after", id);
+		before = copyOf(before, "before", id);
+		noSelfEdge(requires, "requires", id);
+		noSelfEdge(optional, "optional", id);
+		noSelfEdge(after, "after", id);
+		noSelfEdge(before, "before", id);
+	} // end of compact constructor
+
+	/**
+	 * An immutable copy of one token set with every token checked
+	 * non-blank.
+	 *
+	 * @param tokens The caller's token set.
+	 * @param axis The manifest field being validated, for the message.
+	 * @param id The module id, for the message.
+	 *
+	 * @return an immutable copy of the tokens.
+	 *
+	 * @throws IllegalArgumentException if any token is blank.
+	 */
+	private static Set<String> copyOf(Set<String> tokens, String axis,
+			String id) {
+
+		Set<String> copy = Set.copyOf(tokens);
+		for (String token : copy) {
+			if (token.isBlank()) {
+				throw new IllegalArgumentException("blank " + axis
+						+ " token in module '" + id + "'");
+			}
+		}
+		return copy;
+	} // end of copyOf method
+
+	/**
+	 * Reject an axis that names the module itself.
+	 *
+	 * @param tokens The already-copied token set.
+	 * @param axis The manifest field being validated, for the message.
+	 * @param id The module id.
+	 *
+	 * @throws IllegalArgumentException if the set contains the id.
+	 */
+	private static void noSelfEdge(Set<String> tokens, String axis,
+			String id) {
+
+		if (tokens.contains(id)) {
+			throw new IllegalArgumentException("module '" + id
+					+ "' names itself in " + axis);
+		}
+	} // end of noSelfEdge method
+
+} // end of ModuleManifest record

--- a/src/jls/module/ModuleResolutionException.java
+++ b/src/jls/module/ModuleResolutionException.java
@@ -1,0 +1,28 @@
+package jls.module;
+
+/**
+ * Thrown when a set of module manifests cannot be resolved into one
+ * startup order (issue #220): a duplicate module id, a hard
+ * requirement with zero providers, a requirement with more than one
+ * provider and no declared alternative, or a dependency/ordering
+ * cycle. The message names the offenders — the token and its requirer,
+ * the competing providers, or the full cycle path — so the failure is
+ * diagnosable from a single read (§4.2 rule 5: fail loud, never paper
+ * over).
+ */
+public class ModuleResolutionException extends Exception {
+
+	/** Serialization version, required of every Exception subclass. */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Create the exception with a message naming the offenders.
+	 *
+	 * @param message the full description of why resolution failed.
+	 */
+	public ModuleResolutionException(String message) {
+
+		super(message);
+	} // end of constructor
+
+} // end of ModuleResolutionException class

--- a/src/jls/module/ModuleResolver.java
+++ b/src/jls/module/ModuleResolver.java
@@ -1,0 +1,295 @@
+package jls.module;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Resolves a set of {@link ModuleManifest}s into one deterministic
+ * startup order (issue #220, grand-architecture §4.2 rules 1-6).
+ * Resolution happens once, at startup, and fails loudly:
+ *
+ * <ul>
+ * <li>Duplicate module ids are an error.</li>
+ * <li>Every {@code requires} token must have exactly one provider — a
+ * module whose {@code provides} contains the token or whose concrete
+ * id equals it (Debian {@code Provides} style). Zero providers is a
+ * loud error naming the token and its requirer; more than one is an
+ * ambiguity error naming all of them (a declared-alternative syntax is
+ * deliberately absent this slice).</li>
+ * <li>{@code optional} is never a gate and never an edge: an absent
+ * target is a graceful no-op, and a present one is not pulled in or
+ * ordered against unless an {@code after}/{@code before} edge says
+ * so.</li>
+ * <li>{@code requires} implies {@code after}; {@code after} and
+ * {@code before} alone order against every present provider of their
+ * token and pull nothing in.</li>
+ * <li>The order is Kahn's topological sort with an id-sorted
+ * tie-break, so it is a pure function of the manifest set —
+ * independent of input, discovery, or iteration order.</li>
+ * <li>A cycle is a {@link ModuleResolutionException} reporting the
+ * full cycle path (Jenkins/IntelliJ style), never papered over.</li>
+ * </ul>
+ */
+public final class ModuleResolver {
+
+	/** Pure algorithm; never instantiated. */
+	private ModuleResolver() {
+	} // end of constructor
+
+	/**
+	 * Resolve manifests into the deterministic startup order.
+	 *
+	 * @param manifests The manifests to resolve, in any order.
+	 *
+	 * @return the manifests in startup order: every module after the
+	 *         single provider of each of its {@code requires} tokens
+	 *         and after/before every present provider its ordering
+	 *         axes name, ties broken by id.
+	 *
+	 * @throws ModuleResolutionException if two manifests share an id,
+	 *             a {@code requires} token has zero or several
+	 *             providers, or the dependency/ordering edges form a
+	 *             cycle.
+	 */
+	public static List<ModuleManifest> resolve(
+			Collection<ModuleManifest> manifests)
+			throws ModuleResolutionException {
+
+		Map<String, ModuleManifest> byId = indexById(manifests);
+		Map<String, SortedSet<String>> providers = indexProviders(
+				byId.values());
+
+		// successors[u] = modules that must start after u; an edge
+		// u -> v also bumps v's indegree for Kahn's algorithm
+		Map<String, SortedSet<String>> successors = new TreeMap<>();
+		Map<String, Integer> indegree = new TreeMap<>();
+		for (String id : byId.keySet()) {
+			successors.put(id, new TreeSet<>());
+			indegree.put(id, 0);
+		}
+		for (ModuleManifest m : byId.values()) {
+			for (String token : m.requires()) {
+				String provider = soleProvider(token, m.id(), providers);
+				if (!provider.equals(m.id())) {
+					addEdge(provider, m.id(), successors, indegree);
+				}
+			}
+			// optional: no edges ever - not a gate, not an ordering
+			for (String token : m.after()) {
+				for (String provider : presentProviders(token,
+						providers)) {
+					if (!provider.equals(m.id())) {
+						addEdge(provider, m.id(), successors, indegree);
+					}
+				}
+			}
+			for (String token : m.before()) {
+				for (String provider : presentProviders(token,
+						providers)) {
+					if (!provider.equals(m.id())) {
+						addEdge(m.id(), provider, successors, indegree);
+					}
+				}
+			}
+		}
+
+		// Kahn's topological sort; the ready set is id-sorted so ties
+		// resolve identically for every input permutation
+		TreeSet<String> ready = new TreeSet<>();
+		for (Map.Entry<String, Integer> e : indegree.entrySet()) {
+			if (e.getValue() == 0) {
+				ready.add(e.getKey());
+			}
+		}
+		List<ModuleManifest> order = new ArrayList<>();
+		Set<String> emitted = new HashSet<>();
+		while (!ready.isEmpty()) {
+			String id = ready.pollFirst();
+			order.add(byId.get(id));
+			emitted.add(id);
+			for (String next : Objects
+					.requireNonNull(successors.get(id))) {
+				int remaining = Objects
+						.requireNonNull(indegree.get(next)) - 1;
+				indegree.put(next, remaining);
+				if (remaining == 0) {
+					ready.add(next);
+				}
+			}
+		}
+		if (order.size() < byId.size()) {
+			SortedSet<String> stuck = new TreeSet<>(byId.keySet());
+			stuck.removeAll(emitted);
+			throw new ModuleResolutionException(
+					"module dependency cycle: "
+							+ cyclePath(successors, stuck));
+		}
+		return order;
+	} // end of resolve method
+
+	/**
+	 * Index manifests by id, rejecting duplicates.
+	 *
+	 * @param manifests The manifests to index.
+	 *
+	 * @return an id-sorted map of the manifests.
+	 *
+	 * @throws ModuleResolutionException if two manifests share an id.
+	 */
+	private static Map<String, ModuleManifest> indexById(
+			Collection<ModuleManifest> manifests)
+			throws ModuleResolutionException {
+
+		Map<String, ModuleManifest> byId = new TreeMap<>();
+		for (ModuleManifest m : manifests) {
+			if (byId.put(m.id(), m) != null) {
+				throw new ModuleResolutionException(
+						"duplicate module id '" + m.id() + "'");
+			}
+		}
+		return byId;
+	} // end of indexById method
+
+	/**
+	 * The capability index: every token maps to the id-sorted set of
+	 * modules offering it — each module's concrete id plus everything
+	 * in its {@code provides}.
+	 *
+	 * @param manifests The deduplicated manifests.
+	 *
+	 * @return the token-to-provider-ids index.
+	 */
+	private static Map<String, SortedSet<String>> indexProviders(
+			Collection<ModuleManifest> manifests) {
+
+		Map<String, SortedSet<String>> providers = new HashMap<>();
+		for (ModuleManifest m : manifests) {
+			providers.computeIfAbsent(m.id(), t -> new TreeSet<>())
+					.add(m.id());
+			for (String token : m.provides()) {
+				providers.computeIfAbsent(token, t -> new TreeSet<>())
+						.add(m.id());
+			}
+		}
+		return providers;
+	} // end of indexProviders method
+
+	/**
+	 * The single provider a {@code requires} token resolves to.
+	 *
+	 * @param token The required capability token or concrete id.
+	 * @param requirer The id of the requiring module, for messages.
+	 * @param providers The capability index.
+	 *
+	 * @return the sole provider's id (possibly the requirer itself,
+	 *         when a module provides its own requirement).
+	 *
+	 * @throws ModuleResolutionException if zero or several modules
+	 *             provide the token.
+	 */
+	private static String soleProvider(String token, String requirer,
+			Map<String, SortedSet<String>> providers)
+			throws ModuleResolutionException {
+
+		SortedSet<String> offering = providers.get(token);
+		if (offering == null || offering.isEmpty()) {
+			throw new ModuleResolutionException("module '" + requirer
+					+ "' requires '" + token
+					+ "', but no module provides it");
+		}
+		if (offering.size() > 1) {
+			throw new ModuleResolutionException("module '" + requirer
+					+ "' requires '" + token + "', but "
+					+ offering.size() + " modules provide it: "
+					+ offering);
+		}
+		return offering.first();
+	} // end of soleProvider method
+
+	/**
+	 * Every present provider of an ordering token — possibly none,
+	 * because {@code after}/{@code before} pull nothing in.
+	 *
+	 * @param token The ordering token or concrete id.
+	 * @param providers The capability index.
+	 *
+	 * @return the id-sorted providers, empty when the token is absent.
+	 */
+	private static SortedSet<String> presentProviders(String token,
+			Map<String, SortedSet<String>> providers) {
+
+		SortedSet<String> offering = providers.get(token);
+		return offering == null ? new TreeSet<>() : offering;
+	} // end of presentProviders method
+
+	/**
+	 * Record one edge: {@code from} must start before {@code to}.
+	 *
+	 * @param from The module that starts first.
+	 * @param to The module that starts after it.
+	 * @param successors The successor sets, updated in place.
+	 * @param indegree The indegree counts, updated in place; a
+	 *            duplicate edge bumps nothing.
+	 */
+	private static void addEdge(String from, String to,
+			Map<String, SortedSet<String>> successors,
+			Map<String, Integer> indegree) {
+
+		if (Objects.requireNonNull(successors.get(from)).add(to)) {
+			indegree.merge(to, 1, Integer::sum);
+		}
+	} // end of addEdge method
+
+	/**
+	 * The cycle path among the modules Kahn's algorithm could not
+	 * emit, rendered in dependency direction ({@code a -> b} reads "a
+	 * depends on / is ordered after b"). Deterministic: the walk
+	 * starts at the smallest stuck id and always follows the smallest
+	 * stuck predecessor.
+	 *
+	 * @param successors The full successor sets.
+	 * @param stuck The ids left with unresolved predecessors.
+	 *
+	 * @return the path, e.g. {@code "a -> b -> c -> a"}.
+	 */
+	private static String cyclePath(
+			Map<String, SortedSet<String>> successors,
+			SortedSet<String> stuck) {
+
+		// invert the edges among the stuck modules: every stuck module
+		// keeps at least one stuck predecessor, so the walk below must
+		// revisit a module, and where it does is a cycle
+		Map<String, SortedSet<String>> preds = new TreeMap<>();
+		for (String id : stuck) {
+			preds.put(id, new TreeSet<>());
+		}
+		for (String from : stuck) {
+			for (String to : Objects
+					.requireNonNull(successors.get(from))) {
+				if (stuck.contains(to)) {
+					Objects.requireNonNull(preds.get(to)).add(from);
+				}
+			}
+		}
+		List<String> walk = new ArrayList<>();
+		Set<String> seen = new HashSet<>();
+		String node = stuck.first();
+		while (seen.add(node)) {
+			walk.add(node);
+			node = Objects.requireNonNull(preds.get(node)).first();
+		}
+		List<String> cycle = walk.subList(walk.indexOf(node),
+				walk.size());
+		return String.join(" -> ", cycle) + " -> " + node;
+	} // end of cyclePath method
+
+} // end of ModuleResolver class

--- a/src/jls/module/package-info.java
+++ b/src/jls/module/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * The module runtime foundation (issue #220, grand-architecture §4):
+ * declarative {@link jls.module.ModuleManifest} records that describe
+ * what a module provides, requires, and how it orders — readable
+ * without running any module code — plus the
+ * {@link jls.module.ModuleResolver} that turns a set of manifests into
+ * one deterministic startup order (Kahn's topological sort, loud cycle
+ * diagnostics). This package is pure data and algorithm: the sealed
+ * lifecycle interface and the two-phase register/start runner arrive in
+ * a later slice, once the first tenant modules exist.
+ *
+ * <p>Core-clean from birth: nothing here may import AWT, Swing, or
+ * {@code jls.edit}, enforced by {@code HeadlessCoreRatchetTest} with no
+ * baseline entry ever.</p>
+ *
+ * <p>Null-marked (issue #93): every reference in this package is
+ * non-null unless annotated {@code @Nullable}, and NullAway enforces
+ * the contract at compile time on the default build.</p>
+ */
+@NullMarked
+package jls.module;
+
+import org.jspecify.annotations.NullMarked;

--- a/test/jls/HeadlessCoreRatchetTest.java
+++ b/test/jls/HeadlessCoreRatchetTest.java
@@ -68,11 +68,14 @@ class HeadlessCoreRatchetTest {
 	 *  HDL exporter, issue #60) was born clean and must stay clean -
 	 *  it has no baseline entries and never gets one. jls.core (issue
 	 *  #77) is the new headless home - born clean, policed from birth,
-	 *  never gets a baseline entry. */
+	 *  never gets a baseline entry. jls.module (the module runtime
+	 *  foundation, issue #220) likewise: born clean, no baseline
+	 *  entry ever. */
 	private static final Set<String> CORE_PACKAGE_PREFIXES = Set.of(
 			"src/jls/sim/",
 			"src/jls/elem/",
 			"src/jls/hdl/",
+			"src/jls/module/",
 			"src/jls/core/");
 
 	/**

--- a/test/jls/ModuleManifestTest.java
+++ b/test/jls/ModuleManifestTest.java
@@ -1,0 +1,145 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.module.Activation;
+import jls.module.ModuleManifest;
+
+/**
+ * Pins the {@link ModuleManifest} contract (issue #220): the record
+ * validates on construction — non-blank id and tokens, no axis naming
+ * the module itself — and holds immutable defensive copies whatever
+ * the caller passed (issue #94 discipline), so a manifest is safe to
+ * share the moment it exists. Also pins the {@link Activation}
+ * variants' own validation.
+ */
+class ModuleManifestTest {
+
+	/** A manifest with the given id and empty axes. */
+	private static ModuleManifest bare(String id) {
+		return new ModuleManifest(id, 1, Set.of(), Set.of(), Set.of(),
+				Set.of(), Set.of(), new Activation.Eager());
+	}
+
+	@Test
+	void componentsSurviveConstructionVerbatim() {
+		ModuleManifest m = new ModuleManifest("hdl.export", 3,
+				Set.of("hdl-export", "verilog"),
+				Set.of("core", "element-registry"),
+				Set.of("board-constraints"),
+				Set.of("core"),
+				Set.of("batch"),
+				new Activation.OnCommand("export-verilog"));
+		assertEquals("hdl.export", m.id());
+		assertEquals(3, m.apiVersion());
+		assertEquals(Set.of("hdl-export", "verilog"), m.provides());
+		assertEquals(Set.of("core", "element-registry"), m.requires());
+		assertEquals(Set.of("board-constraints"), m.optional());
+		assertEquals(Set.of("core"), m.after());
+		assertEquals(Set.of("batch"), m.before());
+		assertEquals(new Activation.OnCommand("export-verilog"),
+				m.activation());
+	}
+
+	@Test
+	void blankIdRejected() {
+		assertThrows(IllegalArgumentException.class, () -> bare(""));
+		assertThrows(IllegalArgumentException.class, () -> bare("  "));
+	}
+
+	@Test
+	void blankTokensRejectedOnEveryAxis() {
+		Set<String> bad = Set.of(" ");
+		Set<String> ok = Set.of();
+		Activation eager = new Activation.Eager();
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, bad, ok, ok, ok, ok,
+						eager),
+				"blank provides token must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, bad, ok, ok, ok,
+						eager),
+				"blank requires token must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, bad, ok, ok,
+						eager),
+				"blank optional token must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, ok, bad, ok,
+						eager),
+				"blank after token must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, ok, ok, bad,
+						eager),
+				"blank before token must be rejected");
+	}
+
+	@Test
+	void selfEdgesRejectedOnDependencyAndOrderingAxes() {
+		Set<String> self = Set.of("m");
+		Set<String> ok = Set.of();
+		Activation eager = new Activation.Eager();
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, self, ok, ok, ok,
+						eager),
+				"a module must not require itself");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, self, ok, ok,
+						eager),
+				"a module must not optionally use itself");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, ok, self, ok,
+						eager),
+				"a module must not order after itself");
+		assertThrows(IllegalArgumentException.class,
+				() -> new ModuleManifest("m", 1, ok, ok, ok, ok, self,
+						eager),
+				"a module must not order before itself");
+	}
+
+	@Test
+	void providesMayRestateTheConcreteId() {
+		// redundant but harmless: the concrete id is always provided
+		ModuleManifest m = new ModuleManifest("core", 1, Set.of("core"),
+				Set.of(), Set.of(), Set.of(), Set.of(),
+				new Activation.Eager());
+		assertTrue(m.provides().contains("core"));
+	}
+
+	@Test
+	void setsAreDefensivelyCopiedAndImmutable() {
+		Set<String> mutable = new HashSet<>();
+		mutable.add("cap");
+		ModuleManifest m = new ModuleManifest("m", 1, mutable, Set.of(),
+				Set.of(), Set.of(), Set.of(), new Activation.Eager());
+		mutable.add("smuggled");
+		assertEquals(Set.of("cap"), m.provides(),
+				"later caller mutation must not reach the record");
+		assertThrows(UnsupportedOperationException.class,
+				() -> m.provides().add("nope"),
+				"the record's sets must be immutable");
+	}
+
+	@Test
+	void activationTriggersValidateTheirIdentifiers() {
+		assertEquals("export-verilog",
+				new Activation.OnCommand("export-verilog").command());
+		assertEquals("circuit-opened",
+				new Activation.OnEvent("circuit-opened").event());
+		assertThrows(IllegalArgumentException.class,
+				() -> new Activation.OnCommand(" "));
+		assertThrows(IllegalArgumentException.class,
+				() -> new Activation.OnEvent(""));
+		assertEquals(new Activation.Eager(), new Activation.Eager());
+		assertEquals(new Activation.OnDemand(),
+				new Activation.OnDemand());
+	}
+
+} // end of ModuleManifestTest class

--- a/test/jls/ModuleResolverTest.java
+++ b/test/jls/ModuleResolverTest.java
@@ -1,0 +1,232 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.module.Activation;
+import jls.module.ModuleManifest;
+import jls.module.ModuleResolutionException;
+import jls.module.ModuleResolver;
+
+/**
+ * Pins the four falsifiable-acceptance behaviors of the module
+ * resolver from issue #220 — missing hard dependency fails loudly
+ * naming the token and the requirer; a cycle reports its full path;
+ * an absent optional resolves gracefully without pulling anything in;
+ * the resolved order is identical across shuffled input permutations —
+ * plus the supporting rules: duplicate ids, capability-token
+ * satisfaction, provider ambiguity, requires-implies-after, and
+ * ordering-only before/after edges (grand-architecture §4.2 rules
+ * 1-6).
+ */
+class ModuleResolverTest {
+
+	/** Shorthand manifest: all sets default empty, activation eager. */
+	private static ModuleManifest mod(String id, Set<String> provides,
+			Set<String> requires, Set<String> optional,
+			Set<String> after, Set<String> before) {
+		return new ModuleManifest(id, 1, provides, requires, optional,
+				after, before, new Activation.Eager());
+	}
+
+	/** A manifest with an id and nothing else. */
+	private static ModuleManifest bare(String id) {
+		return mod(id, Set.of(), Set.of(), Set.of(), Set.of(),
+				Set.of());
+	}
+
+	/** The resolved order as a list of ids. */
+	private static List<String> ids(List<ModuleManifest> order) {
+		return order.stream().map(ModuleManifest::id).toList();
+	}
+
+	@Test
+	void missingHardDependencyFailsNamingTokenAndRequirer() {
+		ModuleManifest orphan = mod("hdl.export", Set.of(),
+				Set.of("board-constraints"), Set.of(), Set.of(),
+				Set.of());
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleResolver.resolve(List.of(orphan)));
+		assertTrue(ex.getMessage().contains("hdl.export"),
+				"the requirer must be named: " + ex.getMessage());
+		assertTrue(ex.getMessage().contains("board-constraints"),
+				"the missing token must be named: " + ex.getMessage());
+	}
+
+	@Test
+	void ambiguousProvidersFailNamingAllOfThem() {
+		ModuleManifest first = mod("yosys", Set.of("synth"), Set.of(),
+				Set.of(), Set.of(), Set.of());
+		ModuleManifest second = mod("abc", Set.of("synth"), Set.of(),
+				Set.of(), Set.of(), Set.of());
+		ModuleManifest user = mod("hdl.export", Set.of(),
+				Set.of("synth"), Set.of(), Set.of(), Set.of());
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleResolver.resolve(
+						List.of(first, second, user)));
+		assertTrue(ex.getMessage().contains("synth"),
+				"the ambiguous token must be named: "
+						+ ex.getMessage());
+		assertTrue(ex.getMessage().contains("yosys")
+				&& ex.getMessage().contains("abc"),
+				"every competing provider must be named: "
+						+ ex.getMessage());
+	}
+
+	@Test
+	void duplicateModuleIdsFail() {
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleResolver.resolve(
+						List.of(bare("core"), bare("core"))));
+		assertTrue(ex.getMessage().contains("core"),
+				"the duplicated id must be named: " + ex.getMessage());
+	}
+
+	@Test
+	void optionalAbsentResolvesGracefullyAndPullsNothingIn() throws
+			ModuleResolutionException {
+		ModuleManifest soft = mod("gui", Set.of(), Set.of(),
+				Set.of("board-constraints"), Set.of(), Set.of());
+		assertEquals(List.of("gui"),
+				ids(ModuleResolver.resolve(List.of(soft))),
+				"an absent optional is a no-op, never a gate");
+	}
+
+	@Test
+	void requiresImpliesAfterAndTokensResolveToProviders() throws
+			ModuleResolutionException {
+		// "user" requires the capability token, not the concrete id
+		ModuleManifest provider = mod("elem.registry",
+				Set.of("element-registry"), Set.of(), Set.of(),
+				Set.of(), Set.of());
+		ModuleManifest user = mod("aaa.user", Set.of(),
+				Set.of("element-registry"), Set.of(), Set.of(),
+				Set.of());
+		assertEquals(List.of("elem.registry", "aaa.user"),
+				ids(ModuleResolver.resolve(List.of(user, provider))),
+				"the provider must start before its requirer even"
+						+ " though the tie-break alone would not");
+	}
+
+	@Test
+	void afterAloneOrdersWhenPresentAndPullsNothingWhenAbsent() throws
+			ModuleResolutionException {
+		ModuleManifest late = mod("aaa.late", Set.of(), Set.of(),
+				Set.of(), Set.of("board", "ghost"), Set.of());
+		ModuleManifest board = bare("board");
+		assertEquals(List.of("board", "aaa.late"),
+				ids(ModuleResolver.resolve(List.of(late, board))),
+				"after must order against a present provider");
+		assertEquals(List.of("aaa.late"),
+				ids(ModuleResolver.resolve(List.of(late))),
+				"after must pull nothing in when the token is absent");
+	}
+
+	@Test
+	void beforeOrdersAgainstThePresentProvider() throws
+			ModuleResolutionException {
+		ModuleManifest early = mod("zzz.early", Set.of(), Set.of(),
+				Set.of(), Set.of(), Set.of("aaa"));
+		ModuleManifest target = bare("aaa");
+		assertEquals(List.of("zzz.early", "aaa"),
+				ids(ModuleResolver.resolve(List.of(target, early))),
+				"before must win over the id-sorted tie-break");
+	}
+
+	@Test
+	void independentModulesEmergeIdSorted() throws
+			ModuleResolutionException {
+		assertEquals(List.of("batch", "collab", "core", "gui", "hdl"),
+				ids(ModuleResolver.resolve(List.of(bare("gui"),
+						bare("hdl"), bare("core"), bare("batch"),
+						bare("collab")))));
+	}
+
+	@Test
+	void providingYourOwnRequirementIsSatisfiedWithoutACycle() throws
+			ModuleResolutionException {
+		ModuleManifest self = mod("core", Set.of("kernel"),
+				Set.of("kernel"), Set.of(), Set.of(), Set.of());
+		assertEquals(List.of("core"),
+				ids(ModuleResolver.resolve(List.of(self))));
+	}
+
+	@Test
+	void requiresCycleReportsTheFullPath() {
+		ModuleManifest a = mod("a", Set.of(), Set.of("b"), Set.of(),
+				Set.of(), Set.of());
+		ModuleManifest b = mod("b", Set.of(), Set.of("c"), Set.of(),
+				Set.of(), Set.of());
+		ModuleManifest c = mod("c", Set.of(), Set.of("a"), Set.of(),
+				Set.of(), Set.of());
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleResolver.resolve(List.of(a, b, c)));
+		assertTrue(ex.getMessage().contains("a -> b -> c -> a"),
+				"the full cycle path must be reported: "
+						+ ex.getMessage());
+	}
+
+	@Test
+	void orderingOnlyCycleIsAlsoLoud() {
+		ModuleManifest a = mod("a", Set.of(), Set.of(), Set.of(),
+				Set.of("b"), Set.of());
+		ModuleManifest b = mod("b", Set.of(), Set.of(), Set.of(),
+				Set.of("a"), Set.of());
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleResolver.resolve(List.of(a, b)));
+		assertTrue(ex.getMessage().contains("a -> b -> a"),
+				"an after/after cycle must report its path: "
+						+ ex.getMessage());
+	}
+
+	@Test
+	void resolvedOrderIsIdenticalAcrossInputPermutations() throws
+			ModuleResolutionException {
+		// a small layered graph with real ties to break: core first,
+		// then registry (requires core), then three siblings that all
+		// require the registry token, one ordered before another
+		List<ModuleManifest> modules = new ArrayList<>(List.of(
+				mod("core", Set.of("kernel"), Set.of(), Set.of(),
+						Set.of(), Set.of()),
+				mod("elem.registry", Set.of("element-registry"),
+						Set.of("kernel"), Set.of(), Set.of(),
+						Set.of()),
+				mod("gui", Set.of(), Set.of("element-registry"),
+						Set.of("board"), Set.of(), Set.of()),
+				mod("hdl", Set.of(), Set.of("element-registry"),
+						Set.of(), Set.of(), Set.of("batch")),
+				mod("batch", Set.of(), Set.of("element-registry"),
+						Set.of(), Set.of(), Set.of())));
+		List<String> expected = ids(ModuleResolver.resolve(modules));
+		assertEquals(
+				List.of("core", "elem.registry", "gui", "hdl",
+						"batch"),
+				expected,
+				"layers in dependency order, ties id-sorted, before"
+						+ " respected");
+		Random shuffler = new Random(220);
+		for (int permutation = 0; permutation < 50; permutation++) {
+			Collections.shuffle(modules, shuffler);
+			assertEquals(expected,
+					ids(ModuleResolver.resolve(modules)),
+					"resolved order must not depend on discovery"
+							+ " order (permutation " + permutation
+							+ ": " + ids(modules) + ")");
+		}
+	}
+
+} // end of ModuleResolverTest class

--- a/test/jls/NullMarkedRatchetTest.java
+++ b/test/jls/NullMarkedRatchetTest.java
@@ -40,7 +40,8 @@ class NullMarkedRatchetTest {
 			"src/jls/collab/op",
 			"src/jls/collab/session",
 			"src/jls/elem",
-			"src/jls/edit");
+			"src/jls/edit",
+			"src/jls/module");
 
 	/**
 	 * Every package on the marked list still declares

--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -186,7 +186,9 @@ class MemoryModelTest {
 	@Test
 	void timingContractResetsToTheDefaultAccessTime() {
 		Memory mem = newMemory();
-		assertTrue(mem.hasTiming());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Timed,
+				"memory carries a timing contract");
 		assertTrue(mem.usesAccessTime(),
 				"memory is the one element with an access time");
 		assertEquals(100, mem.getDelay(), "documented default access time");
@@ -199,8 +201,11 @@ class MemoryModelTest {
 	@Test
 	void watchAndChangeContract() {
 		Memory mem = newMemory();
-		assertTrue(mem.canWatch());
-		assertTrue(mem.canChange());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Watchable,
+				"memory values can be watched");
+		assertTrue(asElement instanceof Editable,
+				"memory attributes can be edited");
 		assertFalse(mem.isWatched());
 		mem.setWatched(true);
 		assertTrue(mem.isWatched());

--- a/test/jls/elem/RegisterModelTest.java
+++ b/test/jls/elem/RegisterModelTest.java
@@ -124,7 +124,9 @@ class RegisterModelTest {
 	@Test
 	void timingContractResetsToTheDefaultDelay() {
 		Register reg = newRegister();
-		assertTrue(reg.hasTiming());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Timed,
+				"registers carry a timing contract");
 		assertEquals(50, reg.getDelay(), "documented default delay");
 		reg.setDelay(75);
 		assertEquals(75, reg.getDelay());
@@ -136,8 +138,11 @@ class RegisterModelTest {
 	void capabilityContract() {
 		Register reg = newRegister();
 		assertFalse(reg.canCopy(), "registers are named, so not copyable");
-		assertTrue(reg.canChange());
-		assertTrue(reg.canWatch());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Editable,
+				"register attributes can be edited");
+		assertTrue(asElement instanceof Watchable,
+				"register values can be watched");
 		assertFalse(reg.isWatched());
 		reg.setWatched(true);
 		assertTrue(reg.isWatched());
@@ -346,11 +351,12 @@ class RegisterModelTest {
 
 		@Override
 		public void post(jls.sim.SimEvent event) {
-			// only the register's own output-driving posts (non-null
-			// todo): input-change notifications also name the register
-			// as callback but carry a null todo
+			// only the register's own output-driving posts (NewValue):
+			// input-change notifications also name the register as
+			// callback but carry a PinChanged payload
 			if (event.getCallBack() instanceof Register
-					&& event.getTodo() != null) {
+					&& event.getTodo()
+							instanceof jls.sim.SimEvent.NewValue) {
 				registerPosts += 1;
 			}
 			super.post(event);

--- a/test/jls/elem/SubCircuitModelTest.java
+++ b/test/jls/elem/SubCircuitModelTest.java
@@ -150,7 +150,9 @@ class SubCircuitModelTest {
 	@Test
 	void canChangeAndDelayResetAreDelegatedSafely() {
 		SubCircuit sub = loneSub();
-		assertTrue(sub.canChange());
+		Element asElement = sub;
+		assertTrue(asElement instanceof Editable,
+				"subcircuits can be edited");
 		// the passthrough inner circuit has no timed elements; the
 		// delegation must still walk it without faulting
 		sub.resetPropDelay();


### PR DESCRIPTION
Lands the module-runtime foundation from docs/grand-architecture.md
SS4.1-4.2 as a new, born-core-clean, born-@NullMarked package of pure
data and algorithm - no lifecycle, no wiring of existing subsystems
yet:

- ModuleManifest: the SS4.1 descriptor verbatim - id, apiVersion
  (single integer, major = break), provides (capability tokens),
  requires (hard, token or concrete id), optional (soft, never a
  gate), after/before (ordering-only axis), activation - with
  compact-constructor validation (non-blank id and tokens, immutable
  defensive copies per the #94 discipline, no axis may name the
  module itself).
- Activation: sealed interface over Eager / OnCommand(String) /
  OnEvent(String) / OnDemand records; data-only this slice, the
  runner that honors triggers comes with the lifecycle slice.
- ModuleResolver.resolve: duplicate-id detection; a Debian-Provides
  capability index (provides tokens plus concrete ids); requires
  resolution where 0 providers is a loud error naming the token and
  requirer and >1 is an ambiguity error naming every provider;
  optional contributes no edge ever (absent = graceful no-op that
  pulls nothing in); requires implies after, while after/before alone
  order against present providers and pull nothing in; Kahn's
  topological sort with an id-sorted tie-break so the order is a pure
  function of the manifest set; a cycle throws
  ModuleResolutionException reporting the full path (e.g.
  "a -> b -> c -> a").
- Ratchet enrollment: src/jls/module/ joins HeadlessCoreRatchetTest
  CORE_PACKAGE_PREFIXES and NullMarkedRatchetTest MARKED with no
  baseline entries - the package can never grow an AWT/Swing/jls.edit
  import or lose @NullMarked.

Deliberately deferred to later slices per the cycle plan: the sealed
JlsModule lifecycle interface and two-phase register()/start() runner,
wiring compiled-in subsystems as manifests, the typed extension-point
registry (#223), ServiceLoader discovery + apiVersion gate (#212,
M4-gated), lazy-activation execution semantics, and the '|'
declared-alternative syntax (>1 providers stays a hard error).

Verification (headless, nix develop):
- mvn test -Dtest='ModuleManifestTest,ModuleResolverTest': 19 tests
  (7 manifest, 12 resolver), 0 failures. ModuleResolverTest pins the
  four falsifiable-acceptance behaviors from #220: missing hard dep
  fails naming token+requirer; cycle reports its path; optional-absent
  resolves gracefully; identical order across 50 seeded input
  shuffles.
- mvn clean verify: BUILD SUCCESS - headless suite 1133 tests, 0
  failures, 5 skipped; display suite 87 skipped (expected headless).
  NullAway at -Xep:NullAway:ERROR and the doclint gate pass on the
  new package.
- Coverage impact (JaCoCo, not a floor change): jls.module lands at
  100% line coverage (135/135 lines; 57/62 branches, the misses being
  defensive requireNonNull guards).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Bq6UGDVGMgiCZkzkUMBBS


🤖 Generated with [Claude Code](https://claude.com/claude-code)
