### PR TITLE
Add optional clock-edge synchronous write mode to Memory (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ All notable changes to JLS are documented here. The format follows
   failure. The toolbar the user sees is unchanged (the Import button
   stays hand-coded; `SubCircuit`, `WireEnd`, and `TestGen` are the
   documented non-palette types).
+- Optional **synchronous write** mode on RAM `Memory` elements (#199):
+  a creation-dialog checkbox (RAM only) adds a dedicated 1-bit clock
+  input, and writes then commit only on a rising clock edge with CS
+  and WE low — removing the level-sensitive glitch hazard where a
+  settling address bus with WE asserted corrupts memory at addresses
+  the design never targeted. Saved as `int sync 1` (written only when
+  on), so every existing file loads and re-saves byte-identically with
+  the classic level-sensitive behavior; the hazard, the WE-gating
+  workaround, and the new mode are documented in
+  `docs/simulation-semantics.md` §8.4 and the Memory help page.
 - Board-aware HDL export, first slice (#213): `-export` now accepts
   `-board <name>` plus `-pins <file>` and writes a pin-constraint file
   (`.pcf`) next to the exported HDL, generated from the same model walk

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -304,7 +304,7 @@ Version-1 and version-2 writers emit exactly these 32 tags:
 | `InputPin` | circuit input | |
 | `JumpEnd` | named-net receiver | |
 | `JumpStart` | named-net source | |
-| `Memory` | RAM/ROM | initial contents: `String init` (raw dump) **or** `String initrle` (run-length encoded); §9 caveat |
+| `Memory` | RAM/ROM | initial contents: `String init` (raw dump) **or** `String initrle` (run-length encoded); optional `int sync 1` = clock-edge synchronous write, RAM only, written only when on (issue #199); §9 caveat applies to both optional attributes |
 | `Mux` | multiplexer | |
 | `NandGate` | NAND gate | |
 | `NorGate` | NOR gate | |
@@ -467,6 +467,15 @@ version refuses it outright instead of loading a subtly wrong
 circuit. Writers SHOULD therefore prefer a version bump over an
 "ignorable" attribute whenever dropping the attribute would change
 simulation behavior.
+
+`Memory`'s `sync` attribute (issue #199) is a known instance of this
+class: readers older than #199 — including post-versioning ones —
+ignore the unknown name and load a synchronous-write RAM as
+level-sensitive, which changes write timing (§8.4 of
+`simulation-semantics.md`). The attribute is written only when the
+mode is on, so only circuits that opt in are exposed; whether files
+containing it should declare a bumped `FORMAT` version is an open
+question tracked with issue #199's follow-ups.
 
 **Tag stability** (issue #79): tags are frozen identifiers decoupled
 from implementation class names (§7). The reference implementation

--- a/docs/simulation-semantics.md
+++ b/docs/simulation-semantics.md
@@ -369,6 +369,43 @@ at `cycle − one`, and `Clock.react` thereafter alternates: high for
 [cycle−one, cycle), and so on. The first rising edge is at
 `cycle − one`, not at 0 and not at `cycle`.
 
+### 8.4 Memory writes (`src/jls/elem/Memory.java`)
+
+RAM writes are **level-sensitive by default**: `Memory.react` posts a
+write (completing after the access time) on *any* react in which `CS`
+and `WE` are both 0 — when the controls become 0, and again whenever
+the address or data input changes while they stay 0.
+
+- **The glitch hazard**: in a combinational datapath the write-address
+  bus (say, an ALU output) passes through transient values while it
+  settles, and each transient with `WE` asserted commits a write to a
+  *wrong* address — and those spurious writes persist. A store can
+  therefore silently corrupt memory at addresses the program never
+  targeted (issue #199, found building a single-cycle CPU). Pinned by
+  `SimulationSemanticsRegressionTest.memoryDefaultWriteIsLevelSensitiveOnEveryAddressTransient`.
+- **Workaround in the default mode**: gate `WE` with the clock phase
+  so it is asserted only after the datapath has settled (e.g. only
+  while the clock is low in a design whose state registers capture on
+  the rising edge).
+- **Synchronous write** (issue #199): an optional per-element mode
+  (the save-file `int sync 1` attribute, a creation-dialog checkbox,
+  RAM only) adds a dedicated 1-bit `clock` input. A write then
+  commits only on a **rising edge** of that input with `CS` and `WE`
+  both 0, sampling the address and data as of the edge — the same
+  remembered-previous-clock edge detection as the register (§8.1),
+  reset at simulation start. Address/data/control changes between
+  edges never write, which removes the glitch hazard the way real
+  synchronous-write SRAMs do. Falling edges never write; there is no
+  negative-edge or configurable-edge variant. Reads and the tri-state
+  output behavior (§9) are unchanged in both modes, and ROMs have no
+  write path at all. Pinned by `MemoryModelTest`
+  (`syncWriteIgnoresInputChangesWhileTheClockIsSteady`,
+  `syncWriteCommitsExactlyOnceOnTheRisingEdge`,
+  `syncWriteFallingEdgeCommitsNothing`).
+
+The default is unchanged for every pre-#199 circuit: a file without
+the `sync` attribute loads level-sensitive, byte-identically.
+
 ## 9. Tri-state and multi-driver resolution
 
 - A wire net is tri-state iff at least one attached `Output` is

--- a/resources/help/elements/memory/memory.html
+++ b/resources/help/elements/memory/memory.html
@@ -36,6 +36,13 @@ Set the capacity (in words) by entering a number in the
 A memory must have at least two words.
 
 <p>
+For a RAM, checking <b>Synchronous write (clock-edge)</b> gives the
+element a dedicated 1-bit clock input and makes writes commit only on a
+rising edge of that clock (see <b>write</b> under Operation below).
+Like the type, bits per word and capacity, this choice is made when the
+element is created.
+
+<p>
 The values of all words of memory will be zero by default.
 Some or all words of this memory element can be given non-zero initial
 values (that are reset every time the circuit is simulated).
@@ -105,7 +112,8 @@ For example, if you have 12 words of memory and the address is between 12 and
 
 <p>
 <b>write</b>
-Any time an input of a RAM changes there is the possibility of a write.
+By default, any time an input of a RAM changes there is the possibility
+of a write.
 If CS and WE become 0, then a write will be initiated using the current
 values of the address and data inputs.
 If CS and WE are already 0 and either the address or data input changes,
@@ -113,6 +121,28 @@ a write will be initiated.
 The write will complete after the memory access time.
 Right click on the memory element and select <b>Change Timing</b> to
 see and/or change the current memory access time).
+
+<p>
+<b>Beware</b>: because default writes are level-sensitive, an address
+(or data) input that passes through transient values while WE is 0 -
+for example an address computed by combinational logic that has not
+settled yet - will write at every transient address, and those spurious
+writes persist.
+In a clocked design you can avoid this by gating WE with the clock
+phase so that WE is 0 only after the inputs have settled (e.g. only
+while the clock is low, if your registers capture on the rising edge),
+or by creating the RAM with <b>Synchronous write (clock-edge)</b>.
+
+<p>
+A synchronous-write RAM has an extra 1-bit clock input.
+A write is initiated only on a rising edge (0 to 1) of that clock while
+CS and WE are both 0, using the address and data values at the time of
+the edge, and completes after the memory access time.
+Changes to the address, data or control inputs between clock edges
+never cause a write, which is how real synchronous-write memories
+behave.
+Falling edges never initiate a write.
+Reads are unaffected by this option.
 
 <p>
 If the address is greater than the number of words of memory then nothing will

--- a/src/jls/edit/MemoryDialog.java
+++ b/src/jls/edit/MemoryDialog.java
@@ -15,6 +15,7 @@ import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -124,6 +125,12 @@ public final class MemoryDialog implements ElementDialog {
 		private final JRadioButton ram = new JRadioButton("RAM");
 		/** Radio button selecting ROM as the memory type. */
 		private final JRadioButton rom = new JRadioButton("ROM");
+		/**
+		 * Checkbox selecting clock-edge synchronous writes (issue #199).
+		 * RAM only: it is disabled while ROM is selected.
+		 */
+		private final JCheckBox sync =
+				new JCheckBox("Synchronous write (clock-edge)");
 		/** Button that loads the initial contents from a file. */
 		private final JButton fromFile = new JButton("from File");
 		/** Button that opens the built-in initial-value editor. */
@@ -178,6 +185,22 @@ public final class MemoryDialog implements ElementDialog {
 				group.add(ram);
 				group.add(rom);
 				window.add(types);
+
+				// synchronous write is a RAM-only creation choice
+				// (issue #199), structural like bits/capacity/type
+				sync.setToolTipText("writes commit only on a rising edge"
+						+ " of a dedicated clock input");
+				sync.setName("dialog.memory.sync");
+				sync.getAccessibleContext()
+						.setAccessibleName("Synchronous write");
+				sync.setAlignmentX(Component.CENTER_ALIGNMENT);
+				sync.setEnabled(false);
+				ram.addActionListener(e -> sync.setEnabled(true));
+				rom.addActionListener(e -> {
+					sync.setEnabled(false);
+					sync.setSelected(false);
+				});
+				window.add(sync);
 			}
 
 			// set up inputs
@@ -338,6 +361,7 @@ public final class MemoryDialog implements ElementDialog {
 				mem.setType(tram);
 				mem.setBits(tbits);
 				mem.setCapacity(tcapacity);
+				mem.setSyncWrite(tram && sync.isSelected());
 				bitsPad.close();
 				capacityPad.close();
 			}

--- a/src/jls/edit/MemoryRenderer.java
+++ b/src/jls/edit/MemoryRenderer.java
@@ -91,6 +91,18 @@ public final class MemoryRenderer implements ElementRenderer {
 			ElementRenderSupport.drawPut(g, in);
 		}
 
+		// draw synchronous-write clock input and label (issue #199);
+		// the clock pin is appended last so the indices above hold
+		if (m.isRAM() && m.isSyncWrite()) {
+			Input clk = m.getInputList().get(5);
+			lx = clk.getX();
+			ly = clk.getY();
+			h = fm.getAscent()+fm.getDescent();
+			g.setColor(Color.black);
+			g.drawString("clk",lx+d2,ly-h/2+ascent);
+			ElementRenderSupport.drawPut(g, clk);
+		}
+
 		// draw data output and label
 		Output out = m.getOutputList().get(0);
 		lx = out.getX();

--- a/src/jls/elem/Memory.java
+++ b/src/jls/elem/Memory.java
@@ -110,6 +110,12 @@ public final class Memory extends LogicElement
 	private String initialValue = defaultInitialValue;
 	/** True if this memory is being watched during simulation. */
 	private boolean watched = false;
+	/**
+	 * True if writes commit only on a rising edge of the dedicated clock
+	 * input (issue #199); false (the default, and the only pre-#199
+	 * behavior) makes writes level-sensitive on CS/WE. RAM only.
+	 */
+	private boolean syncWrite = false;
 
 	// running properties
 	/**
@@ -132,6 +138,7 @@ public final class Memory extends LogicElement
 	 * Initialize internal info for this element.
 	 * Figures out height and width using font info from graphics object.
 	 * Note input positions: RAM-> 0 - addr, 1 - input, 2 - WE, 3 - OE, 4 - CS
+	 *                              (5 - clock when synchronous write is on)
 	 *                       ROM-> 0 - addr, 1 - OE, 2 - CS
 	 *
 	 * @param g The Graphics object to use.
@@ -183,6 +190,11 @@ public final class Memory extends LogicElement
 		}
 		inputs.add(new Input("OE",this,over,height,1));
 		inputs.add(new Input("CS",this,over+2*s,height,1));
+		if (type == Type.RAM && syncWrite) {
+			// synchronous-write clock (issue #199), appended last so
+			// the pre-#199 input indices are unchanged
+			inputs.add(new Input("clock",this,0,6*s,1));
+		}
 
 		// create output
 		Output out = new Output("output",this,width,4*s,bits);
@@ -282,6 +294,31 @@ public final class Memory extends LogicElement
 	} // end of setType method
 
 	/**
+	 * Whether writes are clock-edge synchronous (issue #199: read by the
+	 * GUI-side renderer to lay out the clock pin and by the dialog).
+	 *
+	 * @return true if writes commit only on a rising clock edge, false
+	 *         for the classic level-sensitive behavior.
+	 */
+	public boolean isSyncWrite() {
+
+		return syncWrite;
+	} // end of isSyncWrite method
+
+	/**
+	 * Set the synchronous-write mode (issue #199: applied by the GUI-side
+	 * dialog at creation, before {@link #init} lays out the pins). RAM
+	 * only; meaningless for ROM.
+	 *
+	 * @param syncWrite True for clock-edge synchronous writes, false for
+	 *        level-sensitive writes.
+	 */
+	public void setSyncWrite(boolean syncWrite) {
+
+		this.syncWrite = syncWrite;
+	} // end of setSyncWrite method
+
+	/**
 	 * Set the number of bits per word (issue #77: applied by the GUI-side
 	 * dialog).
 	 *
@@ -343,6 +380,10 @@ public final class Memory extends LogicElement
 			capacity = value;
 		} else if (name.equals("time")) {
 			accessTime = value;
+		} else if (name.equals("sync")) {
+			// clock-edge synchronous write (issue #199); absent in every
+			// pre-#199 file, so those load level-sensitive as before
+			syncWrite = value != 0;
 		} else if (name.equals("watch")) {
 			if (value == 0)
 				watched = false;
@@ -401,6 +442,11 @@ public final class Memory extends LogicElement
 		output.println(" int bits " + bits);
 		output.println(" int cap " + capacity);
 		output.println(" int time " + accessTime);
+		if (syncWrite) {
+			// written only when on, so pre-#199 circuits re-save
+			// byte-identically (issue #199)
+			output.println(" int sync 1");
+		}
 		output.println(" int watch " + (watched ? 1 : 0));
 		output.println(" String file \"" + fileName + "\"");
 
@@ -622,6 +668,7 @@ public final class Memory extends LogicElement
 		it.fileName = fileName;
 		it.specs = specs;
 		it.watched = watched;
+		it.syncWrite = syncWrite;
 		for (Input input : inputs) {
 			it.inputs.add(input.copy(it));
 		}
@@ -940,6 +987,13 @@ public final class Memory extends LogicElement
 	private @Nullable WordStore initMem;
 	/** The value currently driven on the output, or null if none. */
 	private @Nullable BitSet currentValue;
+	/**
+	 * The most recent value seen on the synchronous-write clock input
+	 * (issue #199), mirroring Register's remembered clock: a rising edge
+	 * is a react in which this is 0 and the clock input is 1. Unused
+	 * unless {@link #syncWrite} is on.
+	 */
+	private int lastClock;
 	/**
 	 * One entry in the write history: the value written (what), the address
 	 * written to (where), and the simulation time of the write (when). Used
@@ -1260,6 +1314,9 @@ public final class Memory extends LogicElement
 		// set current value to null
 		currentValue = null;
 
+		// reset the remembered synchronous-write clock (issue #199)
+		lastClock = 0;
+
 		// clear activity history
 		activity.clear();
 
@@ -1303,8 +1360,22 @@ public final class Memory extends LogicElement
 			if (addr == null)
 				addr = new BitSet();
 
+			// in synchronous-write mode a write needs a rising clock
+			// edge, detected with Register's remembered-clock scheme
+			// (issue #199); in the classic level-sensitive mode any
+			// react with CS and WE low writes
+			boolean writeGate = true;
+			int clock = 0;
+			if (type == Type.RAM && syncWrite) {
+				BitSet clockb = getInput("clock").getValue();
+				if (clockb == null)
+					clockb = new BitSet();
+				clock = clockb.get(0) ? 1 : 0;
+				writeGate = lastClock == 0 && clock == 1;
+			}
+
 			// if RAM, chip select and write enable...
-			if (type == Type.RAM && !cs && !we) {
+			if (type == Type.RAM && !cs && !we && writeGate) {
 
 				// do a write
 				BitSet data = (BitSet)(getInput("input").getValue());
@@ -1314,6 +1385,9 @@ public final class Memory extends LogicElement
 						new MemoryWrite(BitSetUtils.ToInt(addr),
 								(BitSet)(data.clone()))));
 			}
+
+			// remember the clock for the next edge check (issue #199)
+			lastClock = clock;
 
 			// if chip select and output enable ...
 			if (!cs && !oe) {

--- a/test/jls/CircuitTextBuilder.java
+++ b/test/jls/CircuitTextBuilder.java
@@ -243,14 +243,26 @@ public final class CircuitTextBuilder {
 
 	/** Puts: "address", "CS", "OE" (+"WE", "input" for RAM), "output". */
 	public int memory(String type, int bits, int capacity, String init) {
+		return memory(type, bits, capacity, init, false);
+	}
+
+	/**
+	 * Memory with the synchronous-write choice explicit (issue #199);
+	 * sync adds the 1-bit "clock" put (RAM only).
+	 */
+	public int memory(String type, int bits, int capacity, String init,
+			boolean sync) {
 		int id = nextId++;
-		open("Memory", id)
+		StringBuilder block = open("Memory", id)
 				.append(" String name \"mem").append(id).append("\"\n")
 				.append(" String type \"").append(type).append("\"\n")
 				.append(" int bits ").append(bits).append('\n')
 				.append(" int cap ").append(capacity).append('\n')
-				.append(" int time 10\n")
-				.append(" int watch 0\n")
+				.append(" int time 10\n");
+		if (sync) {
+			block.append(" int sync 1\n");
+		}
+		block.append(" int watch 0\n")
 				.append(" String file \"\"\n")
 				.append(" String init \"").append(init).append("\"\n")
 				.append("END\n");

--- a/test/jls/SimulationSemanticsRegressionTest.java
+++ b/test/jls/SimulationSemanticsRegressionTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import jls.elem.Element;
 import jls.elem.Input;
 import jls.elem.LogicElement;
+import jls.elem.Memory;
 import jls.elem.OutputPin;
 import jls.elem.Pause;
 import jls.elem.Register;
@@ -46,6 +47,10 @@ import jls.sim.Simulator;
  * - S6: TriState suppresses redundant output events like Gate.react;
  * - S7: Constant masks its value to the attached net's width
  *   (documented as intended in the spec, section 6.2).
+ *
+ * Also pins the level-sensitive memory-write default of spec section
+ * 8.4 - the glitch hazard the optional synchronous-write mode of
+ * issue #199 exists to avoid.
  */
 class SimulationSemanticsRegressionTest {
 
@@ -600,5 +605,43 @@ class SimulationSemanticsRegressionTest {
 		sim.runSim();
 		assertEquals(15, pinValue(circuit, "o"),
 				"a constant wider than its net drives value mod 2^bits");
+	}
+
+	// ---------------------------------------------------------------
+	// memory write sensitivity (spec section 8.4, issue #199)
+	// ---------------------------------------------------------------
+
+	/**
+	 * Memory writes are level-sensitive by default: with CS and WE held
+	 * low, every address transient commits a write, so an address bus
+	 * that moves while WE is asserted corrupts memory at addresses the
+	 * design never targeted. This pins the documented hazard the
+	 * optional synchronous-write mode (MemoryModelTest's sync tests)
+	 * exists to avoid.
+	 */
+	@Test
+	void memoryDefaultWriteIsLevelSensitiveOnEveryAddressTransient()
+			throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int ram = cb.memory("RAM", 8, 2, "");
+		int addr = cb.clock(20, 10);
+		int data = cb.constant(7);
+		int select = cb.constant(0);
+		int write = cb.constant(0);
+		int enable = cb.constant(1);
+		cb.wire(addr, "output", ram, "address");
+		cb.wire(data, "output", ram, "input");
+		cb.wire(select, "output", ram, "CS");
+		cb.wire(write, "output", ram, "WE");
+		cb.wire(enable, "output", ram, "OE");
+		Circuit circuit = load(cb.build());
+		BatchSimulator sim = new BatchSimulator();
+		sim.setCircuit(circuit);
+		sim.setTimeLimit(100);
+		sim.runSim();
+		Memory mem = find(circuit, Memory.class);
+		assertEquals(java.util.Set.of(0, 1), mem.storedAddresses(),
+				"a level-sensitive RAM writes at every address the bus"
+						+ " visits while CS and WE are low");
 	}
 }

--- a/test/jls/elem/AttributePersistenceTest.java
+++ b/test/jls/elem/AttributePersistenceTest.java
@@ -1,6 +1,7 @@
 package jls.elem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -118,6 +119,46 @@ class AttributePersistenceTest {
 		assertEquals(withoutSid(saveElement(constant)),
 				withoutSid(saveElement(copy)),
 				"a copy must serialize identically to its original");
+	}
+
+	@Test
+	void memorySyncWriteAttributeRoundTrips() throws Exception {
+		// the synchronous-write mode (issue #199) saves as "int sync 1"
+		Circuit circuit = load("CIRCUIT attrtest\n"
+				+ "ELEMENT Memory\n"
+				+ " int id 0\n int x 60\n int y 60\n int width 48\n int height 64\n"
+				+ " String name \"m1\"\n String type \"RAM\"\n"
+				+ " int bits 8\n int cap 4\n int time 10\n int sync 1\n"
+				+ " int watch 0\n String file \"\"\n String init \"\"\n"
+				+ "END\n"
+				+ "ENDCIRCUIT\n");
+		Memory mem = (Memory) circuit.getElements().iterator().next();
+		assertTrue(mem.isSyncWrite(),
+				"int sync 1 must load the synchronous-write mode");
+		assertTrue(saveElement(mem).contains(" int sync 1"),
+				"the synchronous-write mode must survive a re-save");
+		Memory copy = (Memory) mem.copy();
+		assertTrue(copy.isSyncWrite(),
+				"copy must carry the synchronous-write mode (#23 drift)");
+	}
+
+	@Test
+	void memoryWithoutSyncAttributeStaysAsync() throws Exception {
+		// every pre-#199 file omits sync and must keep today's
+		// level-sensitive writes, byte-identically on re-save
+		Circuit circuit = load("CIRCUIT attrtest\n"
+				+ "ELEMENT Memory\n"
+				+ " int id 0\n int x 60\n int y 60\n int width 48\n int height 64\n"
+				+ " String name \"m1\"\n String type \"RAM\"\n"
+				+ " int bits 8\n int cap 4\n int time 10\n"
+				+ " int watch 0\n String file \"\"\n String init \"\"\n"
+				+ "END\n"
+				+ "ENDCIRCUIT\n");
+		Memory mem = (Memory) circuit.getElements().iterator().next();
+		assertFalse(mem.isSyncWrite(),
+				"an omitted sync attribute must default to async");
+		assertFalse(saveElement(mem).contains("sync"),
+				"the default must stay omitted on re-save");
 	}
 
 	/** Saved text minus the sid line, which copy() deliberately skips. */

--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -62,6 +62,11 @@ class MemoryModelTest {
 
 	/** Load circuit text, run the batch simulator, return the memory. */
 	private static Memory simulate(String circuitText) {
+		return simulate(circuitText, 1_000_000);
+	}
+
+	/** Load circuit text, run the batch simulator to the given time. */
+	private static Memory simulate(String circuitText, long timeLimit) {
 		Circuit circuit = new Circuit("memmodel");
 		assertTrue(circuit.load(new Scanner(circuitText)),
 				() -> "load failed: " + JLSInfo.loadError);
@@ -73,7 +78,7 @@ class MemoryModelTest {
 		}
 		BatchSimulator sim = new BatchSimulator();
 		sim.setCircuit(circuit);
-		sim.setTimeLimit(1_000_000);
+		sim.setTimeLimit(timeLimit);
 		sim.runSim();
 		return findMemory(circuit);
 	}
@@ -336,6 +341,92 @@ class MemoryModelTest {
 		cb.wire(select, "output", rom, "CS");
 		cb.wire(enable, "output", rom, "OE");
 		return cb.build();
+	}
+
+	// ---------------------------------------------------------------
+	// synchronous write (issue #199): writes commit only on a rising
+	// edge of the dedicated clock input
+	// ---------------------------------------------------------------
+
+	/**
+	 * A synchronous-write RAM with address, data and the (active-low)
+	 * controls driven by constants and the dedicated clock driven by a
+	 * Clock element with cycle 1000, one 400: the output is 0 on
+	 * [0,600), 1 on [600,1000), so the only rising edge before 1600 is
+	 * at 600 and the only falling edge is at 1000.
+	 */
+	private static String syncRamCircuit(long addr, long data) {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int ram = cb.memory("RAM", 8, 4, "", true);
+		int a = cb.constant(addr);
+		int d = cb.constant(data);
+		int select = cb.constant(0);
+		int write = cb.constant(0);
+		int enable = cb.constant(1);
+		int clk = cb.clock(1000, 400);
+		cb.wire(a, "output", ram, "address");
+		cb.wire(d, "output", ram, "input");
+		cb.wire(select, "output", ram, "CS");
+		cb.wire(write, "output", ram, "WE");
+		cb.wire(enable, "output", ram, "OE");
+		cb.wire(clk, "output", ram, "clock");
+		return cb.build();
+	}
+
+	@Test
+	void syncWriteIgnoresInputChangesWhileTheClockIsSteady() {
+		// the glitch hazard of issue #199 inverted: the address keeps
+		// toggling (a Clock drives the 1-bit address bus) with CS and
+		// WE held low, but the write clock never rises, so nothing at
+		// all may be written
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int ram = cb.memory("RAM", 8, 2, "", true);
+		int a = cb.clock(20, 10);
+		int d = cb.constant(7);
+		int select = cb.constant(0);
+		int write = cb.constant(0);
+		int enable = cb.constant(1);
+		int clk = cb.constant(0);
+		cb.wire(a, "output", ram, "address");
+		cb.wire(d, "output", ram, "input");
+		cb.wire(select, "output", ram, "CS");
+		cb.wire(write, "output", ram, "WE");
+		cb.wire(enable, "output", ram, "OE");
+		cb.wire(clk, "output", ram, "clock");
+		Memory mem = simulate(cb.build(), 500);
+		assertTrue(mem.storedAddresses().isEmpty(),
+				"no rising clock edge means no write, however the"
+						+ " address moves");
+		assertEquals("", mem.getActivityTrace(),
+				"a gated-off write must not enter the activity history");
+	}
+
+	@Test
+	void syncWriteCommitsExactlyOnceOnTheRisingEdge() {
+		// one rising edge (at 600) inside the time limit commits one
+		// write at the settled address
+		Memory mem = simulate(syncRamCircuit(2, 7), 800);
+		BitSet stored = mem.getCurrentValue(2);
+		assertNotNull(stored);
+		assertEquals(7, BitSetUtils.ToLong(stored));
+		assertEquals(java.util.Set.of(2), mem.storedAddresses(),
+				"the rising edge must write exactly the settled address");
+		String trace = mem.getActivityTrace();
+		assertEquals(1, trace.split("\n", -1).length - 1,
+				"exactly one write, got:\n" + trace);
+		assertTrue(trace.contains("0x7 written to location 0x2 at time "),
+				trace);
+	}
+
+	@Test
+	void syncWriteFallingEdgeCommitsNothing() {
+		// widening the window past the falling edge at 1000 (the next
+		// rising edge is at 1600) must not add a second write
+		Memory mem = simulate(syncRamCircuit(2, 7), 1300);
+		assertEquals(java.util.Set.of(2), mem.storedAddresses());
+		String trace = mem.getActivityTrace();
+		assertEquals(1, trace.split("\n", -1).length - 1,
+				"the falling edge must not write, got:\n" + trace);
 	}
 
 	@Test


### PR DESCRIPTION
RAM writes in JLS are level-sensitive: `Memory.react` posts a write on
any react with CS and WE both 0, so a combinational write-address bus
that glitches through transient values while WE is asserted commits
persistent writes at addresses the design never targeted (found
building a single-cycle RV32I CPU). This lands the opt-in fix scoped
for #199, default behavior unchanged.

What landed:

- `Memory` (model): a `syncWrite` flag saved as `int sync 1` (written
  only when on, so every pre-#199 file loads and re-saves
  byte-identically as level-sensitive), loaded via `setValue`, copied
  by `copy()`. When on, `init()` appends a dedicated 1-bit `clock`
  input after the existing pins (indices unchanged), and the
  PinChanged case of `react()` gates the MemoryWrite post on a rising
  edge of that clock, using Register's remembered-previous-clock
  scheme (`lastClock`, reset in `initSim`). Reads, TriStateOff, and
  ROMs are untouched.
- `MemoryDialog`: a "Synchronous write (clock-edge)" checkbox in the
  create form, enabled only while RAM is selected (structural like
  type/bits/capacity, so creation-only, matching the dialog's
  existing precedent).
- `MemoryRenderer`: draws the extra clock pin with a "clk" label.
- Docs: new `docs/simulation-semantics.md` section 8.4 (hazard,
  WE-gating workaround, sync semantics), `docs/file-format.md` Memory
  row + a silent-drop-caveat note (`sync` is an "ignorable" attribute
  a pre-#199 reader drops, degrading to level-sensitive writes;
  whether such files should bump FORMAT is flagged as an open #199
  follow-up), Memory help page (Creation + Operation), CHANGELOG.

Tests (all through the real loader + BatchSimulator, no hand-posted
events):

- `MemoryModelTest`: steady clock with CS/WE low and a toggling
  address stores zero writes; one rising edge commits exactly one
  write at the settled address; the falling edge commits nothing.
- `SimulationSemanticsRegressionTest`: pins the level-sensitive
  default hazard (a moving address bus with CS/WE low writes at every
  visited address) as documented semantics, per spec section 8.4.
- `AttributePersistenceTest`: `int sync 1` round-trips through
  save/load/copy; an omitted attribute loads async and stays omitted
  on re-save.
- `CircuitTextBuilder`: `memory(...)` overload with an explicit sync
  flag.

Verification (headless, nix develop):

- Targeted: MemoryModelTest (26), AttributePersistenceTest (6),
  SimulationSemanticsRegressionTest (9), AllElementsRoundTripTest (2),
  ElementRegistryTest (5), DeterministicSaveTest (10) - 58/58 pass.
- Full `mvn clean verify`: BUILD SUCCESS, 1120 tests, 0 failures,
  5 skipped (pre-existing) + 87 display-tagged tests skipped headless
  as expected; coverage ratchet passes.
- Coverage after the change: Memory.java 94.5% instruction
  (1972/2086), jls.elem 75.4%; no pom coverage floors touched.

Deferred per the slice scope: issue #201 entirely (multi-port
register file, sign/zero-extend elements - they collide with #78's
descriptor work this cycle), negative/configurable-edge writes, ROM
sync mode, and any renderer redesign beyond the extra pin.

Closes #199.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Bq6UGDVGMgiCZkzkUMBBS


🤖 Generated with [Claude Code](https://claude.com/claude-code)
