### PR TITLE
Give KeyPad's icon-only buttons accessible names and tooltips (#75)

### DIFF
--- a/src/jls/KeyPad.java
+++ b/src/jls/KeyPad.java
@@ -55,6 +55,21 @@ public final class KeyPad extends JButton implements ActionListener {
 		URL up = KeyPad.class.getResource("images/up.gif");
 		hide.setIcon(new ImageIcon(up));
 
+		// accessible names and tooltips for the icon-only buttons, so a
+		// screen reader announces them instead of nothing (#75), plus
+		// stable component names for the UI harness (#91,
+		// docs/component-naming.md)
+		setToolTipText("Show keypad");
+		getAccessibleContext().setAccessibleName("Show keypad");
+		setName("keypad.toggle");
+		hide.setToolTipText("Hide keypad");
+		hide.getAccessibleContext().setAccessibleName("Hide keypad");
+		hide.setName("keypad.hide");
+		reset.setToolTipText("Clear to default value");
+		reset.getAccessibleContext().setAccessibleName(
+				"Clear to default value");
+		reset.setName("keypad.reset");
+
 
 		// save parameters
 		this.target = target;

--- a/test/jls/KeyPadAccessibilityPinTest.java
+++ b/test/jls/KeyPadAccessibilityPinTest.java
@@ -1,0 +1,101 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the KeyPad accessibility wiring (issue #75) in headless runs.
+ * The KeyPad's toggle button (the KeyPad itself, down.gif) and hide
+ * button (up.gif) are icon-only, so without an explicit accessible
+ * name a screen reader focusing them announces nothing, and the reset
+ * button's bare "C" announces as a letter rather than an action.
+ *
+ * The GUI cannot be constructed under surefire's
+ * {@code java.awt.headless=true}, so the constructor wiring is pinned
+ * by reading the source from the repo tree — the same
+ * compensating-control pattern as MenuAcceleratorPolicyTest. The real
+ * accessibility channel is asserted by the display-tagged
+ * {@code jls.ui.KeyPadAccessibilityTest} under the #162 substrate.
+ */
+class KeyPadAccessibilityPinTest {
+
+	/**
+	 * The icon-only toggle button (the KeyPad itself) sets an
+	 * accessible name, a tooltip, and its harness component name.
+	 */
+	@Test
+	void toggleButtonIsWiredForAccessibility() throws IOException {
+		String text = readSource("src/jls/KeyPad.java");
+
+		assertTrue(text.contains(
+				"getAccessibleContext().setAccessibleName(\"Show keypad\")"),
+				"the icon-only toggle button must set an accessible name");
+		assertTrue(text.contains("setToolTipText(\"Show keypad\")"),
+				"the toggle button must have a tooltip");
+		assertTrue(text.contains("setName(\"keypad.toggle\")"),
+				"the toggle button must carry its #91 harness name");
+	}
+
+	/**
+	 * The icon-only hide button sets an accessible name, a tooltip,
+	 * and its harness component name.
+	 */
+	@Test
+	void hideButtonIsWiredForAccessibility() throws IOException {
+		String text = readSource("src/jls/KeyPad.java");
+
+		assertTrue(text.contains(
+				"hide.getAccessibleContext().setAccessibleName(\"Hide keypad\")"),
+				"the icon-only hide button must set an accessible name");
+		assertTrue(text.contains("hide.setToolTipText(\"Hide keypad\")"),
+				"the hide button must have a tooltip");
+		assertTrue(text.contains("hide.setName(\"keypad.hide\")"),
+				"the hide button must carry its #91 harness name");
+	}
+
+	/**
+	 * The reset button announces its action ("Clear to default value")
+	 * instead of the bare letter C, and carries a tooltip and its
+	 * harness component name.
+	 */
+	@Test
+	void resetButtonAnnouncesItsAction() throws IOException {
+		String text = readSource("src/jls/KeyPad.java");
+
+		assertTrue(text.contains("reset.getAccessibleContext()"),
+				"the reset button must set an explicit accessible name");
+		assertTrue(text.contains("\"Clear to default value\")"),
+				"the reset button's accessible name must describe the"
+						+ " action, not the bare letter C");
+		assertTrue(text.contains(
+				"reset.setToolTipText(\"Clear to default value\")"),
+				"the reset button must have a tooltip");
+		assertTrue(text.contains("reset.setName(\"keypad.reset\")"),
+				"the reset button must carry its #91 harness name");
+	}
+
+	/**
+	 * Read a source file from the repo tree (maven runs tests with
+	 * user.dir at the repo root).
+	 *
+	 * @param relative repo-relative path of the source file.
+	 *
+	 * @return the file's text.
+	 *
+	 * @throws IOException if the file cannot be read.
+	 */
+	private static String readSource(String relative) throws IOException {
+		Path source = Path.of(System.getProperty("user.dir"), relative);
+		assertTrue(Files.isRegularFile(source),
+				"run from the repo root (maven sets user.dir there): "
+						+ source);
+		return Files.readString(source, StandardCharsets.UTF_8);
+	} // end of readSource method
+
+} // end of KeyPadAccessibilityPinTest class

--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -186,7 +186,9 @@ class MemoryModelTest {
 	@Test
 	void timingContractResetsToTheDefaultAccessTime() {
 		Memory mem = newMemory();
-		assertTrue(mem.hasTiming());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Timed,
+				"memory carries a timing contract");
 		assertTrue(mem.usesAccessTime(),
 				"memory is the one element with an access time");
 		assertEquals(100, mem.getDelay(), "documented default access time");
@@ -199,8 +201,11 @@ class MemoryModelTest {
 	@Test
 	void watchAndChangeContract() {
 		Memory mem = newMemory();
-		assertTrue(mem.canWatch());
-		assertTrue(mem.canChange());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Watchable,
+				"memory values can be watched");
+		assertTrue(asElement instanceof Editable,
+				"memory attributes can be edited");
 		assertFalse(mem.isWatched());
 		mem.setWatched(true);
 		assertTrue(mem.isWatched());

--- a/test/jls/elem/RegisterModelTest.java
+++ b/test/jls/elem/RegisterModelTest.java
@@ -124,7 +124,9 @@ class RegisterModelTest {
 	@Test
 	void timingContractResetsToTheDefaultDelay() {
 		Register reg = newRegister();
-		assertTrue(reg.hasTiming());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Timed,
+				"registers carry a timing contract");
 		assertEquals(50, reg.getDelay(), "documented default delay");
 		reg.setDelay(75);
 		assertEquals(75, reg.getDelay());
@@ -136,8 +138,11 @@ class RegisterModelTest {
 	void capabilityContract() {
 		Register reg = newRegister();
 		assertFalse(reg.canCopy(), "registers are named, so not copyable");
-		assertTrue(reg.canChange());
-		assertTrue(reg.canWatch());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Editable,
+				"register attributes can be edited");
+		assertTrue(asElement instanceof Watchable,
+				"register values can be watched");
 		assertFalse(reg.isWatched());
 		reg.setWatched(true);
 		assertTrue(reg.isWatched());
@@ -346,11 +351,12 @@ class RegisterModelTest {
 
 		@Override
 		public void post(jls.sim.SimEvent event) {
-			// only the register's own output-driving posts (non-null
-			// todo): input-change notifications also name the register
-			// as callback but carry a null todo
+			// only the register's own output-driving posts (NewValue):
+			// input-change notifications also name the register as
+			// callback but carry a PinChanged payload
 			if (event.getCallBack() instanceof Register
-					&& event.getTodo() != null) {
+					&& event.getTodo()
+							instanceof jls.sim.SimEvent.NewValue) {
 				registerPosts += 1;
 			}
 			super.post(event);

--- a/test/jls/elem/SubCircuitModelTest.java
+++ b/test/jls/elem/SubCircuitModelTest.java
@@ -150,7 +150,9 @@ class SubCircuitModelTest {
 	@Test
 	void canChangeAndDelayResetAreDelegatedSafely() {
 		SubCircuit sub = loneSub();
-		assertTrue(sub.canChange());
+		Element asElement = sub;
+		assertTrue(asElement instanceof Editable,
+				"subcircuits can be edited");
 		// the passthrough inner circuit has no timed elements; the
 		// delegation must still walk it without faulting
 		sub.resetPropDelay();

--- a/test/jls/ui/KeyPadAccessibilityTest.java
+++ b/test/jls/ui/KeyPadAccessibilityTest.java
@@ -1,0 +1,163 @@
+package jls.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.awt.Component;
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
+
+import javax.swing.AbstractButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import jls.KeyPad;
+
+/**
+ * Every button in the KeyPad exposes a non-blank accessible name
+ * (issue #75 accessibility). The keypad-toggle button (the KeyPad
+ * itself) and the hide button are icon-only (down.gif / up.gif), so
+ * without an explicit accessible name a screen reader focusing them
+ * would announce nothing — they were the last blank-accessible-name
+ * components in src/. The reset button carried only the bare text "C",
+ * which announces as the letter rather than what it does.
+ *
+ * This test reads {@code getAccessibleContext().getAccessibleName()}
+ * on the real buttons inside the real keypad JDialog — the same
+ * accessibility channel an AT queries — modeled on
+ * {@link PaletteButtonAccessibilityTest}, with the KeyPad construction
+ * and window-reflection plumbing of {@link KeyPadDismissalTest}.
+ *
+ * Tagged {@code display}: constructs real Swing components, so it runs
+ * under the #162 substrate
+ * (xvfb-run -a mvn -B verify -Djls.test.headless=false) and skips
+ * headless. The headless counterpart is
+ * {@code jls.KeyPadAccessibilityPinTest}.
+ */
+@Tag("display")
+class KeyPadAccessibilityTest {
+
+	private JFrame owner;
+	private JTextField field;
+	private KeyPad pad;
+
+	@BeforeEach
+	void requireDisplay() throws Exception {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"display suite: skipped in headless runs");
+		SwingUtilities.invokeAndWait(() -> {
+			owner = new JFrame("keypad-a11y-test");
+			field = new JTextField(10);
+			pad = new KeyPad(field, 16, 0, owner);
+			owner.getContentPane().add(field);
+			owner.getContentPane().add(pad);
+			owner.pack();
+		});
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			if (pad != null) {
+				pad.close();
+			}
+			if (owner != null) {
+				owner.dispose();
+			}
+		});
+	}
+
+	/** The keypad's popup window, reached through its private field. */
+	private JDialog padWindow() throws Exception {
+		Field win = KeyPad.class.getDeclaredField("win");
+		win.setAccessible(true);
+		return (JDialog) win.get(pad);
+	}
+
+	/**
+	 * Every AbstractButton in the keypad window announces a non-blank
+	 * accessible name — the digit buttons derive theirs from their
+	 * text, and the icon-only hide button and the reset button carry
+	 * the explicit names set in the constructor.
+	 */
+	@Test
+	void everyKeypadButtonHasAnAccessibleName() throws Exception {
+		JDialog win = padWindow();
+		SwingUtilities.invokeAndWait(() -> {
+			int buttons = 0;
+			for (Component c : win.getContentPane().getComponents()) {
+				if (!(c instanceof AbstractButton button)) {
+					continue;
+				}
+				buttons += 1;
+				String name = button.getAccessibleContext()
+						.getAccessibleName();
+				assertFalse(name == null || name.isBlank(),
+						"keypad button (name '" + button.getName()
+								+ "', text '" + button.getText()
+								+ "') exposes a non-blank accessible"
+								+ " name, got '" + name + "'");
+			}
+			assertEquals(18, buttons,
+					"the base-16 keypad has 16 digits + reset + hide");
+		});
+	}
+
+	/**
+	 * The icon-only toggle and hide buttons and the bare-"C" reset
+	 * button announce what they do, both to a screen reader (accessible
+	 * name) and to a sighted user hovering them (tooltip), and carry
+	 * stable component names for the #91 harness.
+	 */
+	@Test
+	void iconOnlyButtonsAnnounceTheirPurpose() throws Exception {
+		JDialog win = padWindow();
+		SwingUtilities.invokeAndWait(() -> {
+			// the toggle button is the KeyPad itself
+			assertEquals("Show keypad",
+					pad.getAccessibleContext().getAccessibleName(),
+					"the icon-only keypad-toggle button announces"
+							+ " itself");
+			assertEquals("Show keypad", pad.getToolTipText(),
+					"the toggle button has a matching tooltip");
+			assertEquals("keypad.toggle", pad.getName(),
+					"the toggle button carries its harness name");
+
+			AbstractButton hide = byName(win, "keypad.hide");
+			assertEquals("Hide keypad",
+					hide.getAccessibleContext().getAccessibleName(),
+					"the icon-only hide button announces itself");
+			assertEquals("Hide keypad", hide.getToolTipText(),
+					"the hide button has a matching tooltip");
+
+			AbstractButton reset = byName(win, "keypad.reset");
+			assertEquals("Clear to default value",
+					reset.getAccessibleContext().getAccessibleName(),
+					"the reset button announces its action, not the"
+							+ " bare letter C");
+			assertEquals("Clear to default value",
+					reset.getToolTipText(),
+					"the reset button has a matching tooltip");
+		});
+	}
+
+	/** Find the button with the given component name in the window. */
+	private static AbstractButton byName(JDialog win, String name) {
+		for (Component c : win.getContentPane().getComponents()) {
+			if (c instanceof AbstractButton button
+					&& name.equals(button.getName())) {
+				return button;
+			}
+		}
+		throw new AssertionError("no keypad button named " + name);
+	}
+
+} // end of KeyPadAccessibilityTest class


### PR DESCRIPTION
The KeyPad's keypad-toggle button (the KeyPad itself, down.gif) and
hide button (up.gif) had no text, no tooltip, and no accessible name —
the last blank-accessible-name components in src/ — so a screen reader
focusing them announced nothing. The reset button announced only the
bare letter "C". This lands the accessible-names remnant of #75's
FILLED menu/dialog-a11y scope:

- `src/jls/KeyPad.java`: the constructor now sets an explicit
  accessible name and a matching tooltip on all three buttons —
  "Show keypad" (toggle), "Hide keypad" (hide), and
  "Clear to default value" (reset, instead of the bare "C") — plus
  stable component names for the #91 harness
  (`keypad.toggle`/`keypad.hide`/`keypad.reset`), following the
  docs/component-naming.md dot-separated scheme.
- `test/jls/ui/KeyPadAccessibilityTest.java` (new, @Tag("display")):
  asserts the real accessibility channel on the real keypad JDialog —
  every AbstractButton in the base-16 pad (16 digits + reset + hide)
  exposes a non-blank `getAccessibleContext().getAccessibleName()`,
  and the toggle/hide/reset names, tooltips, and component names are
  exactly as wired. Modeled on PaletteButtonAccessibilityTest with
  KeyPadDismissalTest's construction/reflection plumbing; skips
  headless, runs under the #162 xvfb substrate in CI.
- `test/jls/KeyPadAccessibilityPinTest.java` (new, headless): pins the
  constructor wiring by scanning src/jls/KeyPad.java from the repo
  tree (MenuAcceleratorPolicyTest's compensating-control pattern), so
  the change is provable in headless CI/sandbox.

Explicitly deferred, staying on open #75 (this commit does not close
it): the shared Action-layer rebase held from PR #196, the File>Close
accelerator (sequenced behind the H2 wire-start migration), the H2
keyboard-construction spike, and canvas screen-reader support (out of
scope per the FILLED adjudication).

Verification (headless, nix develop):
- mvn -B test -Dtest=KeyPadAccessibilityPinTest,KeyPadAccessibilityTest:
  pin test 3/3 green; display test compiles and skips cleanly
  (2 skipped).
- mvn -B clean verify: BUILD SUCCESS — 1117 headless tests, 0
  failures, 5 skipped; display lane 89 skipped (expected headless);
  coverage ratchet green. Coverage impact: ~11 new constructor lines
  in KeyPad are display-only and uncovered headless; the jls-package
  LINE floor still passes with margin.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Bq6UGDVGMgiCZkzkUMBBS


🤖 Generated with [Claude Code](https://claude.com/claude-code)
