### PR TITLE
Extract OptionMenuPolicy and pin context-menu content headlessly (#86)

### DIFF
--- a/src/jls/edit/OptionMenuPolicy.java
+++ b/src/jls/edit/OptionMenuPolicy.java
@@ -1,0 +1,206 @@
+package jls.edit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import jls.elem.Editable;
+import jls.elem.Element;
+import jls.elem.JumpStart;
+import jls.elem.QuickEditable;
+import jls.elem.Rotatable;
+import jls.elem.Timed;
+import jls.elem.Watchable;
+import jls.elem.Wire;
+
+/**
+ * The per-element content policy for the editor's right-click option
+ * menu (issue #86, H3 close-out).
+ *
+ * <p>{@code SimpleEditor.makeOptionMenu} used to decide <em>which</em>
+ * items an element's context menu shows inline, between Swing calls, so
+ * the decision was untestable headless (the surefire JVM runs with
+ * {@code java.awt.headless=true}, where the editor cannot be
+ * constructed). This class is that decision, extracted verbatim: a pure
+ * function from an element's capability traits (issue #78) and state to
+ * an ordered list of typed {@link Entry} values. The editor maps each
+ * entry onto its existing shared menu items ({@link EditOp}-backed
+ * {@code Action}s from issue #75, the quick-shortcuts submenu, the
+ * matching-jump item) without adding or reordering anything, so the
+ * menu a user sees is exactly this list.</p>
+ *
+ * <p>Like {@link DeleteKeyPolicy} and
+ * {@link KeyboardConstructionPolicy}, the class names no AWT or Swing
+ * type, so every branch is unit-testable headless.</p>
+ *
+ * @jls.testedby jls.edit.OptionMenuPolicyTest
+ */
+final class OptionMenuPolicy {
+
+	/** Watch item label when the element is not being watched. */
+	static final String WATCH_LABEL = "Watch Element";
+
+	/** Watch item label when the element is already being watched. */
+	static final String UNWATCH_LABEL = "Un-watch Element";
+
+	/** Probe item label when the wire has no probe. */
+	static final String ATTACH_PROBE_LABEL = "Attach Probe";
+
+	/** Probe item label when the wire already has a probe. */
+	static final String REMOVE_PROBE_LABEL = "Remove Probe";
+
+	/** Label of the matching-jump-end item (JumpStart only). */
+	static final String MATCH_JUMP_LABEL = "Create Matching End";
+
+	/** Label of the quick-shortcuts submenu (built by
+	 * {@link ElementQuickMenus}, which owns the submenu contents). */
+	static final String QUICK_LABEL = "shortcuts";
+
+	/**
+	 * Prevents instantiation; the class holds only static policy methods.
+	 */
+	private OptionMenuPolicy() {
+		// static use only
+	} // end of OptionMenuPolicy constructor
+
+	/**
+	 * The kind of surface a menu entry maps to.
+	 */
+	enum Kind {
+
+		/** The element's quick-shortcuts submenu (issue #77's
+		 * {@code ElementQuickMenus} builds it). */
+		QUICK,
+
+		/** A menu item backed by an {@link EditOp} shared Action. */
+		OP,
+
+		/** The create-matching-jump-end item, the one popup-only
+		 * operation without a shared Action (issue #86 note: the last
+		 * legacy ActionListener). */
+		MATCH_JUMP
+
+	} // end of Kind enum
+
+	/**
+	 * One entry of an element's option menu, in menu order.
+	 *
+	 * @param kind which surface the entry maps to.
+	 * @param op the backing operation for {@link Kind#OP} entries,
+	 *           null for the other kinds.
+	 * @param label the label the item shows; for state-labelled entries
+	 *              (watch, probe) it already reflects the element state.
+	 */
+	record Entry(Kind kind, @Nullable EditOp op, String label) {
+
+		/**
+		 * The quick-shortcuts submenu entry.
+		 *
+		 * @return the QUICK entry.
+		 */
+		static Entry quick() {
+
+			return new Entry(Kind.QUICK, null, QUICK_LABEL);
+		} // end of quick method
+
+		/**
+		 * An operation-backed entry with the operation's stable label.
+		 *
+		 * @param op the backing operation.
+		 * @return the OP entry.
+		 */
+		static Entry of(EditOp op) {
+
+			return new Entry(Kind.OP, op, op.label());
+		} // end of of method
+
+		/**
+		 * An operation-backed entry with a state-dependent label.
+		 *
+		 * @param op the backing operation.
+		 * @param label the label reflecting the element's state.
+		 * @return the OP entry.
+		 */
+		static Entry of(EditOp op, String label) {
+
+			return new Entry(Kind.OP, op, label);
+		} // end of of method
+
+		/**
+		 * The create-matching-jump-end entry.
+		 *
+		 * @return the MATCH_JUMP entry.
+		 */
+		static Entry matchJump() {
+
+			return new Entry(Kind.MATCH_JUMP, null, MATCH_JUMP_LABEL);
+		} // end of matchJump method
+
+		/**
+		 * The backing operation of an {@link Kind#OP} entry, for
+		 * callers past the kind check (keeps NullAway provable).
+		 *
+		 * @return the backing operation; never null.
+		 * @throws IllegalStateException if the entry is not OP-backed.
+		 */
+		EditOp requireOp() {
+
+			if (op == null)
+				throw new IllegalStateException(
+						"entry " + kind + " has no backing operation");
+			return op;
+		} // end of requireOp method
+
+	} // end of Entry record
+
+	/**
+	 * The option-menu content for one element, in menu order. Element
+	 * kind decides through capability traits which operations apply;
+	 * {@code isUneditable()} suppresses every mutating entry, leaving
+	 * view (any {@link Watchable}) and probe (any {@link Wire}) as the
+	 * only entries an uneditable element offers. The multi-selection
+	 * items (cut/copy/delete/lock) are appended by the editor, not
+	 * decided here.
+	 *
+	 * @param el The element the menu is being shown for.
+	 * @return the ordered menu entries; may be empty.
+	 */
+	static List<Entry> entries(Element el) {
+
+		List<Entry> entries = new ArrayList<Entry>();
+		boolean editable = !el.isUneditable();
+		if (el instanceof QuickEditable && editable) {
+			entries.add(Entry.quick());
+		}
+		if (el instanceof Editable && editable) {
+			entries.add(Entry.of(EditOp.MODIFY));
+		}
+		if (el instanceof Timed && editable) {
+			entries.add(Entry.of(EditOp.TIMING));
+		}
+		if (el instanceof Watchable watchable) {
+			if (editable) {
+				entries.add(Entry.of(EditOp.WATCH,
+						watchable.isWatched() ? UNWATCH_LABEL : WATCH_LABEL));
+			}
+			entries.add(Entry.of(EditOp.VIEW_VALUE));
+		}
+		if (el instanceof Rotatable rot && rot.canRotate() && editable) {
+			entries.add(Entry.of(EditOp.ROTATE_CW));
+			entries.add(Entry.of(EditOp.ROTATE_CCW));
+		}
+		if (el instanceof Rotatable rot && rot.canFlip() && editable) {
+			entries.add(Entry.of(EditOp.FLIP));
+		}
+		if (el instanceof JumpStart && editable) {
+			entries.add(Entry.matchJump());
+		}
+		if (el instanceof Wire wire) {
+			entries.add(Entry.of(EditOp.PROBE,
+					wire.hasProbe() ? REMOVE_PROBE_LABEL : ATTACH_PROBE_LABEL));
+		}
+		return entries;
+	} // end of entries method
+
+} // end of OptionMenuPolicy class

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -79,7 +79,6 @@ import jls.collab.op.RemoveProbe;
 import jls.collab.op.RotateElement;
 import jls.collab.op.ToggleWatched;
 import jls.core.Geometry;
-import jls.elem.Editable;
 import jls.elem.Element;
 import jls.elem.ElementId;
 import jls.elem.Group;
@@ -2959,65 +2958,68 @@ public abstract class SimpleEditor extends JPanel {
 
 
 			/**
-			 * Set up the options popup menu.
+			 * Set up the options popup menu. Which items the element
+			 * gets is decided by the headless
+			 * {@link OptionMenuPolicy} (issue #86); this method only
+			 * maps its entries onto the existing shared menu items, in
+			 * the order the policy returned them.
 			 *
 			 * @param el The element the menu is being shown for.
 			 */
 			private void makeOptionMenu(Element el) {
 
 				optionMenu.removeAll();
-				if (el instanceof QuickEditable quick && !el.isUneditable()) {
-					optionMenu.add(ElementQuickMenus.build(quick, me));
-				}
-				if (el instanceof Editable && !el.isUneditable()) {
-					optionMenu.add(modify);
-				}
-				if (el instanceof Timed && !el.isUneditable()) {
-					optionMenu.add(timing);
-				}
-				if (el instanceof Watchable watchable) {
-					if (!el.isUneditable()) {
-						if (watchable.isWatched()) {
-							watch.setText("Un-watch Element");
-						}
-						else {
-							watch.setText("Watch Element");
-						}
-						optionMenu.add(watch);
-					}
-					optionMenu.add(view);
-				}
-				if(el instanceof Rotatable rot && rot.canRotate())
-				{
-					if(!el.isUneditable())
-					{
-						optionMenu.add(Crotate);
-						optionMenu.add(CCrotate);
+				for (OptionMenuPolicy.Entry entry
+						: OptionMenuPolicy.entries(el)) {
+					switch (entry.kind()) {
+						case QUICK:
+							optionMenu.add(ElementQuickMenus.build(
+									(QuickEditable)el, me));
+							break;
+						case MATCH_JUMP:
+							optionMenu.add(matchJump);
+							break;
+						case OP:
+							JMenuItem item = popupItem(entry.requireOp());
+							item.setText(entry.label());
+							optionMenu.add(item);
+							break;
 					}
 				}
-				if(el instanceof Rotatable rot && rot.canFlip())
-				{
-					if(!el.isUneditable())
-					{
-						optionMenu.add(flip);
-					}
+			} // end of makeOptionMenu method
+
+			/**
+			 * The popup menu item backed by an operation's shared
+			 * {@link Action} (issue #75). Only the operations
+			 * {@link OptionMenuPolicy} emits have popup items.
+			 *
+			 * @param op The backing operation of a policy entry.
+			 * @return the popup menu item for that operation.
+			 */
+			private JMenuItem popupItem(EditOp op) {
+
+				switch (op) {
+					case PROBE:
+						return probe;
+					case WATCH:
+						return watch;
+					case MODIFY:
+						return modify;
+					case TIMING:
+						return timing;
+					case VIEW_VALUE:
+						return view;
+					case ROTATE_CW:
+						return Crotate;
+					case ROTATE_CCW:
+						return CCrotate;
+					case FLIP:
+						return flip;
+					default:
+						throw new IllegalArgumentException(
+								"no popup item for " + op);
 				}
-				if (el instanceof JumpStart) {
-					if(!el.isUneditable())
-					{
-						optionMenu.add(matchJump);
-					}
-				}
-				if (el instanceof Wire wire) {
-					if (wire.hasProbe()) {
-						probe.setText("Remove Probe");
-					}
-					else {
-						probe.setText("Attach Probe");
-					}
-					optionMenu.add(probe);
-				}
-			} // end of makeOptions method
+			} // end of popupItem method
 
 			/**
 			 * React to mouse release events.

--- a/test/jls/edit/OptionMenuPolicyTest.java
+++ b/test/jls/edit/OptionMenuPolicyTest.java
@@ -1,0 +1,265 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Scanner;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.CircuitTextBuilder;
+import jls.JLSInfo;
+import jls.edit.OptionMenuPolicy.Entry;
+import jls.edit.OptionMenuPolicy.Kind;
+import jls.elem.AndGate;
+import jls.elem.Constant;
+import jls.elem.Element;
+import jls.elem.JumpStart;
+import jls.elem.Register;
+import jls.elem.Wire;
+
+/**
+ * Headless pins for the right-click option menu's per-element content
+ * (issue #86, H3 close-out / P6). Before the {@link OptionMenuPolicy}
+ * extraction this decision lived inline in
+ * {@code SimpleEditor.makeOptionMenu} between Swing calls, so no
+ * headless test could state which items an AND gate, a constant, a
+ * wire, or a locked element actually offers. Each test builds real
+ * elements through the circuit loader (the same idiom as
+ * {@link DragCandidateBoundTest}) and asserts the exact entry list,
+ * including the state-dependent watch and probe labels. Menu
+ * <em>dispatch</em> is display-territory and stays pinned by
+ * {@code jls.ui.PopupOperationBehaviorTest} and
+ * {@code jls.ui.EditActionMatrixTest} on the xvfb substrate.
+ */
+class OptionMenuPolicyTest {
+
+	/**
+	 * Load a built circuit text, failing loudly on loader errors.
+	 *
+	 * @param text the circuit text to load.
+	 * @return the loaded circuit.
+	 */
+	private static Circuit load(String text) throws Exception {
+		Circuit circuit = new Circuit("policy");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/**
+	 * The sole element of the given class in the circuit.
+	 *
+	 * @param <T> the element class.
+	 * @param circuit the circuit to search.
+	 * @param type the element class to find.
+	 * @return the one element of that class.
+	 */
+	private static <T> T sole(Circuit circuit, Class<T> type) {
+		T found = null;
+		for (Element el : circuit.getElements()) {
+			if (type.isInstance(el)) {
+				if (found != null) {
+					throw new AssertionError(
+							"more than one " + type.getSimpleName());
+				}
+				found = type.cast(el);
+			}
+		}
+		if (found == null) {
+			throw new AssertionError("no " + type.getSimpleName()
+					+ " in the circuit");
+		}
+		return found;
+	}
+
+	/** An unattached 2-input AND gate. */
+	private static AndGate andGate() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.gate("AndGate", 1, 2);
+		return sole(load(cb.build()), AndGate.class);
+	}
+
+	/** An unattached constant. */
+	private static Constant constant() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.constant(1);
+		return sole(load(cb.build()), Constant.class);
+	}
+
+	/** An unattached D register, loaded as watched ("int watch 1"). */
+	private static Register register() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.register(4, 0, "D");
+		return sole(load(cb.build()), Register.class);
+	}
+
+	/** An unattached, unwatched jump start. */
+	private static JumpStart jumpStart() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.jumpStart("j", 1);
+		return sole(load(cb.build()), JumpStart.class);
+	}
+
+	/** A wire between a constant and an output pin. */
+	private static Wire wire() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		int c = cb.constant(1);
+		int pin = cb.outputPin("out", 1);
+		cb.wire(c, "output", pin, "input");
+		return sole(load(cb.build()), Wire.class);
+	}
+
+	/** The backing ops of the OP entries, in menu order. */
+	private static List<EditOp> ops(List<Entry> entries) {
+		return entries.stream()
+				.filter(e -> e.kind() == Kind.OP)
+				.map(Entry::requireOp)
+				.toList();
+	}
+
+	/** The one entry backed by the given op. */
+	private static Entry entryFor(List<Entry> entries, EditOp op) {
+		return entries.stream()
+				.filter(e -> e.kind() == Kind.OP && e.requireOp() == op)
+				.reduce((a, b) -> {
+					throw new AssertionError("duplicate " + op);
+				})
+				.orElseThrow(() -> new AssertionError("no " + op));
+	}
+
+	/**
+	 * An AND gate offers timing plus both rotates and flip - and no
+	 * modify: gates do not implement {@code Editable}, exactly as the
+	 * pre-extraction makeOptionMenu behaved (the extraction is
+	 * behavior-preserving).
+	 */
+	@Test
+	void andGateGetsTimingRotatesAndFlip() throws Exception {
+		List<Entry> entries = OptionMenuPolicy.entries(andGate());
+		assertEquals(List.of(EditOp.TIMING, EditOp.ROTATE_CW,
+				EditOp.ROTATE_CCW, EditOp.FLIP), ops(entries));
+		assertEquals(entries.size(), ops(entries).size(),
+				"gate menu must contain only OP entries");
+	}
+
+	/**
+	 * A constant leads with its quick-shortcuts submenu, then modify,
+	 * then the reorientation items.
+	 */
+	@Test
+	void constantLeadsWithQuickShortcutsSubmenu() throws Exception {
+		List<Entry> entries = OptionMenuPolicy.entries(constant());
+		assertEquals(Kind.QUICK, entries.get(0).kind(),
+				"quick-shortcuts submenu must come first");
+		assertEquals(OptionMenuPolicy.QUICK_LABEL, entries.get(0).label());
+		assertEquals(List.of(EditOp.MODIFY, EditOp.ROTATE_CW,
+				EditOp.ROTATE_CCW, EditOp.FLIP), ops(entries));
+	}
+
+	/**
+	 * A wire offers exactly one entry - probe - and its label follows
+	 * the probe state: Attach without one, Remove with one.
+	 */
+	@Test
+	void wireProbeLabelFollowsProbeState() throws Exception {
+		Wire wire = wire();
+		List<Entry> bare = OptionMenuPolicy.entries(wire);
+		assertEquals(1, bare.size(), "a wire's menu is probe only");
+		assertEquals(OptionMenuPolicy.ATTACH_PROBE_LABEL,
+				entryFor(bare, EditOp.PROBE).label());
+
+		wire.attachProbe("p0");
+		assertEquals(OptionMenuPolicy.REMOVE_PROBE_LABEL,
+				entryFor(OptionMenuPolicy.entries(wire),
+						EditOp.PROBE).label());
+	}
+
+	/**
+	 * A watchable element's watch entry flips its label with the
+	 * watched state, and view-contents is always present alongside.
+	 */
+	@Test
+	void watchLabelFollowsWatchedState() throws Exception {
+		Register reg = register();
+		assertTrue(reg.isWatched(), "builder loads the register watched");
+		List<Entry> watched = OptionMenuPolicy.entries(reg);
+		assertEquals(OptionMenuPolicy.UNWATCH_LABEL,
+				entryFor(watched, EditOp.WATCH).label());
+		entryFor(watched, EditOp.VIEW_VALUE);
+
+		reg.setWatched(false);
+		assertEquals(OptionMenuPolicy.WATCH_LABEL,
+				entryFor(OptionMenuPolicy.entries(reg),
+						EditOp.WATCH).label());
+	}
+
+	/**
+	 * The full register menu, in order: modify, timing, watch, view,
+	 * rotates, flip (Editable + Timed + Watchable + Rotatable).
+	 */
+	@Test
+	void registerGetsTheFullEditableMenu() throws Exception {
+		assertEquals(List.of(EditOp.MODIFY, EditOp.TIMING, EditOp.WATCH,
+				EditOp.VIEW_VALUE, EditOp.ROTATE_CW, EditOp.ROTATE_CCW,
+				EditOp.FLIP), ops(OptionMenuPolicy.entries(register())));
+	}
+
+	/**
+	 * A jump start gets the popup-only matching-end entry, after its
+	 * watch/view/flip entries (it flips but never rotates).
+	 */
+	@Test
+	void jumpStartGetsMatchingEndEntry() throws Exception {
+		List<Entry> entries = OptionMenuPolicy.entries(jumpStart());
+		assertEquals(List.of(EditOp.WATCH, EditOp.VIEW_VALUE, EditOp.FLIP),
+				ops(entries));
+		Entry last = entries.get(entries.size() - 1);
+		assertEquals(Kind.MATCH_JUMP, last.kind());
+		assertEquals(OptionMenuPolicy.MATCH_JUMP_LABEL, last.label());
+	}
+
+	/**
+	 * Uneditable (locked) elements keep only their non-mutating
+	 * entries: view-contents on a watchable element, probe on a wire;
+	 * everything else disappears.
+	 */
+	@Test
+	void uneditableElementsKeepOnlyViewAndProbe() throws Exception {
+		Register reg = register();
+		reg.makeUneditable();
+		List<Entry> regEntries = OptionMenuPolicy.entries(reg);
+		assertEquals(List.of(EditOp.VIEW_VALUE), ops(regEntries));
+		assertEquals(1, regEntries.size());
+
+		Wire wire = wire();
+		wire.makeUneditable();
+		List<Entry> wireEntries = OptionMenuPolicy.entries(wire);
+		assertEquals(List.of(EditOp.PROBE), ops(wireEntries));
+		assertEquals(1, wireEntries.size());
+
+		JumpStart js = jumpStart();
+		js.makeUneditable();
+		assertEquals(List.of(EditOp.VIEW_VALUE),
+				ops(OptionMenuPolicy.entries(js)),
+				"locked jump start loses watch, flip, and matching-end");
+	}
+
+	/**
+	 * Only OP entries carry a backing operation; asking the other
+	 * kinds is a programming error and fails fast (the editor calls
+	 * {@code requireOp()} only behind its kind switch).
+	 */
+	@Test
+	void nonOpEntriesRefuseRequireOp() throws Exception {
+		assertThrows(IllegalStateException.class,
+				() -> Entry.quick().requireOp());
+		assertThrows(IllegalStateException.class,
+				() -> Entry.matchJump().requireOp());
+	}
+}

--- a/test/jls/ui/PopupOperationBehaviorTest.java
+++ b/test/jls/ui/PopupOperationBehaviorTest.java
@@ -21,6 +21,8 @@ import jls.JLSInfo;
 import jls.elem.AndGate;
 import jls.elem.Element;
 import jls.elem.Gate;
+import jls.elem.Register;
+import jls.elem.Wire;
 
 /**
  * Right-click popup editing operations, verified behaviorally (issue #75
@@ -30,7 +32,11 @@ import jls.elem.Gate;
  * {@link EditActionMatrixTest} pins object <em>identity</em> for a few of
  * them but never fires them, and Watch/Probe/Modify/Timing had no popup
  * coverage at all - so a regression that left a popup item wired to a
- * disabled or no-op Action would pass. This drives the popup items the way a
+ * disabled or no-op Action would pass. Issue #86 (H3) closed the
+ * non-modal half of that gap: watch and probe dispatch are driven below,
+ * while Modify/Timing stay uncovered here because they open modal
+ * dialogs. Which items each element's menu contains is pinned headless
+ * by {@code jls.edit.OptionMenuPolicyTest}. This drives the popup items the way a
  * user's click does ({@code doClick} on the shown menu item, after the
  * right-press that selects the element) and observes the element's persisted
  * form change, proving the op actually ran through the popup surface.
@@ -102,7 +108,7 @@ class PopupOperationBehaviorTest {
 			AndGate gate = assertElementPresent(circuit, AndGate.class);
 			String original = save(gate);
 
-			openPopupTo(ui, gate, itemText);
+			openPopupTo(ui, centerX(gate), centerY(gate), itemText);
 			ui.clickPopupItem(itemText);
 			ui.waitFor(() -> !save(soleGate(ui)).equals(original),
 					"popup '" + itemText + "' mutated the gate");
@@ -112,7 +118,7 @@ class PopupOperationBehaviorTest {
 	}
 
 	/**
-	 * Right-press the gate to raise its popup, retrying the press until the
+	 * Right-press a point to raise its popup, retrying the press until the
 	 * target item is actually showing. A single right-press occasionally
 	 * fails to materialize the popup under the WM-less #162 Xvfb (a
 	 * popup-show timing flake, the same class as {@link EditorGestureTest}'s
@@ -122,14 +128,15 @@ class PopupOperationBehaviorTest {
 	 * fails fast rather than hanging to the outer timeout.
 	 *
 	 * @param ui the gesture harness.
-	 * @param gate the gate to right-press.
+	 * @param x the circuit x coordinate to right-press.
+	 * @param y the circuit y coordinate to right-press.
 	 * @param itemText the popup item that must become visible.
 	 * @throws Exception on EDT failure.
 	 */
-	private static void openPopupTo(EditorGestureSupport ui, Gate gate,
+	private static void openPopupTo(EditorGestureSupport ui, int x, int y,
 			String itemText) throws Exception {
 		for (int attempt = 0; attempt < 6; attempt++) {
-			ui.rightPress(centerX(gate), centerY(gate));
+			ui.rightPress(x, y);
 			for (int i = 0; i < 40; i++) {
 				if (ui.isPopupItemShowing(itemText)) {
 					return;
@@ -171,5 +178,128 @@ class PopupOperationBehaviorTest {
 	@Test
 	void popupFlipFlipsTheGate() throws Exception {
 		assertPopupItemMutatesTheGate("Flip");
+	}
+
+	// ------------------------------------------------------------------
+	// watch and probe dispatch (issue #86 H3): the non-modal half of the
+	// coverage gap this class's javadoc names - Modify/Timing open modal
+	// dialogs, so they stay out of scope here
+	// ------------------------------------------------------------------
+
+	/** A circuit with a single watched D register (Watchable). */
+	private static Circuit oneRegister() throws Exception {
+		CircuitTextBuilder cb = new CircuitTextBuilder();
+		cb.register(4, 0, "D");
+		Circuit circuit = new Circuit("popup-watch");
+		assertTrue(circuit.load(new Scanner(cb.build())),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/**
+	 * A circuit with one wire long enough to right-click: Wire.contains
+	 * rejects points within POINT_DIAMETER (6px) of either end, so the
+	 * ends sit 240px apart - the builder's fixed 12px wire-end spacing
+	 * would make the wire unclickable, hence the explicit text.
+	 */
+	private static Circuit oneLongWire() throws Exception {
+		String text = """
+				CIRCUIT popup-probe
+				ELEMENT Constant
+				 int id 0
+				 int x 60
+				 int y 60
+				 int width 24
+				 int height 24
+				 Int value 1
+				 int base 10
+				 String orient "RIGHT"
+				END
+				ELEMENT OutputPin
+				 int id 1
+				 int x 480
+				 int y 60
+				 int width 24
+				 int height 24
+				 String name "out"
+				 int bits 1
+				 int watch 0
+				 String orient "RIGHT"
+				END
+				ELEMENT WireEnd
+				 int id 2
+				 int x 120
+				 int y 300
+				 int width 8
+				 int height 8
+				 String put "output"
+				 ref attach 0
+				 ref wire 3
+				END
+				ELEMENT WireEnd
+				 int id 3
+				 int x 360
+				 int y 300
+				 int width 8
+				 int height 8
+				 String put "input"
+				 ref attach 1
+				 ref wire 2
+				END
+				ENDCIRCUIT
+				""";
+		Circuit circuit = new Circuit("popup-probe");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(null),
+				() -> "finishLoad: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/**
+	 * The popup Un-watch item on a watched register dispatches the shared
+	 * WATCH Action and clears the watched flag. Watching is non-modal
+	 * (ToggleWatched flips model state directly), unlike Modify/Timing.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void popupUnwatchClearsTheRegisterWatchFlag() throws Exception {
+		Circuit circuit = oneRegister();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			Register reg = assertElementPresent(circuit, Register.class);
+			assertTrue(reg.isWatched(), "builder loads the register watched");
+
+			openPopupTo(ui, centerX(reg), centerY(reg), "Un-watch Element");
+			ui.clickPopupItem("Un-watch Element");
+			ui.waitFor(() -> !reg.isWatched(),
+					"popup un-watch cleared the watched flag");
+		}
+	}
+
+	/**
+	 * The popup Remove Probe item on a probed wire dispatches the shared
+	 * PROBE Action and removes the probe. The remove direction is the
+	 * non-modal one (attach prompts for a probe name), so the test
+	 * pre-attaches a probe to the model before driving the popup.
+	 *
+	 * @throws Exception on EDT failure.
+	 */
+	@Test
+	void popupRemoveProbeRemovesTheWireProbe() throws Exception {
+		Circuit circuit = oneLongWire();
+		Wire wire = assertElementPresent(circuit, Wire.class);
+		wire.attachProbe("p0");
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			int midX = (wire.getEnd().getX() + wire.getEnd2().getX()) / 2;
+			int midY = (wire.getEnd().getY() + wire.getEnd2().getY()) / 2;
+
+			openPopupTo(ui, midX, midY, "Remove Probe");
+			ui.clickPopupItem("Remove Probe");
+			ui.waitFor(() -> !wire.hasProbe(),
+					"popup remove-probe detached the probe");
+		}
 	}
 }


### PR DESCRIPTION
H3 close-out for #86 (ERGONOMICS-AUDIT U10, advancing #33 Phase 8): the
right-click option menu's per-element content decision moves out of
SimpleEditor.makeOptionMenu into a new pure, headless-testable policy.

What landed:
- New jls.edit.OptionMenuPolicy: a pure function from an element's
  capability traits (#78) and state to an ordered, typed entry list
  (EditOp-backed entries plus QUICK / MATCH_JUMP kinds, with the
  state-dependent Watch/Un-watch and Attach/Remove Probe labels decided
  in the policy). Extraction is verbatim - no behavior change.
- SimpleEditor.makeOptionMenu is now a thin mapper from policy entries
  to the existing shared JMenuItems (new popupItem(EditOp) lookup);
  both popup call sites (mousePressed and mouseReleased) go through it
  unchanged. The unused jls.elem.Editable import moved to the policy.
- New headless OptionMenuPolicyTest (8 tests) pins P6 content per
  capability: AndGate -> timing + rotate CW/CCW + flip (gates are not
  Editable, so no modify - pinned explicitly), Constant -> quick
  shortcuts submenu first then modify/rotates/flip, Wire -> probe only
  with Attach/Remove label flip, Register -> the full editable menu
  with Watch/Un-watch label flip + view, JumpStart -> matching-end
  entry last, uneditable elements -> view/probe only, and requireOp()
  fails fast on non-OP entries.
- PopupOperationBehaviorTest gains the two non-modal dispatch tests its
  javadoc named as the gap: popup Un-watch on a watched register clears
  the watched flag, popup Remove Probe on a probed wire detaches the
  probe (openPopupTo generalized from Gate to coordinates; the probe
  fixture uses explicit circuit text because Wire.contains rejects
  points within 6 px of an end, making the builder's 12 px wire
  unclickable). Display-tagged: they skip headless and run on the #162
  xvfb substrate.

Deliberately deferred (per slice scope): matchJump ActionListener ->
EditOp migration (last legacy listener), multi-selection
cut/copy/delete/lock policy, modal Modify/Timing dispatch tests, #84
state-machine menu construction, newMenu/canvas-menu changes.

Verification (headless, nix develop):
- mvn -B test -Dtest=OptionMenuPolicyTest: 8/8 pass.
- mvn -B clean verify: BUILD SUCCESS; 1122 tests, 0 failures, 5 skipped
  (display-tagged); display execution 89 skipped as expected headless;
  coverage ratchet green ("All coverage checks have been met").
- Coverage impact: OptionMenuPolicy + nested types 36/36 lines covered
  by the new suite; no pom coverage floors touched.

Closes #86.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
