### PR TITLE
Refresh coverage climb conventions; add TextFilter suite (#159)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,19 @@ The climb convention:
 
 - **Floors only ever move up.** A PR that raises coverage should also
   raise the nearest floor (bundle and/or package) to just below the new
-  measurement, so the gain cannot silently erode later. "Just below"
-  means a small margin (a few tenths of a point) to absorb JDK jitter.
+  measurement, so the gain cannot silently erode later.
+- **Leave epsilon headroom under every per-package floor.** Zero-margin
+  floors flake across the JDK matrix — the #233 incident: a
+  `jls.collab.op` BRANCH floor of 0.770, set from a JDK 25 run,
+  measured 0.768 on JDK 26 and failed an unrelated PR. "Just below the
+  measurement" therefore means at least 0.5–1.0 point of headroom;
+  BRANCH counters jitter the most across JDKs and deserve the larger
+  margin.
+- **Raise floors from the canonical JDK only** — currently JDK 25, the
+  matrix entry whose failure blocks CI (the newer-JDK entries are
+  advisory, `continue-on-error` in `ci.yml`). Coverage measured on
+  other matrix JDKs shifts with JDK internals and must not be copied
+  into the floors.
 - **Raise floors from headless numbers only.** The floors are pinned to
   a plain `mvn verify` with no display so the build passes anywhere.
   CI's display-substrate run (`xvfb-run` with `-Djls.test.headless=false`)
@@ -85,8 +96,16 @@ The climb convention:
 - `jls.edit` is deliberately unfloored until the editor decomposition
   work (#84/#91) makes that code testable headlessly; do not add a
   floor there that would either bind at ~0% or block unrelated PRs.
-- Milestone: when the headless bundle LINE ratio crosses 0.50, the PIT
-  mutation-testing evaluation (#161) is unblocked.
+- **Mutation-testing status** (#159/#161): the 0.50 headless bundle
+  LINE milestone is crossed and pinned (PR #244), and the PIT
+  evaluation it gated (#161) is closed — PIT is adopted report-only as
+  the opt-in `-Ppitest` profile plus the weekly non-blocking
+  `mutation.yml` workflow (trial record:
+  [`docs/mutation-testing-trial-2026-07.md`](docs/mutation-testing-trial-2026-07.md)).
+  The remaining step — promoting a `mutationThreshold` climb-ratchet
+  over the scoped classes (`jls.sim.*`, `jls.BitSetUtils`, `jls.Util`,
+  `jls.SpatialIndex`, `jls.collab.op.*`) once a few weekly reports
+  establish a stable baseline — is tracked in #159.
 
 ## Reporting bugs
 

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,15 @@
                      any floor experiment needs `mvn clean verify` -
                      the agent appends to target/jacoco.exec, so an
                      unclean rerun unions with prior coverage and
-                     floors can never trip. -->
+                     floors can never trip.
+                     Raised 2026-07-26 (issue #159): the jls floors
+                     sit under a fresh headless canonical-JDK (25)
+                     measurement of jls 52.08/50.77/56.28 after the
+                     TextFilter suite covered the package's last
+                     untested headless-tractable class, with the
+                     documented 0.5-1.0pt epsilon headroom (the
+                     bundle moved well under half a point and its
+                     floors are unchanged). -->
                 <rule>
                   <element>PACKAGE</element>
                   <includes>
@@ -424,17 +432,17 @@
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.495</minimum>
+                      <minimum>0.515</minimum>
                     </limit>
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.480</minimum>
+                      <minimum>0.500</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.530</minimum>
+                      <minimum>0.555</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/test/jls/TextFilterTest.java
+++ b/test/jls/TextFilterTest.java
@@ -1,0 +1,221 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import javax.swing.JTextField;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.BadLocationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the numeric-field document filter (issue #159): the
+ * last untested headless-tractable class in the jls core package.
+ * Every edit is driven through a real JTextField's document, exactly
+ * as Swing routes user edits - setText goes through
+ * AbstractDocument.replace and thus the installed filter, direct
+ * document inserts go through insertString, deletions through
+ * remove - so these tests pin the filter's observable contract:
+ * inserts are blocked, removals pass through, and replacements land
+ * only when the resulting text is numeric in the configured base and
+ * within the configured maximum.
+ *
+ * Also pins the issue #51 regression: setMax takes a VALUE, not
+ * digits. The old code re-parsed the max's decimal rendering in the
+ * field's base, so a hex field's setMax(255) meant 0x255 (597) and a
+ * binary field's setMax(5) threw NumberFormatException on the EDT.
+ */
+class TextFilterTest {
+
+	private JTextField field;
+	private TextFilter filter;
+
+	@BeforeEach
+	void installFilter() {
+
+		field = new JTextField();
+		filter = new TextFilter(field);
+		((AbstractDocument)field.getDocument()).setDocumentFilter(filter);
+	}
+
+	/** Replace directly through the document, as a caret edit would. */
+	private void replace(int offset, int length, String str)
+			throws BadLocationException {
+
+		((AbstractDocument)field.getDocument()).replace(offset, length,
+				str, null);
+	}
+
+	// ------------------------------------------------------------------
+	// insertString: blocked; remove: pass-through
+	// ------------------------------------------------------------------
+
+	@Test
+	void directInsertsAreBlocked() throws BadLocationException {
+
+		field.setText("42");
+		field.getDocument().insertString(1, "9", null);
+		assertEquals("42", field.getText(),
+				"insertString must be a no-op; edits arrive via replace");
+	}
+
+	@Test
+	void removalsPassThroughEvenWhenTheRemainderIsNotNumeric()
+			throws BadLocationException {
+
+		// paste "-5" (BigInteger-valid), then delete the digit: the
+		// lone "-" is not numeric, but deletions can never grow the
+		// value, so the filter lets them through unchanged
+		field.setText("-5");
+		assertEquals("-5", field.getText());
+		field.getDocument().remove(1, 1);
+		assertEquals("-", field.getText());
+	}
+
+	// ------------------------------------------------------------------
+	// replace, insertion path (length == 0)
+	// ------------------------------------------------------------------
+
+	@Test
+	void numericInsertionIntoAnEmptyFieldIsAccepted() {
+
+		field.setText("123");
+		assertEquals("123", field.getText());
+	}
+
+	@Test
+	void nonNumericInsertionIsIgnored() {
+
+		field.setText("12a");
+		assertEquals("", field.getText(),
+				"non-numeric text must never enter the field");
+	}
+
+	@Test
+	void insertionMayReachButNotExceedTheMaximum()
+			throws BadLocationException {
+
+		filter.setMax(100);
+		field.setText("10");
+		replace(2, 0, "0");
+		assertEquals("100", field.getText(),
+				"a value equal to the maximum is allowed");
+		replace(3, 0, "0");
+		assertEquals("100", field.getText(),
+				"a keystroke that would exceed the maximum is ignored");
+	}
+
+	@Test
+	void insertionInTheMiddleChecksTheResultingValue()
+			throws BadLocationException {
+
+		filter.setMax(100);
+		field.setText("10");
+		replace(1, 0, "5");
+		assertEquals("10", field.getText(),
+				"150 exceeds the maximum even though the typed digit "
+						+ "is small");
+	}
+
+	// ------------------------------------------------------------------
+	// replace, replacement path (length > 0)
+	// ------------------------------------------------------------------
+
+	@Test
+	void settingTextOverExistingContentNormalizesTheValue() {
+
+		field.setText("42");
+		field.setText("007");
+		assertEquals("7", field.getText(),
+				"a full replacement re-renders through BigInteger");
+	}
+
+	@Test
+	void settingEmptyTextCannotClearTheField() {
+
+		// only remove() can empty the field (see the pass-through
+		// test); an empty replacement is not numeric and is ignored
+		field.setText("42");
+		field.setText("");
+		assertEquals("42", field.getText());
+	}
+
+	@Test
+	void nonNumericReplacementKeepsTheOldContent() {
+
+		field.setText("42");
+		field.setText("4x2");
+		assertEquals("42", field.getText());
+	}
+
+	@Test
+	void replacementBeyondTheMaximumIsIgnored() {
+
+		filter.setMax(100);
+		field.setText("99");
+		field.setText("101");
+		assertEquals("99", field.getText());
+	}
+
+	@Test
+	void withoutAMaximumArbitrarilyLargeValuesAreAccepted() {
+
+		// the guard for the fields that feed Integer.parseInt lives in
+		// NumericField, not here (see InteractiveSimulatorFieldTest)
+		field.setText("99999999999999999999");
+		assertEquals("99999999999999999999", field.getText());
+	}
+
+	// ------------------------------------------------------------------
+	// bases 2 and 16, and the issue #51 setMax regression
+	// ------------------------------------------------------------------
+
+	@Test
+	void base16AcceptsHexDigitsAndNormalizesCase() {
+
+		filter.setBase(16);
+		field.setText("ff");
+		assertEquals("ff", field.getText());
+		field.setText("FF");
+		assertEquals("ff", field.getText(),
+				"replacement re-renders via toString(16), lowercase");
+		field.setText("fg");
+		assertEquals("ff", field.getText(),
+				"g is not a hex digit");
+	}
+
+	@Test
+	void hexMaximumIsAValueNotDigits() {
+
+		// issue #51: setMax(255) once meant "255 read in base 16",
+		// i.e. 597 - which admitted 0x100 (256) into a byte field
+		filter.setBase(16);
+		filter.setMax(255);
+		field.setText("ff");
+		assertEquals("ff", field.getText(),
+				"0xff is exactly the maximum");
+		field.setText("100");
+		assertEquals("ff", field.getText(),
+				"0x100 (256) exceeds a maximum of 255");
+	}
+
+	@Test
+	void binaryMaximumWithNonBinaryDigitsDoesNotThrow() {
+
+		// issue #51: setMax(5) once parsed "5" in base 2 and threw
+		// NumberFormatException on the EDT
+		filter.setBase(2);
+		assertDoesNotThrow(() -> filter.setMax(5));
+		field.setText("101");
+		assertEquals("101", field.getText(),
+				"binary 101 is exactly the maximum");
+		field.setText("110");
+		assertEquals("101", field.getText(),
+				"binary 110 (6) exceeds a maximum of 5");
+		field.setText("102");
+		assertEquals("101", field.getText(),
+				"2 is not a binary digit");
+	}
+}

--- a/test/jls/elem/MemoryModelTest.java
+++ b/test/jls/elem/MemoryModelTest.java
@@ -186,7 +186,9 @@ class MemoryModelTest {
 	@Test
 	void timingContractResetsToTheDefaultAccessTime() {
 		Memory mem = newMemory();
-		assertTrue(mem.hasTiming());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Timed,
+				"memory carries a timing contract");
 		assertTrue(mem.usesAccessTime(),
 				"memory is the one element with an access time");
 		assertEquals(100, mem.getDelay(), "documented default access time");
@@ -199,8 +201,11 @@ class MemoryModelTest {
 	@Test
 	void watchAndChangeContract() {
 		Memory mem = newMemory();
-		assertTrue(mem.canWatch());
-		assertTrue(mem.canChange());
+		Element asElement = mem;
+		assertTrue(asElement instanceof Watchable,
+				"memory values can be watched");
+		assertTrue(asElement instanceof Editable,
+				"memory attributes can be edited");
 		assertFalse(mem.isWatched());
 		mem.setWatched(true);
 		assertTrue(mem.isWatched());

--- a/test/jls/elem/RegisterModelTest.java
+++ b/test/jls/elem/RegisterModelTest.java
@@ -124,7 +124,9 @@ class RegisterModelTest {
 	@Test
 	void timingContractResetsToTheDefaultDelay() {
 		Register reg = newRegister();
-		assertTrue(reg.hasTiming());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Timed,
+				"registers carry a timing contract");
 		assertEquals(50, reg.getDelay(), "documented default delay");
 		reg.setDelay(75);
 		assertEquals(75, reg.getDelay());
@@ -136,8 +138,11 @@ class RegisterModelTest {
 	void capabilityContract() {
 		Register reg = newRegister();
 		assertFalse(reg.canCopy(), "registers are named, so not copyable");
-		assertTrue(reg.canChange());
-		assertTrue(reg.canWatch());
+		Element asElement = reg;
+		assertTrue(asElement instanceof Editable,
+				"register attributes can be edited");
+		assertTrue(asElement instanceof Watchable,
+				"register values can be watched");
 		assertFalse(reg.isWatched());
 		reg.setWatched(true);
 		assertTrue(reg.isWatched());
@@ -346,11 +351,12 @@ class RegisterModelTest {
 
 		@Override
 		public void post(jls.sim.SimEvent event) {
-			// only the register's own output-driving posts (non-null
-			// todo): input-change notifications also name the register
-			// as callback but carry a null todo
+			// only the register's own output-driving posts (NewValue):
+			// input-change notifications also name the register as
+			// callback but carry a PinChanged payload
 			if (event.getCallBack() instanceof Register
-					&& event.getTodo() != null) {
+					&& event.getTodo()
+							instanceof jls.sim.SimEvent.NewValue) {
 				registerPosts += 1;
 			}
 			super.post(event);

--- a/test/jls/elem/SubCircuitModelTest.java
+++ b/test/jls/elem/SubCircuitModelTest.java
@@ -150,7 +150,9 @@ class SubCircuitModelTest {
 	@Test
 	void canChangeAndDelayResetAreDelegatedSafely() {
 		SubCircuit sub = loneSub();
-		assertTrue(sub.canChange());
+		Element asElement = sub;
+		assertTrue(asElement instanceof Editable,
+				"subcircuits can be edited");
 		// the passthrough inner circuit has no timed elements; the
 		// delegation must still walk it without faulting
 		sub.resetPropDelay();


### PR DESCRIPTION
Lands the #159 climb-convention refresh plus a test suite for the last
untested headless-tractable jls-core class:

- CONTRIBUTING.md "Coverage ratchet": documents the #233-derived
  epsilon-headroom rule (every per-package floor keeps at least
  0.5-1.0pt of headroom under its headless measurement; zero-margin
  BRANCH floors flake across the JDK matrix) and the canonical-JDK
  rule (raise floors only from JDK 25, the blocking matrix entry).
  The stale milestone bullet is rewritten: the 0.50 bundle LINE gate
  is crossed and pinned (PR #244), #161 is closed with PIT adopted
  report-only (opt-in -Ppitest profile plus the weekly non-blocking
  mutation.yml workflow; trial record in
  docs/mutation-testing-trial-2026-07.md), and the remaining
  mutationThreshold climb-ratchet promotion over the scoped classes
  is tracked in #159.
- test/jls/TextFilterTest.java: 14 headless tests driving TextFilter
  through a real JTextField document (insertString blocked, remove
  pass-through even when the remainder is non-numeric, replace
  filtering in bases 2/10/16, maximum boundary checks on both the
  insertion and replacement paths, value normalization), including
  the issue #51 setMax value-vs-digits regression: a hex field's
  setMax(255) must not mean 0x255, and a binary field's setMax(5)
  must not throw.
- pom.xml: jls package floors raised 0.495/0.480/0.530 ->
  0.515/0.500/0.555 (instruction/line/branch), sitting under the
  fresh headless canonical-JDK measurement of 52.08/50.77/56.28 with
  the newly documented epsilon headroom; the dated baseline comment
  is extended. Bundle floors unchanged: the bundle measured
  57.25/55.99/53.46 and moved well under half a point.

Verification (headless, canonical JDK 25, nix develop):

- mvn -Djls.test.headless=true clean verify is green with the raised
  floors: 1128 tests, 0 failures, 5 skipped, plus 87 display-tagged
  tests skipped as expected; the coverage ratchet passes.
- mvn test -Dtest=TextFilterTest: 14/14 pass. jls package LINE
  measures 50.34 without the suite and 50.77 with it (TextFilter was
  previously 0% covered).
- Floor non-vacuity probe: deleting TextFilterTest cannot trip an
  epsilon-compliant floor (the class carries ~0.4 LINE pt, less than
  the mandated 0.5pt minimum headroom), so non-vacuity was proven by
  temporarily setting the jls LINE floor to 0.600 and observing
  jacoco:check@coverage-ratchet fail against the same execution data,
  then restoring 0.500.

Merge-queue note: this slice touches the shared coverage-ratchet
block; merge it last among pom-floor-touching siblings and re-measure
headless at the integrated tip before finalizing the numbers (same
protocol as PR #244).

Advances #159.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
