### PR TITLE
ci: promote aarch64 Linux installer reproducibility leg to hard gate (#188)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,19 +504,20 @@ jobs:
   # ubuntu-24.04-arm runner.  The build script is arch-agnostic — only the
   # pinned appimagetool binary differs per arch (build-installer.sh already
   # carries the aarch64 sha256) — so this reuses the identical mechanism.
-  # Kept a separate advisory (continue-on-error) job rather than a matrix
-  # leg of the gate above, so that required check keeps its stable name
-  # while this arm leg accrues its own 20-run stability record (the same
-  # promotion rule the windows and gui-wayland lanes use); the honesty gate
-  # of #188 §10 still holds — a red leg means a byte still varies.
+  # Kept a separate job rather than a matrix leg of the gate above so the
+  # x86_64 required check keeps its stable name.  HARD GATE since #188
+  # (§7 item 4 promotion rule): the leg ran as a continue-on-error advisory
+  # while it accrued a stability record and went 10/10 green on the last ten
+  # non-cron ci.yml runs (runs 30231795586, 30231810697, 30233072799,
+  # 30233081534, 30233449347, 30275748279, 30275761243, 30275782726,
+  # 30276526422, 30277051630), so a red run here now fails CI — the honesty
+  # gate of #188 §10 holds: a red leg means a byte still varies.
   installer-reproducibility-aarch64:
     name: Linux installer reproducibility (aarch64)
     # runs on push/PR like the other jobs (skips only the nightly cron, which
-    # runs gui-wayland alone); advisory via continue-on-error while the
-    # cross-platform double-build stabilizes on real runners (#189/#190/#191)
+    # runs gui-wayland alone)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-24.04-arm
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -15,15 +15,14 @@ environment a third party needs, and gives the verification recipes.
 | Application jar | `jls-<version>.jar` | **Yes** — bit-for-bit |
 | CycloneDX SBOM | `bom.json` (also built: `bom.xml`) | **Yes** — bit-for-bit |
 | Maven pom | (GitHub Packages) | **Yes** — it is source |
-| Native installers — `deb`/`rpm`/AppImage (Linux x86_64) | `SHA256SUMS-installers-*` assets | **Yes** — gated by CI, see §5 |
-| Native installers — `msi`, `dmg`, and the Linux aarch64 leg | `SHA256SUMS-installers-*` assets | **No** — see §5 |
+| Native installers — `deb`/`rpm`/AppImage (Linux x86_64 and aarch64) | `SHA256SUMS-installers-*` assets | **Yes** — gated by CI, see §5 |
+| Native installers — `msi`, `dmg` | `SHA256SUMS-installers-*` assets | **No** — see §5 |
 | Container image | `ghcr.io/anadon/jls` | **No** — see §5 |
 
 The reproducibility claim covers the **jar, the BOM, and the Linux
-x86_64 `deb`/`rpm`/AppImage installers**. Nothing in this document
-should be read as claiming the `msi`, the `dmg`, the Linux aarch64
-installers, or the container image reproduce; their integrity story is
-different (§5).
+`deb`/`rpm`/AppImage installers on x86_64 and aarch64**. Nothing in
+this document should be read as claiming the `msi`, the `dmg`, or the
+container image reproduce; their integrity story is different (§5).
 
 ## 2. Build environment record: the `.buildinfo`
 
@@ -160,15 +159,18 @@ pins `%_buildhost`, `%use_source_date_epoch_as_buildtime`, and
 timestamp sources.
 
 With that plumbing in place, the `deb`, `rpm`, and AppImage installers
-built on Linux x86_64 **are** reproducible: the `installer-reproducibility`
-job in `.github/workflows/ci.yml` builds all three twice from the same
-commit and diffs the SHA-256 of every artifact, failing (and running
-`diffoscope`) on any mismatch. This is the CI gate the table in §1
-refers to.
+built on Linux **are** reproducible on both x86_64 and aarch64: the
+`installer-reproducibility` (ubuntu x86_64) and
+`installer-reproducibility-aarch64` (ubuntu-24.04-arm, lane owned by
+issue #189) jobs in `.github/workflows/ci.yml` each build all three
+twice from the same commit and diff the SHA-256 of every artifact,
+failing (and running `diffoscope`) on any mismatch. These are the CI
+gates the table in §1 refers to. The aarch64 job first ran as a
+continue-on-error advisory and was promoted to a hard gate (#188 §7
+item 4) after a sustained all-green run record.
 
-The `msi` and `dmg` installers, and the Linux aarch64 leg, are **not**
-yet reproducible, and this document deliberately does not claim
-otherwise:
+The `msi` and `dmg` installers are **not** yet reproducible, and this
+document deliberately does not claim otherwise:
 
 - **`msi`** (owned by issue #190): `scripts/normalize-msi.py` rewrites
   the known volatile bytes (the WiX package-code GUID, SummaryInformation
@@ -188,11 +190,6 @@ otherwise:
   byte-identical (the full HFS+ normalization stays disabled because
   its round-trip corrupts the image on macOS) — see
   `docs/dmg-reproducibility.md`.
-- **Linux aarch64** (owned by issue #189): the same `SOURCE_DATE_EPOCH`
-  derivation and `clamp_mtimes()` apply on this architecture, but only
-  the report-only probe (`.github/workflows/repro-installers.yml`)
-  exercises it — there is no hard double-build gate for aarch64, so no
-  reproducibility claim is made for it.
 
 Their integrity model, in the meantime, is *attestation-backed*: per-file
 SHA-256 checksums (`SHA256SUMS-installers-*`) and build-provenance
@@ -200,14 +197,14 @@ attestations (`gh attestation verify`). The container image is unchanged
 by #188 and remains out of scope: it installs distribution packages at
 build time and is not reproducible; its integrity model is the same
 checksum/attestation story plus a keyless cosign signature on the
-manifest digest. As `msi`/`dmg`/aarch64 reproducibility and the
-container image land, the table in §1 expands further.
+manifest digest. As `msi`/`dmg` reproducibility and the container
+image land, the table in §1 expands further.
 
 ## 6. Future work
 
 - Submit a rebuild recipe to
   [reproducible-central](https://github.com/jvm-repo-rebuild/reproducible-central)
   once a conforming release has shipped with its `.buildinfo`.
-- Extend the specified-artifact set as #189/#190/#191 make the
-  remaining installers (msi, dmg, Linux aarch64) deterministic, and as
-  #184 makes the container image deterministic.
+- Extend the specified-artifact set as #190/#191 make the remaining
+  installers (msi, dmg) deterministic, and as #184 makes the container
+  image deterministic.


### PR DESCRIPTION
## Summary

Promotes the `installer-reproducibility-aarch64` CI job from a `continue-on-error` advisory to a hard gate, per the #188 §7 item 4 promotion rule, and updates `docs/reproducibility.md` so the documented reproducibility claim matches the new gated reality: Linux `deb`/`rpm`/AppImage installers are now claimed reproducible on **both x86_64 and aarch64**.

## What / why

**`.github/workflows/ci.yml`**
- Removed `continue-on-error: true` from `installer-reproducibility-aarch64` (and the now-stale "advisory while stabilizing" comment lines). A red aarch64 double-build leg now fails CI — the honesty gate of #188 §10 holds: a red leg means a byte still varies.
- Rewrote the job's comment block to record the promotion rationale and the 10-run stability record that justified it (run IDs cited inline and in the commit body).
- No other job touched: `continue-on-error` remains on the JDK matrix (line 41), the three other advisory lanes (lines 120, 175, 308), and the macOS dmg job (line 591).

**`docs/reproducibility.md`**
- §1 table and claim paragraph: Linux aarch64 installers moved from the "No" row to the gated "Yes" row.
- §5: the gated paragraph now names both `installer-reproducibility` (x86_64) and `installer-reproducibility-aarch64` (ubuntu-24.04-arm, lane owned by #189) as the CI gates, with the advisory-to-gate promotion attributed to #188 §7 item 4. The stale "no hard double-build gate for aarch64" bullet (formerly lines 191-195) is removed, and aarch64 is dropped from the not-yet-reproducible enumeration (formerly line 203).
- §6 future work: aarch64 removed from the remaining-installers list (now msi/dmg via #190/#191 only).

No CHANGELOG entry: recent CI/docs-only PRs (#250, #252, #254) establish no per-PR CHANGELOG convention for non-feature changes, and the Unreleased aggregate entry already cites the #188/#189 installer-reproducibility gates.

## Verification (independent, by reviewer)

- **Pass record re-verified via `gh api`**: all 10 cited runs (30231795586, 30231810697, 30233072799, 30233081534, 30233449347, 30275748279, 30275761243, 30275782726, 30276526422, 30277051630) show `conclusion=success` for job "Linux installer reproducibility (aarch64)"; the intervening cron run 30247754587 is `skipped` by design. The workflow run listing confirms these are exactly the 10 most recent non-cron successful ci.yml runs (interleaved non-successes are `cancelled`, not failed) — the record is not cherry-picked.
- **`continue-on-error` inventory** diffed against origin/master: removed only from the aarch64 job; lines 41/120/175/308 byte-identical, dmg job's occurrence intact (shifted 590→591 by the comment rewrite).
- **actionlint** (`nix run nixpkgs#actionlint`): finding set is byte-identical to origin/master — 7 pre-existing shellcheck info-level notes (SC2035/SC2012), no new findings. Note: actionlint exits 1 on both master and this branch because of those pre-existing info notes (the implementer's claim of exit 0 was inaccurate; no regression either way).
- **Full build**: `mvn verify` under `nix develop` (JDK 25, Maven 3.9.11) — BUILD SUCCESS. Surefire: **Tests run: 1192, Failures: 0, Errors: 0, Skipped: 5**; display-tagged suite: 92/92 skipped headless as expected.
- **Docs consistency**: repo-wide grep finds no remaining stale "aarch64 advisory" claims in docs/README/CHANGELOG; no `needs:` aggregation job references the aarch64 job, so no other workflow wiring was required.

## Caveats

- If the repository ruleset enumerates required status checks by name, the maintainer may want to add "Linux installer reproducibility (aarch64)" as a named required check; the `continue-on-error` removal alone already makes a red leg fail the workflow run, which is the gating mechanism the other hard gates use.
- The change is CI/docs-only; `mvn verify` was run as a regression guard and exercises no new Java surface.
- Commit is an unsigned snapshot (`commit.gpgsign=false`); it must be re-signed via `git commit --amend` before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW9SQJcVqt859o6XWEb7aW