### PR TITLE
test: land #96 closeout gates — sealed conventions, Cloneable and NullAway-suppression ratchets (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Added
+- Modern-Java program closeout gates (#96): a new headless
+  `ModernJavaGatesTest` scans `src/` and `test/` and fails the build
+  on any `Cloneable` in an `implements`/`extends` clause (#94 retired
+  it for explicit copy construction) or any NullAway suppression (a `@SuppressWarnings`
+  naming NullAway, or `castToNonNull` — #93 closed with zero), with
+  an empty in-test allowlist as the recorded escape hatch;
+  CONTRIBUTING gains the #95 sealed-dispatch conventions
+  (three-population `instanceof` rule, no `default` arm on
+  sealed/`Orientation` switches, final leaves pinned by
+  `SealedHierarchyTest`).
 - The editor palette is now generated from a declarative table (#78):
   `jls.edit.PaletteEntry` (icon, fallback text, tooltip, toolbar
   group, help topic per element — the GUI half of the two-layer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ follows the current LTS and is revisited each LTS cycle). Sources live in
   make a class a record if its `equals`/`hashCode` are intentionally
   non-structural (see `jls.sim.SimEvent`), and never land a repo-wide
   `final`/formatting sweep — churn hides real diffs.
+- **Sealed dispatch** (#95): the three-population `instanceof` rule —
+  dispatch on an element or payload *kind* is an exhaustive
+  pattern-matching `switch` with no `default` arm, so the compiler
+  flags every dispatch site when the hierarchy grows; a single
+  test-and-cast is an `instanceof` pattern; capability probes stay
+  plain interface checks. Never add a `default:` arm to a `switch`
+  over a sealed type (the `Element`/`Gate` subtrees,
+  `SimEvent.Payload`) or the `Orientation` enum. Sealed leaves stay
+  `final`; the permits tree is pinned by
+  `test/jls/elem/SealedHierarchyTest.java`.
 - `mvn verify` must be green: it runs the test suite and SpotBugs
   (threshold High). Do not add blanket entries to
   `config/spotbugs-exclude.xml`; new entries need a `Class` scope and a

--- a/test/jls/ModernJavaGatesTest.java
+++ b/test/jls/ModernJavaGatesTest.java
@@ -1,0 +1,106 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Modern-Java program closeout gates (#96): the two practices the
+ * program left as advisory bullets become executable ratchets. #94
+ * retired {@code Cloneable} from the codebase in favor of explicit
+ * copy construction (the {@code Element.copy()} contract from #78),
+ * and #93's NullAway rollout closed with zero suppressions. These
+ * scans hold both counts at zero; a legitimately necessary exception
+ * is added to {@link #ALLOWED} with a justification comment in the
+ * same PR.
+ */
+class ModernJavaGatesTest {
+
+	/**
+	 * Files (as repo-relative paths) allowed to carry a NullAway
+	 * suppression. Empty on purpose - #93 landed with zero
+	 * suppressions, so this list is the visible escape hatch: an
+	 * entry needs a justification comment beside it explaining why an
+	 * honest {@code @Nullable} annotation or explicit check cannot
+	 * express the contract.
+	 */
+	private static final List<String> ALLOWED = List.of();
+
+	@Test
+	void noCloneableInSources() throws IOException {
+		// The clause pattern catches Cloneable anywhere in an
+		// implements/extends type list ("implements Foo, Cloneable",
+		// an interface extending it), not just first position; the
+		// character class - names, dots, generics, commas, whitespace
+		// - keeps the match inside a type list, so ordinary prose in
+		// comments does not trip the gate.
+		List<String> hits = scan(Pattern.compile(
+				"(?:implements|extends)\\s[\\w.<>,\\s]*"
+						+ "\\bCloneable\\b"));
+		assertTrue(hits.isEmpty(),
+				"Cloneable is retired (#94): value-shaped types are"
+						+ " copied explicitly - a copy constructor or"
+						+ " the #78 copy() contract - never clone():"
+						+ " " + hits);
+	}
+
+	@Test
+	void noNullAwaySuppressions() throws IOException {
+		List<String> hits = scan(Pattern.compile(
+				"SuppressWarnings\\s*\\([^)]*NullAway[^)]*\\)"
+						+ "|castToNonNull"));
+		hits.removeIf(hit -> ALLOWED.stream()
+				.anyMatch(path -> hit.startsWith(path + ":")));
+		assertTrue(hits.isEmpty(),
+				"NullAway suppression (#93 closed with zero): prefer"
+						+ " an honest @Nullable annotation and an"
+						+ " explicit check; a truly unavoidable"
+						+ " suppression is listed in ALLOWED with a"
+						+ " justification: " + hits);
+	}
+
+	/**
+	 * Scans every {@code .java} file under {@code src/} and
+	 * {@code test/} for the pattern, returning {@code path:line}
+	 * hits. Skips {@code package-info.java} (prose only) and this
+	 * gate itself, whose patterns and messages name the constructs
+	 * they hunt.
+	 */
+	private static List<String> scan(Pattern pattern)
+			throws IOException {
+		List<String> hits = new ArrayList<String>();
+		for (Path root : List.of(Path.of("src"), Path.of("test"))) {
+			List<Path> files;
+			try (Stream<Path> walk = Files.walk(root)) {
+				files = walk
+						.filter(f -> f.toString().endsWith(".java"))
+						.filter(f -> !f.getFileName().toString()
+								.equals("package-info.java"))
+						.filter(f -> !f.getFileName().toString()
+								.equals("ModernJavaGatesTest.java"))
+						.sorted()
+						.toList();
+			}
+			for (Path file : files) {
+				String text = Files.readString(file);
+				Matcher m = pattern.matcher(text);
+				while (m.find()) {
+					long line = 1 + text.substring(0, m.start())
+							.chars().filter(c -> c == '\n').count();
+					hits.add(file + ":" + line);
+				}
+			}
+		}
+		return hits;
+	}
+
+} // end of ModernJavaGatesTest class


### PR DESCRIPTION
## Summary

Program closeout for the modern-Java series (#93/#94/#95): the two practices that were only advisory bullets become executable ratchets, and the #95 sealed-dispatch conventions land in CONTRIBUTING. Closes #96.

## What / why

- **`test/jls/ModernJavaGatesTest.java`** (new, headless, 2 tests) scans every `.java` under `src/` and `test/` and fails the build with `path:line` diagnostics on:
  - `noCloneableInSources` — any `Cloneable` in an `implements`/`extends` clause. #94 retired `Cloneable` for explicit copy construction (copy constructors / the #78 `Element.copy()` contract). The clause pattern catches Cloneable at any position in a type list (`implements Foo, Cloneable`) and interfaces extending it, while staying scoped to type lists so prose mentions in comments don't trip.
  - `noNullAwaySuppressions` — any `@SuppressWarnings` naming NullAway, or `castToNonNull`. #93 closed with zero suppressions; an empty in-test `ALLOWED` list is the recorded escape hatch (an entry requires a justification comment in the same PR). The pattern matches suppression *constructs*, not the bare word "NullAway", so existing prose mentions (e.g. `src/jls/edit/OptionMenuPolicy.java:142`, the `@NullMarked` package-info docs) do not trip; `package-info.java` and the gate test itself are excluded from the scan.
- **`CONTRIBUTING.md`** gains the #95 sealed-dispatch conventions bullet (three-population `instanceof` rule; no `default` arm on switches over sealed types or `Orientation`; final leaves pinned by `SealedHierarchyTest`). Inserted in the Conventions list after the #94 value-semantics bullet — disjoint from #159's Mutation-testing region, so any overlap with sibling branches is a trivial union conflict.
- **`CHANGELOG.md`** Unreleased/Added entry per repo convention (may union-conflict with sibling branches; trivial to resolve).

Follows the repo's existing ratchet idiom (`NullMarkedRatchetTest`, `CollabSecurityRatchetTest`): source-text scan from the build basedir, offender set reported against an explicit allowlist.

## Verification

- Independent full builds from scratch in the worktree (`nix develop`, JDK 25, Maven 3.9.11), run twice — before and after review fixes: **BUILD SUCCESS**, headless surefire **1194 tests / 0 failures / 0 errors / 5 skipped**, display leg 92/92 skipped (expected headless), coverage ratchet passed. `ModernJavaGatesTest`: 2/2 green. Wall times 3:04–4:05 min on the verifying machine.
- **Negative-path mutation** (probe files added, gate run, probes removed):
  - `src/jls/TempCloneProbe.java` with `implements java.util.RandomAccess, Cloneable` → `noCloneableInSources` fails: `[src/jls/TempCloneProbe.java:3]`
  - `src/jls/TempExtendsProbe.java` with `interface ... extends Cloneable` → fails: `[src/jls/TempExtendsProbe.java:3]`
  - `test/jls/TempSuppressProbe.java` with `@SuppressWarnings("NullAway")` → `noNullAwaySuppressions` fails: `[test/jls/TempSuppressProbe.java:4]`
- **Adversarial review fix folded in:** the original Cloneable pattern (`implements\s+Cloneable`) only matched first-position Cloneable — the comma-form probe above sailed through it undetected. The pattern was broadened to the clause-scoped form and both bypasses re-proved to trip; full verify re-run green (zero false positives across the tree).

## Wall-time adjudication (recorded here per plan)

Implementer's measurement: `mvn clean verify` is 162.8 s at this tip vs 70.8 s at the post-#92/pre-#93 baseline `be709d2` (PR #107 merge), same machine, warm `~/.m2` — ratio 2.30x, nominally past the program's 1.5x falsification budget. However, the src+test tree grew 52,207 → 120,308 lines (2.30x) and 300 → 1194 tests over the same span, so per-line build cost is exactly flat: the growth is codebase/test-suite size, not Error Prone/NullAway overhead. **Adjudicated: budget not tripped.**

## Caveats / merge notes

- **Merge this branch EARLY in the cycle** so the gates bind on sibling branches' rebases (all approved sibling branches are instructed to add no suppressions and no Cloneable, so landing early is safe).
- CHANGELOG (and possibly CONTRIBUTING) may union-conflict with sibling branches; both insertions are self-contained bullets, trivial to resolve.
- The gates are text scans that police comments/strings too for `castToNonNull` (consistent with the `CollabSecurityRatchetTest` idiom); the escape hatch is the in-test `ALLOWED` list with a justification comment.
- Commit is unsigned (sandbox has no signing agent) — needs `git commit --amend -S` before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW9SQJcVqt859o6XWEb7aW