### PR TITLE
feat(module): two-phase JlsModule lifecycle runtime honoring activation triggers (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to JLS are documented here. The format follows
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
 ### Added
+- Module activation runtime (#220): the `jls.module.JlsModule`
+  lifecycle SPI (`manifest()` / `register()` / `start()`) and
+  `jls.module.ModuleRuntime`, a two-phase runner that resolves
+  manifests once through `ModuleResolver`, registers every module in
+  topological order, then starts them per their declared trigger —
+  `Eager` at boot; `OnCommand` / `OnEvent` / `OnDemand` on first
+  `dispatchCommand` / `fireEvent` / `demand` (by concrete id or
+  `provides` token). Activation transitively starts the sole provider
+  of each `requires` token in topological order; `optional` / `after` /
+  `before` never trigger activation. Each module runs a start-once
+  state machine: a throwing `start()` becomes a permanent
+  `ModuleActivationException` naming the module and phase, rethrown on
+  every later touch and never silently retried; unknown commands,
+  events, and tokens are graceful no-ops. Pure JVM, deterministic
+  across discovery order; pinned by the new headless
+  `ModuleRuntimeTest`.
 - The editor palette is now generated from a declarative table (#78):
   `jls.edit.PaletteEntry` (icon, fallback text, tooltip, toolbar
   group, help topic per element — the GUI half of the two-layer

--- a/src/jls/module/JlsModule.java
+++ b/src/jls/module/JlsModule.java
@@ -1,0 +1,50 @@
+package jls.module;
+
+/**
+ * The lifecycle SPI one module implements (issue #220,
+ * grand-architecture §4.2 rule 7): a static, side-effect-free
+ * {@link #manifest()} the resolver reads without running module code,
+ * plus the two-phase {@link #register()} / {@link #start()} pair that
+ * {@link ModuleRuntime} drives. The two phases are the only cycle
+ * escape hatch the model offers: every module registers before any
+ * module starts, so a started module may safely resolve references to
+ * anything any other module published during registration.
+ *
+ * <p>Deliberately deferred from this slice (issue #223): sealing this
+ * interface over the compiled-in module set — it is plain for now so
+ * tests and future tenants can implement it freely — and the registrar
+ * parameter through which {@code register()} will publish typed
+ * extension points; until that parameter exists, {@code register()}
+ * takes no arguments and publishes nothing beyond the module's own
+ * construction.</p>
+ */
+public interface JlsModule {
+
+	/**
+	 * The static descriptor of this module. Must be stable: every call
+	 * returns an equal manifest, with no side effects — the runtime
+	 * reads it once at boot and reasons from that snapshot.
+	 *
+	 * @return this module's manifest.
+	 */
+	ModuleManifest manifest();
+
+	/**
+	 * Phase 1: construct internal state and publish what this module
+	 * offers. Called exactly once per module, in topological order,
+	 * before <em>any</em> module's {@link #start()}. Must not touch any
+	 * other module — the other module may not have registered yet.
+	 */
+	void register();
+
+	/**
+	 * Phase 2: resolve references to other modules and go live. Called
+	 * at most once, in topological order, after every module has
+	 * registered — at boot for {@link Activation.Eager} modules,
+	 * on first trigger otherwise. May use anything a dependency
+	 * published, because every {@code requires} provider is started
+	 * first.
+	 */
+	void start();
+
+} // end of JlsModule interface

--- a/src/jls/module/ModuleActivationException.java
+++ b/src/jls/module/ModuleActivationException.java
@@ -1,0 +1,31 @@
+package jls.module;
+
+/**
+ * Thrown when a module's lifecycle phase fails (issue #220): its
+ * {@code register()} or {@code start()} threw, or a phase was demanded
+ * of a module that already failed. The message names the failing
+ * module id and the phase, and the cause is the module's original
+ * exception when there is one — so the failure is diagnosable from a
+ * single read (§4.2 rule 5: fail loud, never paper over). A failed
+ * module stays failed: the runtime rethrows this exception on every
+ * later touch and never silently retries.
+ */
+public class ModuleActivationException extends Exception {
+
+	/** Serialization version, required of every Exception subclass. */
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Create the exception with a message naming the failing module id
+	 * and phase, wrapping the module's own exception.
+	 *
+	 * @param message the full description of which module failed in
+	 *            which phase.
+	 * @param cause the exception the module's lifecycle method threw.
+	 */
+	public ModuleActivationException(String message, Throwable cause) {
+
+		super(message, cause);
+	} // end of constructor
+
+} // end of ModuleActivationException class

--- a/src/jls/module/ModuleRuntime.java
+++ b/src/jls/module/ModuleRuntime.java
@@ -1,0 +1,408 @@
+package jls.module;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * The two-phase module runner (issue #220, grand-architecture §4.2
+ * rules 6-8): {@link #boot(Collection)} resolves the manifests once
+ * into one deterministic topological order via {@link ModuleResolver},
+ * runs phase 1 — {@link JlsModule#register()} on <em>every</em> module,
+ * in that order — and then phase 2, starting only what the declared
+ * {@link Activation} triggers demand:
+ *
+ * <ul>
+ * <li>{@link Activation.Eager} modules start at boot, in topological
+ * order.</li>
+ * <li>{@link Activation.OnCommand} / {@link Activation.OnEvent} /
+ * {@link Activation.OnDemand} modules stay registered-but-dormant
+ * until {@link #dispatchCommand(String)}, {@link #fireEvent(String)},
+ * or {@link #demand(String)} first touches them (VS Code
+ * {@code activationEvents} / Emacs autoloads).</li>
+ * <li>Starting a module first starts, in topological order, the sole
+ * provider of each of its {@code requires} tokens, transitively —
+ * whatever trigger that provider declared. {@code optional},
+ * {@code after}, and {@code before} never cause activation.</li>
+ * </ul>
+ *
+ * <p>Every module runs a start-once state machine: registered, then
+ * started or failed. A start that throws marks the module failed and
+ * surfaces as a {@link ModuleActivationException} naming the module
+ * and phase; every later touch rethrows that same exception — a failed
+ * module is never silently retried. All trigger methods are idempotent
+ * and report whether they started anything; unknown commands, events,
+ * and tokens are graceful no-ops.</p>
+ */
+public final class ModuleRuntime {
+
+	/** The start-once state machine of one registered module. */
+	private enum State {
+		/** Phase 1 ran; phase 2 has not. */
+		REGISTERED,
+		/** Phase 2 ran and returned normally. */
+		STARTED,
+		/** Phase 2 threw; every later touch rethrows. */
+		FAILED
+	} // end of State enum
+
+	/** Modules by id, iteration in topological order. */
+	private final Map<String, JlsModule> modulesById;
+
+	/** Manifests by id, iteration in topological order. */
+	private final Map<String, ModuleManifest> manifestsById;
+
+	/** Topological position of each module id, for closure sorting. */
+	private final Map<String, Integer> topoIndex;
+
+	/**
+	 * The capability index: every token maps to the id-sorted set of
+	 * modules offering it — each module's concrete id plus everything
+	 * in its {@code provides}. Precomputed locally; the resolver
+	 * already guaranteed every {@code requires} token exactly one
+	 * provider.
+	 */
+	private final Map<String, SortedSet<String>> providersByToken;
+
+	/** Lifecycle state of each module id. */
+	private final Map<String, State> states;
+
+	/** The failure of each {@link State#FAILED} module, for rethrow. */
+	private final Map<String, ModuleActivationException> failures;
+
+	/** Ids of started modules, in the order they started. */
+	private final List<String> startedIds;
+
+	/**
+	 * Wire the resolved structures; {@link #boot(Collection)} then
+	 * drives the two phases.
+	 *
+	 * @param order The manifests in resolved topological order.
+	 * @param byId The modules keyed by their manifest id.
+	 */
+	private ModuleRuntime(List<ModuleManifest> order,
+			Map<String, JlsModule> byId) {
+
+		modulesById = new LinkedHashMap<>();
+		manifestsById = new LinkedHashMap<>();
+		topoIndex = new HashMap<>();
+		providersByToken = new HashMap<>();
+		states = new HashMap<>();
+		failures = new HashMap<>();
+		startedIds = new ArrayList<>();
+		for (ModuleManifest manifest : order) {
+			String id = manifest.id();
+			modulesById.put(id,
+					Objects.requireNonNull(byId.get(id)));
+			manifestsById.put(id, manifest);
+			topoIndex.put(id, topoIndex.size());
+			providersByToken
+					.computeIfAbsent(id, t -> new TreeSet<>()).add(id);
+			for (String token : manifest.provides()) {
+				providersByToken
+						.computeIfAbsent(token, t -> new TreeSet<>())
+						.add(id);
+			}
+		}
+	} // end of constructor
+
+	/**
+	 * Resolve, register, and eagerly start a module set. Each module's
+	 * {@link JlsModule#manifest()} is read exactly once; the manifests
+	 * are resolved into one deterministic order (duplicate ids, missing
+	 * or ambiguous requirements, and cycles fail loudly there); phase 1
+	 * then calls {@link JlsModule#register()} on every module in that
+	 * order; phase 2 starts the {@link Activation.Eager} modules — and,
+	 * transitively, their {@code requires} providers — in that order.
+	 *
+	 * @param modules The modules to run, in any order.
+	 *
+	 * @return the booted runtime, ready to dispatch triggers.
+	 *
+	 * @throws ModuleResolutionException if the manifests do not resolve
+	 *             (propagated from {@link ModuleResolver} untouched).
+	 * @throws ModuleActivationException if a module's
+	 *             {@code register()} or an eager {@code start()}
+	 *             throws.
+	 */
+	public static ModuleRuntime boot(Collection<JlsModule> modules)
+			throws ModuleResolutionException,
+			ModuleActivationException {
+
+		List<JlsModule> snapshot = List.copyOf(modules);
+		List<ModuleManifest> manifests = new ArrayList<>();
+		for (JlsModule module : snapshot) {
+			manifests.add(module.manifest());
+		}
+		List<ModuleManifest> order = ModuleResolver.resolve(manifests);
+		// the resolver rejected duplicate ids, so this map is total
+		Map<String, JlsModule> byId = new HashMap<>();
+		for (int i = 0; i < snapshot.size(); i++) {
+			byId.put(manifests.get(i).id(), snapshot.get(i));
+		}
+		ModuleRuntime runtime = new ModuleRuntime(order, byId);
+		runtime.registerAll();
+		runtime.startEager();
+		return runtime;
+	} // end of boot method
+
+	/**
+	 * First-time invocation of a named command: start every dormant
+	 * module whose activation is {@link Activation.OnCommand} on this
+	 * command, in topological order, each with its transitive
+	 * {@code requires} providers first. Idempotent — modules already
+	 * started are untouched.
+	 *
+	 * @param command The command identifier being invoked.
+	 *
+	 * @return true if any module started; false if every matching
+	 *         module was already started or no module declares this
+	 *         command.
+	 *
+	 * @throws ModuleActivationException if a start throws, or a touched
+	 *             module already failed.
+	 */
+	public boolean dispatchCommand(String command)
+			throws ModuleActivationException {
+
+		boolean started = false;
+		for (ModuleManifest manifest : manifestsById.values()) {
+			if (manifest
+					.activation() instanceof Activation.OnCommand trigger
+					&& trigger.command().equals(command)) {
+				started |= activate(manifest.id());
+			}
+		}
+		return started;
+	} // end of dispatchCommand method
+
+	/**
+	 * First firing of a named event: start every dormant module whose
+	 * activation is {@link Activation.OnEvent} on this event, in
+	 * topological order, each with its transitive {@code requires}
+	 * providers first. Idempotent — modules already started are
+	 * untouched.
+	 *
+	 * @param event The event identifier being fired.
+	 *
+	 * @return true if any module started; false if every matching
+	 *         module was already started or no module declares this
+	 *         event.
+	 *
+	 * @throws ModuleActivationException if a start throws, or a touched
+	 *             module already failed.
+	 */
+	public boolean fireEvent(String event)
+			throws ModuleActivationException {
+
+		boolean started = false;
+		for (ModuleManifest manifest : manifestsById.values()) {
+			if (manifest
+					.activation() instanceof Activation.OnEvent trigger
+					&& trigger.event().equals(event)) {
+				started |= activate(manifest.id());
+			}
+		}
+		return started;
+	} // end of fireEvent method
+
+	/**
+	 * First real use of a capability: start every dormant module whose
+	 * concrete id matches the token or whose {@code provides} contains
+	 * it, in topological order, each with its transitive
+	 * {@code requires} providers first — whatever trigger the provider
+	 * declared, because a demanded capability must exist (the literal
+	 * meaning of issue #212's demand gate). Idempotent — modules
+	 * already started are untouched.
+	 *
+	 * @param token The demanded capability token or concrete id.
+	 *
+	 * @return true if any module started; false if every provider was
+	 *         already started or no module offers the token.
+	 *
+	 * @throws ModuleActivationException if a start throws, or a touched
+	 *             module already failed.
+	 */
+	public boolean demand(String token)
+			throws ModuleActivationException {
+
+		SortedSet<String> providers = providersByToken.get(token);
+		if (providers == null) {
+			return false;
+		}
+		boolean started = false;
+		for (String id : inTopoOrder(providers)) {
+			started |= activate(id);
+		}
+		return started;
+	} // end of demand method
+
+	/**
+	 * The ids of every started module, in the order they started.
+	 *
+	 * @return an immutable snapshot of the start log.
+	 */
+	public List<String> startedIds() {
+
+		return List.copyOf(startedIds);
+	} // end of startedIds method
+
+	/**
+	 * Whether a module has started.
+	 *
+	 * @param id The concrete module id.
+	 *
+	 * @return true if the module's {@code start()} ran and returned
+	 *         normally; false while it is dormant, after it failed, or
+	 *         when no module has the id.
+	 */
+	public boolean isStarted(String id) {
+
+		return states.get(id) == State.STARTED;
+	} // end of isStarted method
+
+	/**
+	 * Phase 1: {@link JlsModule#register()} on every module, in
+	 * topological order, exactly once.
+	 *
+	 * @throws ModuleActivationException if a registration throws,
+	 *             naming the module and the phase.
+	 */
+	private void registerAll() throws ModuleActivationException {
+
+		for (Map.Entry<String, JlsModule> e : modulesById.entrySet()) {
+			try {
+				e.getValue().register();
+			} catch (RuntimeException cause) {
+				throw new ModuleActivationException("module '"
+						+ e.getKey() + "' failed during register",
+						cause);
+			}
+			states.put(e.getKey(), State.REGISTERED);
+		}
+	} // end of registerAll method
+
+	/**
+	 * Phase 2, eager pass: activate every {@link Activation.Eager}
+	 * module in topological order.
+	 *
+	 * @throws ModuleActivationException if an eager start throws.
+	 */
+	private void startEager() throws ModuleActivationException {
+
+		for (ModuleManifest manifest : manifestsById.values()) {
+			if (manifest.activation() instanceof Activation.Eager) {
+				activate(manifest.id());
+			}
+		}
+	} // end of startEager method
+
+	/**
+	 * Start one module and, first, the transitive closure of its
+	 * {@code requires} providers, all in topological order. Modules
+	 * already started are skipped; a failed module in the closure
+	 * rethrows its recorded failure. {@code optional}, {@code after},
+	 * and {@code before} contribute nothing to the closure.
+	 *
+	 * @param rootId The id of the module being activated.
+	 *
+	 * @return true if this call started at least one module.
+	 *
+	 * @throws ModuleActivationException if a start throws, or a module
+	 *             in the closure already failed.
+	 */
+	private boolean activate(String rootId)
+			throws ModuleActivationException {
+
+		Set<String> seen = new HashSet<>();
+		Deque<String> pending = new ArrayDeque<>();
+		seen.add(rootId);
+		pending.add(rootId);
+		while (!pending.isEmpty()) {
+			String id = pending.remove();
+			ModuleManifest manifest = Objects
+					.requireNonNull(manifestsById.get(id));
+			for (String token : manifest.requires()) {
+				// sole by the resolver's zero/ambiguity checks
+				String provider = Objects
+						.requireNonNull(providersByToken.get(token))
+						.first();
+				if (seen.add(provider)) {
+					pending.add(provider);
+				}
+			}
+		}
+		boolean started = false;
+		for (String id : inTopoOrder(seen)) {
+			started |= startOne(id);
+		}
+		return started;
+	} // end of activate method
+
+	/**
+	 * Run one module's start-once state machine: a started module is a
+	 * no-op, a failed one rethrows its recorded failure, and a
+	 * registered one runs {@link JlsModule#start()} — recording either
+	 * the start or, if it throws, a permanent failure naming the module
+	 * and the phase.
+	 *
+	 * @param id The id of the module to start.
+	 *
+	 * @return true if the module started on this call.
+	 *
+	 * @throws ModuleActivationException if the start throws now, or
+	 *             threw on an earlier touch.
+	 */
+	private boolean startOne(String id)
+			throws ModuleActivationException {
+
+		State state = states.get(id);
+		if (state == State.STARTED) {
+			return false;
+		}
+		if (state == State.FAILED) {
+			throw Objects.requireNonNull(failures.get(id));
+		}
+		try {
+			Objects.requireNonNull(modulesById.get(id)).start();
+		} catch (RuntimeException cause) {
+			ModuleActivationException failure =
+					new ModuleActivationException("module '" + id
+							+ "' failed during start", cause);
+			states.put(id, State.FAILED);
+			failures.put(id, failure);
+			throw failure;
+		}
+		states.put(id, State.STARTED);
+		startedIds.add(id);
+		return true;
+	} // end of startOne method
+
+	/**
+	 * The given module ids sorted into topological order.
+	 *
+	 * @param ids The ids to sort; every id must be a known module.
+	 *
+	 * @return the ids, smallest topological position first.
+	 */
+	private List<String> inTopoOrder(Collection<String> ids) {
+
+		TreeMap<Integer, String> ordered = new TreeMap<>();
+		for (String id : ids) {
+			ordered.put(Objects.requireNonNull(topoIndex.get(id)), id);
+		}
+		return new ArrayList<>(ordered.values());
+	} // end of inTopoOrder method
+
+} // end of ModuleRuntime class

--- a/test/jls/ModuleRuntimeTest.java
+++ b/test/jls/ModuleRuntimeTest.java
@@ -1,0 +1,412 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import jls.module.Activation;
+import jls.module.JlsModule;
+import jls.module.ModuleActivationException;
+import jls.module.ModuleManifest;
+import jls.module.ModuleResolutionException;
+import jls.module.ModuleRuntime;
+
+/**
+ * Pins the two-phase lifecycle contract of the module runtime from
+ * issue #220 — every {@code register()} precedes every {@code start()},
+ * each exactly once, both in topological order; eager modules start at
+ * boot and lazy ones do not; commands, events, and demand start their
+ * modules first-time-only; activation transitively starts the sole
+ * provider of each {@code requires} token while {@code optional} /
+ * {@code after} / {@code before} never trigger anything; a throwing
+ * {@code start()} becomes a permanent {@code ModuleActivationException}
+ * naming the module, rethrown on every later touch and never retried;
+ * the whole thing is deterministic across shuffled input permutations;
+ * and resolution failures propagate from {@code boot()} untouched.
+ */
+class ModuleRuntimeTest {
+
+	/**
+	 * A recording module: appends {@code "register:<id>"} and
+	 * {@code "start:<id>"} to a shared log, counts calls, and
+	 * optionally throws from {@code start()}.
+	 */
+	private static final class FakeModule implements JlsModule {
+
+		/** The static descriptor this fake reports. */
+		private final ModuleManifest manifest;
+
+		/** The log shared by every module in the scenario. */
+		private final List<String> log;
+
+		/** Whether start() throws instead of succeeding. */
+		private final boolean failOnStart;
+
+		/** How many times register() ran. */
+		private int registerCalls;
+
+		/** How many times start() ran (including a throwing run). */
+		private int startCalls;
+
+		FakeModule(ModuleManifest manifest, List<String> log,
+				boolean failOnStart) {
+			this.manifest = manifest;
+			this.log = log;
+			this.failOnStart = failOnStart;
+		}
+
+		@Override
+		public ModuleManifest manifest() {
+			return manifest;
+		}
+
+		@Override
+		public void register() {
+			registerCalls++;
+			log.add("register:" + manifest.id());
+		}
+
+		@Override
+		public void start() {
+			startCalls++;
+			log.add("start:" + manifest.id());
+			if (failOnStart) {
+				throw new IllegalStateException(
+						"boom in " + manifest.id());
+			}
+		}
+
+	} // end of FakeModule class
+
+	/** Shorthand manifest with every axis explicit. */
+	private static ModuleManifest manifest(String id,
+			Set<String> provides, Set<String> requires,
+			Set<String> optional, Set<String> after, Set<String> before,
+			Activation activation) {
+		return new ModuleManifest(id, 1, provides, requires, optional,
+				after, before, activation);
+	}
+
+	/** A module with an id, an activation, and nothing else. */
+	private static FakeModule bare(String id, Activation activation,
+			List<String> log) {
+		return new FakeModule(manifest(id, Set.of(), Set.of(), Set.of(),
+				Set.of(), Set.of(), activation), log, false);
+	}
+
+	/** A module requiring the given tokens. */
+	private static FakeModule requiring(String id, Set<String> requires,
+			Activation activation, List<String> log) {
+		return new FakeModule(manifest(id, Set.of(), requires, Set.of(),
+				Set.of(), Set.of(), activation), log, false);
+	}
+
+	@Test
+	void allRegistersPrecedeAllStartsExactlyOnceInTopoOrder() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule core = bare("core", new Activation.Eager(), log);
+		FakeModule gui = requiring("gui", Set.of("core"),
+				new Activation.Eager(), log);
+		FakeModule batch = requiring("batch", Set.of("core"),
+				new Activation.Eager(), log);
+		ModuleRuntime runtime = ModuleRuntime
+				.boot(List.of(gui, batch, core));
+		assertEquals(List.of("register:core", "register:batch",
+				"register:gui", "start:core", "start:batch",
+				"start:gui"), log,
+				"phase 1 must fully precede phase 2, both in topo"
+						+ " order with the id-sorted tie-break");
+		assertEquals(1, core.registerCalls);
+		assertEquals(1, gui.registerCalls);
+		assertEquals(1, batch.registerCalls);
+		assertEquals(1, core.startCalls);
+		assertEquals(List.of("core", "batch", "gui"),
+				runtime.startedIds());
+	}
+
+	@Test
+	void eagerStartsAtBootAndLazyDoesNot() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule kernel = bare("kernel", new Activation.Eager(), log);
+		FakeModule lazyCommand = bare("cmd.mod",
+				new Activation.OnCommand("export"), log);
+		FakeModule lazyEvent = bare("evt.mod",
+				new Activation.OnEvent("opened"), log);
+		FakeModule lazyDemand = bare("dem.mod",
+				new Activation.OnDemand(), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(
+				List.of(lazyCommand, lazyEvent, lazyDemand, kernel));
+		assertTrue(runtime.isStarted("kernel"));
+		assertFalse(runtime.isStarted("cmd.mod"),
+				"an OnCommand module must stay dormant at boot");
+		assertFalse(runtime.isStarted("evt.mod"),
+				"an OnEvent module must stay dormant at boot");
+		assertFalse(runtime.isStarted("dem.mod"),
+				"an OnDemand module must stay dormant at boot");
+		assertEquals(List.of("kernel"), runtime.startedIds());
+		assertEquals(1, lazyCommand.registerCalls,
+				"dormant modules still register in phase 1");
+	}
+
+	@Test
+	void dispatchCommandStartsFirstTimeOnly() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule exporter = bare("hdl.export",
+				new Activation.OnCommand("export"), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(exporter));
+		assertTrue(runtime.dispatchCommand("export"),
+				"the first dispatch must start the module");
+		assertTrue(runtime.isStarted("hdl.export"));
+		assertFalse(runtime.dispatchCommand("export"),
+				"a repeat dispatch must start nothing");
+		assertEquals(1, exporter.startCalls,
+				"start() must run exactly once");
+	}
+
+	@Test
+	void fireEventStartsFirstTimeOnly() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule collab = bare("collab",
+				new Activation.OnEvent("session-opened"), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(collab));
+		assertTrue(runtime.fireEvent("session-opened"));
+		assertFalse(runtime.fireEvent("session-opened"),
+				"a repeat event must start nothing");
+		assertEquals(1, collab.startCalls);
+	}
+
+	@Test
+	void demandMatchesConcreteIdAndProvidesToken() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule byId = bare("board.db", new Activation.OnDemand(),
+				log);
+		FakeModule byToken = new FakeModule(
+				manifest("elem.registry", Set.of("element-registry"),
+						Set.of(), Set.of(), Set.of(), Set.of(),
+						new Activation.OnDemand()),
+				log, false);
+		ModuleRuntime runtime = ModuleRuntime
+				.boot(List.of(byId, byToken));
+		assertTrue(runtime.demand("board.db"),
+				"demand by concrete id must start the module");
+		assertTrue(runtime.demand("element-registry"),
+				"demand by provides token must start the provider");
+		assertTrue(runtime.isStarted("elem.registry"));
+		assertFalse(runtime.demand("element-registry"),
+				"a repeat demand must start nothing");
+		assertEquals(1, byToken.startCalls);
+	}
+
+	@Test
+	void unknownCommandEventAndTokenAreGracefulNoOps() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule module = bare("core",
+				new Activation.OnCommand("real"), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(module));
+		assertFalse(runtime.dispatchCommand("ghost"));
+		assertFalse(runtime.fireEvent("ghost"));
+		assertFalse(runtime.demand("ghost"));
+		assertFalse(runtime.isStarted("ghost"),
+				"an unknown id is simply not started");
+		assertEquals(0, module.startCalls,
+				"unknown triggers must start nothing");
+		assertEquals(List.of(), runtime.startedIds());
+	}
+
+	@Test
+	void activationTransitivelyStartsRequiresChainInTopoOrder() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule a = bare("a", new Activation.OnDemand(), log);
+		FakeModule b = requiring("b", Set.of("a"),
+				new Activation.OnDemand(), log);
+		FakeModule c = requiring("c", Set.of("b"),
+				new Activation.OnDemand(), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(c, a, b));
+		assertTrue(runtime.demand("c"));
+		assertEquals(List.of("a", "b", "c"), runtime.startedIds(),
+				"activating c must first start its transitive"
+						+ " providers, in topo order");
+		assertTrue(runtime.isStarted("a"));
+		assertTrue(runtime.isStarted("b"));
+	}
+
+	@Test
+	void optionalAfterAndBeforeNeverTriggerActivation() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule soft = bare("soft", new Activation.OnDemand(), log);
+		FakeModule late = bare("late", new Activation.OnDemand(), log);
+		FakeModule early = bare("early", new Activation.OnDemand(),
+				log);
+		FakeModule user = new FakeModule(
+				manifest("user", Set.of(), Set.of(), Set.of("soft"),
+						Set.of("late"), Set.of("early"),
+						new Activation.OnDemand()),
+				log, false);
+		ModuleRuntime runtime = ModuleRuntime
+				.boot(List.of(soft, late, early, user));
+		assertTrue(runtime.demand("user"));
+		assertEquals(List.of("user"), runtime.startedIds(),
+				"optional, after, and before must pull nothing into"
+						+ " activation");
+		assertFalse(runtime.isStarted("soft"));
+		assertFalse(runtime.isStarted("late"));
+		assertFalse(runtime.isStarted("early"));
+	}
+
+	@Test
+	void throwingStartFailsPermanentlyNamingModuleAndPhase() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule broken = new FakeModule(
+				manifest("broken", Set.of(), Set.of(), Set.of(),
+						Set.of(), Set.of(),
+						new Activation.OnCommand("go")),
+				log, true);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(broken));
+		ModuleActivationException first = assertThrows(
+				ModuleActivationException.class,
+				() -> runtime.dispatchCommand("go"));
+		assertTrue(first.getMessage().contains("broken"),
+				"the failing module must be named: "
+						+ first.getMessage());
+		assertTrue(first.getMessage().contains("start"),
+				"the failing phase must be named: "
+						+ first.getMessage());
+		assertTrue(first.getCause() instanceof IllegalStateException,
+				"the module's own exception must be the cause");
+		assertFalse(runtime.isStarted("broken"));
+		ModuleActivationException again = assertThrows(
+				ModuleActivationException.class,
+				() -> runtime.dispatchCommand("go"));
+		assertSame(first, again,
+				"a failed module must rethrow its recorded failure");
+		ModuleActivationException demanded = assertThrows(
+				ModuleActivationException.class,
+				() -> runtime.demand("broken"));
+		assertSame(first, demanded,
+				"every later touch rethrows; no other trigger path"
+						+ " may retry");
+		assertEquals(1, broken.startCalls,
+				"a failed start must never be silently retried");
+	}
+
+	@Test
+	void throwingRegisterFailsBootNamingModuleAndPhase() {
+		List<String> log = new ArrayList<>();
+		JlsModule broken = new JlsModule() {
+
+			@Override
+			public ModuleManifest manifest() {
+				return ModuleRuntimeTest.manifest("reg.broken",
+						Set.of(), Set.of(), Set.of(), Set.of(),
+						Set.of(), new Activation.OnDemand());
+			}
+
+			@Override
+			public void register() {
+				throw new IllegalStateException("register boom");
+			}
+
+			@Override
+			public void start() {
+				log.add("start:reg.broken");
+			}
+
+		};
+		ModuleActivationException ex = assertThrows(
+				ModuleActivationException.class,
+				() -> ModuleRuntime.boot(List.of(broken)));
+		assertTrue(ex.getMessage().contains("reg.broken"),
+				"the failing module must be named: " + ex.getMessage());
+		assertTrue(ex.getMessage().contains("register"),
+				"the failing phase must be named: " + ex.getMessage());
+		assertEquals(List.of(), log,
+				"no start may run when registration fails");
+	}
+
+	@Test
+	void bootIsDeterministicAcrossInputPermutations() throws
+			ModuleResolutionException, ModuleActivationException {
+		// the resolver test's layered graph, all eager, so the start
+		// log itself is the determinism witness
+		List<String> expectedLog = new ArrayList<>();
+		List<String> expectedStarted = new ArrayList<>();
+		Random shuffler = new Random(220);
+		for (int permutation = 0; permutation < 25; permutation++) {
+			List<String> log = new ArrayList<>();
+			List<JlsModule> modules = new ArrayList<>(List.of(
+					new FakeModule(manifest("core", Set.of("kernel"),
+							Set.of(), Set.of(), Set.of(), Set.of(),
+							new Activation.Eager()), log, false),
+					new FakeModule(
+							manifest("elem.registry",
+									Set.of("element-registry"),
+									Set.of("kernel"), Set.of(),
+									Set.of(), Set.of(),
+									new Activation.Eager()),
+							log, false),
+					requiring("gui", Set.of("element-registry"),
+							new Activation.Eager(), log),
+					new FakeModule(manifest("hdl", Set.of(),
+							Set.of("element-registry"), Set.of(),
+							Set.of(), Set.of("batch"),
+							new Activation.Eager()), log, false),
+					requiring("batch", Set.of("element-registry"),
+							new Activation.Eager(), log)));
+			Collections.shuffle(modules, shuffler);
+			ModuleRuntime runtime = ModuleRuntime.boot(modules);
+			if (permutation == 0) {
+				expectedLog.addAll(log);
+				expectedStarted.addAll(runtime.startedIds());
+				assertEquals(List.of("core", "elem.registry", "gui",
+						"hdl", "batch"), expectedStarted);
+			} else {
+				assertEquals(expectedLog, log,
+						"the full register/start log must not depend"
+								+ " on discovery order (permutation "
+								+ permutation + ")");
+				assertEquals(expectedStarted, runtime.startedIds());
+			}
+		}
+	}
+
+	@Test
+	void bootPropagatesResolutionFailuresUntouched() {
+		List<String> log = new ArrayList<>();
+		FakeModule orphan = requiring("orphan",
+				Set.of("board-constraints"), new Activation.Eager(),
+				log);
+		ModuleResolutionException ex = assertThrows(
+				ModuleResolutionException.class,
+				() -> ModuleRuntime.boot(List.of(orphan)));
+		assertTrue(ex.getMessage().contains("board-constraints"),
+				"the resolver's diagnostic must pass through: "
+						+ ex.getMessage());
+		assertEquals(0, orphan.registerCalls,
+				"nothing may register when resolution fails");
+		FakeModule one = bare("dup", new Activation.Eager(), log);
+		FakeModule two = bare("dup", new Activation.Eager(), log);
+		assertThrows(ModuleResolutionException.class,
+				() -> ModuleRuntime.boot(List.of(one, two)),
+				"duplicate ids must be rejected via the resolver");
+	}
+
+} // end of ModuleRuntimeTest class


### PR DESCRIPTION
## Summary

Closes #220. Adds the module activation runtime on top of the #220 resolver slice: the `jls.module.JlsModule` lifecycle SPI (`manifest()` / `register()` / `start()`) and `jls.module.ModuleRuntime`, a two-phase runner that resolves manifests once through `ModuleResolver`, registers every module in topological order, then starts modules per their declared `Activation` trigger.

## What / why

- **`JlsModule`** (new, 50 lines): the SPI one module implements — a static side-effect-free `manifest()`, plus `register()` (phase 1: publish, touch nothing else) and `start()` (phase 2: resolve references, go live). The two phases are the model's only cycle escape hatch: every module registers before any module starts. The registrar parameter for `register()` is deliberately deferred to #223 and documented in prose only — no reference to `ExtensionPoint`/`ExtensionRegistry` anywhere.
- **`ModuleRuntime`** (new, 408 lines): `boot(Collection<JlsModule>)` reads each manifest exactly once, resolves via `ModuleResolver` (duplicate ids / missing or ambiguous requires / cycles fail loudly there and propagate untouched), registers all modules in topo order, then starts `Eager` modules. `dispatchCommand` / `fireEvent` / `demand` start dormant `OnCommand` / `OnEvent` / `OnDemand` modules first-time-only (VS Code `activationEvents` / Emacs autoloads). Activation transitively starts the sole provider of each `requires` token in topological order; `optional` / `after` / `before` never trigger activation. `demand(token)` matches concrete id or `provides` token and activates every provider regardless of its declared trigger — a demanded capability must exist, consistent with transitive `requires` activation (documented in javadoc).
- **Start-once state machine**: registered → started | failed. A throwing `start()` becomes a permanent `ModuleActivationException` naming the module and phase; every later touch rethrows the identical stored instance (pinned by `assertSame`) — never silently retried. `register()`-phase failures are wrapped the same way, naming phase `register`. Unknown commands/events/tokens are graceful no-ops.
- **`ModuleActivationException`** (new): checked, mirroring `ModuleResolutionException` in style, single `(message, cause)` constructor.
- **`ModuleRuntimeTest`** (new, 12 tests): pins phase ordering (all registers precede all starts, each exactly once, topo order with id-sorted tie-break), eager-vs-dormant boot behavior, first-time-only semantics of all three triggers, demand by id and by token, graceful no-ops, transitive `requires` activation order, optional/after/before non-activation, permanent failure with exception identity across trigger paths, register-phase boot failure, determinism across 25 seeded input permutations, and untouched propagation of resolution failures.
- **CHANGELOG**: one entry at the top of Unreleased/Added.

The provider index (`token → id-sorted providers`, concrete id + `provides`) is precomputed locally inside `ModuleRuntime` using the same rule as the resolver — `ModuleResolver` and `ModuleManifest` public APIs are unchanged.

## Verification

Independently re-verified by a separate reviewer from a clean run in the worktree (JDK 25, Maven 3.9.11 via `nix develop`):

- `mvn verify`: **BUILD SUCCESS** in 03:14. Surefire XML aggregate: **1296 tests, 0 failures, 0 errors, 97 skipped** (the skips are `@Tag("display")` tests skipping headless — expected).
- `ModuleRuntimeTest`: 12/12 pass. `ModuleResolverTest`: 12/12 pass (unchanged, confirming no resolver API drift). NullMarked and headless-core ratchets pass.
- Jacoco coverage checks, SpotBugs (0 findings), javadoc doclint gate, enforcer, and Spotless all pass. No jacoco floor raises, no NullAway suppressions, no pom changes.
- Adversarial review confirmed: the `.first()` sole-provider assumption in the activation closure is guaranteed by the resolver's zero/ambiguity validation of every `requires` token before boot proceeds; the determinism test's expected topological order was verified by hand against Kahn-with-id-tiebreak including the `before` edge; all tests assert exact sequences/counts/exception identity (no tautologies).

## De-confliction with #224

Shares `src/jls/module` with #224 but is fully disjoint: only new files (`JlsModule`, `ModuleActivationException`, `ModuleRuntime`, `ModuleRuntimeTest`) plus one CHANGELOG hunk. `package-info.java` untouched; zero references to `ExtensionPoint`/`ExtensionRegistry` (grep-verified); `ModuleResolver`/`ModuleManifest` untouched. Whichever of #220/#224 merges second sees at most a trivial CHANGELOG rebase conflict confined to the Unreleased/Added hunk.

## Caveats

- The runtime is single-threaded by design for this slice; no thread-safety is claimed.
- Only `RuntimeException` from lifecycle methods is wrapped; `Error` propagates raw (deliberate, consistent with the codebase's fail-loud posture).
- The commit is unsigned (sandbox has no gpg agent); the author must re-sign via `git commit --amend -S` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW9SQJcVqt859o6XWEb7aW