### PR TITLE
feat(#167): partial-net delete travels as RemoveWire + AddWire survivors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,26 @@ All notable changes to JLS are documented here. The format follows
   `RemoveWire` per wholly-selected wire net plus one `RemoveElements`
   (jump starts expanded with their jump ends), submitted as a single
   batch via the new `OpSink.submitAll` so a wired delete stays exactly
-  one undo snapshot. Selections the vocabulary cannot express yet
-  (partially selected nets, subcircuits) fall back to the previous
+  one undo snapshot. Selections the vocabulary cannot express
+  (subcircuits, in-progress wiring) fall back to the previous
   inline removal unchanged; user-facing undo mechanics are untouched.
   Byte parity between the op path and the inline path is pinned
   headlessly by `DeleteGestureTest`, and the end-to-end delete-key +
   single-undo behavior by a new display-tagged `EditorGestureTest`
   case.
+- The delete gesture's partial-net fallback is gone (#167): a
+  selection that clips a wire net — a middle or leaf segment of a
+  larger net, or a wired element deleted without its wiring — now
+  travels through the operation layer as `RemoveWire` of the whole net
+  plus one `AddWire` per surviving connected component, built by the
+  new `AddWire.survivors` factory (`WireEnd.save`-exact blocks
+  filtered to the surviving subgraph: kept wires and probes only,
+  attachments to deleted elements dropped, tri-state recomputed per
+  component the way the inline re-partition does). Only subcircuits,
+  in-progress wiring, and uneditable cascades still take the inline
+  path. Byte parity with the inline delete is pinned by
+  `DeleteGestureTest` on constructed and save/load-restored circuits
+  alike, and a clipped-net delete stays exactly one undo snapshot.
 - Board-aware HDL export, first slice (#213): `-export` now accepts
   `-board <name>` plus `-pins <file>` and writes a pin-constraint file
   (`.pcf`) next to the exported HDL, generated from the same model walk

--- a/docs/operation-layer.md
+++ b/docs/operation-layer.md
@@ -100,8 +100,14 @@ and the anchors travel alongside the blocks as stable ids (#165).
   clearing the tri-state property of elements a tri-state net drove).
   Its inverse carries the net's serialized blocks: a true, byte-exact
   restore. Net granularity is deliberate: a gesture that deletes one
-  segment of a larger net re-partitions the remainder, and will travel
-  as `RemoveWire` plus `AddWire` ops for the surviving pieces.
+  segment of a larger net re-partitions the remainder, and travels as
+  `RemoveWire` plus one `AddWire` per surviving connected component,
+  built by `AddWire.survivors(ends, keptWires, removedAnchors)`: the
+  wire-end blocks in `WireEnd.save`'s exact format filtered to the
+  surviving subgraph (kept wires and their probes only, attachments to
+  removed elements dropped, the tri-state flag recomputed per
+  component the way `WireNet.makeNet` does), written without touching
+  the ends' save-time ids (HDL export consumes those).
 
 ## Mutation-site inventory (§7 step 1)
 
@@ -121,8 +127,8 @@ the migration commit.
 | Move-selection commit (mouse release) | `MoveElements` | op implemented + tested, and wired into the keyboard nudge (issue #75, `submitOp(new MoveElements(...))` at `SimpleEditor.java:3254`); the mouse-release drag commit is still inline (live drag must become preview-then-commit) |
 | Placement drop (fixPosition + connect) | `AddElements` (+ implicit wiring) | op implemented + tested for the unwired case; gesture still inline (the drop's `connect()` needs the wiring vocabulary, and placement must become preview-then-commit) |
 | Matching JumpEnd creation, context menu | `AddElements` | op implemented + tested (jump-source validation included); gesture still inline (the created end stays mouse-attached in `chosen` state, so the commit point is the later drop) |
-| Delete selection (delete key, Edit menu, popup Delete, and CUT's removal half) | `RemoveWire` per attached net + `RemoveElements` | **migrated with a partial-net fallback**: `SimpleEditor.deleteSelectionPlan` maps the selection to an op plan (jump starts expanded with their jump ends, one `RemoveWire` per wholly-selected net, then `RemoveElements`), submitted as one batch through `OpSink.submitAll` so the gesture stays a single undo snapshot (`DeleteGestureTest`). A selection that clips a net (e.g. a wired element deleted without its wiring) has no plan yet and takes the inline fallback; expressing it as `RemoveWire` plus `AddWire` of the surviving pieces removes the fallback in a follow-up |
-| Delete wire net / detach (popup delete on a wire) | `RemoveWire` | **migrated with a partial-net fallback** via the same plan builder: a wire selection covering its whole net travels as `RemoveWire` (`DeleteGestureTest.wireOnlySelectionPlansToARemoveWire`); a segment delete that clips a larger net falls back inline until the `RemoveWire`+`AddWire`-survivors composition lands |
+| Delete selection (delete key, Edit menu, popup Delete, and CUT's removal half) | `RemoveWire` per attached net + `AddWire` per surviving component + `RemoveElements` | **migrated**: `SimpleEditor.deleteSelectionPlan` maps the selection to an op plan (jump starts expanded with their jump ends; per affected net one `RemoveWire` of the whole net plus, when the selection only clips it, one `AddWire.survivors` per surviving connected component; then `RemoveElements`), submitted as one batch through `OpSink.submitAll` so the gesture stays a single undo snapshot (`DeleteGestureTest`). Only subcircuits, in-progress wiring, and uneditable cascades still take the inline fallback |
+| Delete wire net / detach (popup delete on a wire) | `RemoveWire` (+ `AddWire` survivors) | **migrated** via the same plan builder: a wire selection covering its whole net travels as `RemoveWire` (`DeleteGestureTest.wireOnlySelectionPlansToARemoveWire`); a segment delete that clips a larger net travels as `RemoveWire` plus one survivor `AddWire` per remaining component (`DeleteGestureTest.middleSegmentDeletePlansTwoSurvivorAddWires`) |
 | Paste | `AddElements` + `AddWire` | op machinery in place (multi-block add with paste's name/jump validation; pasted nets travel as `AddWire`); gesture still inline |
 | Wire-attach finish (mouse) | `AddWire` | op implemented + tested at net granularity (a commit that extends an existing net travels as `RemoveWire` of the old net plus `AddWire` of the merged one); gesture still inline — wiring gestures become commit-time ops |
 | Wire-draw cancel (right button / end-wire key, two sites) | none — gesture-local cleanup of the in-progress wire; these `markChanged` calls compensate for live mutation and disappear when wiring is commit-time | deferred |
@@ -146,16 +152,11 @@ rule 2; only the future `jls.collab.ui` may touch Swing).
 
 ## What lands next
 
-1. The partial-net delete composition: a selection that clips a net
-   travels as `RemoveWire` of the whole net plus `AddWire` of the
-   surviving pieces, removing `deleteSelectionPlan`'s inline fallback
-   (delete itself migrated without preview-then-commit because its
-   commit point was already a single model-only method).
-2. Preview-then-commit for the move, placement, and wiring gestures,
+1. Preview-then-commit for the move, placement, and wiring gestures,
    anchored by the #91 gesture harness (`EditorGestureTest`) - the
    step that migrates the remaining gestures whose ops already exist
    (`MoveElements`, `AddElements`, `AddWire`).
-3. Wiring the dialog-commit gestures onto `SetElementConfig`, whose op
+2. Wiring the dialog-commit gestures onto `SetElementConfig`, whose op
    already exists; the commit paths mutate in place until then.
-4. Op-inverse (precise) undo activation is explicitly *not* this
+3. Op-inverse (precise) undo activation is explicitly *not* this
    stage: snapshot undo stays user-facing until Stage 2 (#163).

--- a/src/jls/collab/op/AddWire.java
+++ b/src/jls/collab/op/AddWire.java
@@ -65,6 +65,38 @@ public record AddWire(List<ElementId> attach, List<String> blocks)
 	} // end of compact constructor
 
 	/**
+	 * Serialize one surviving connected component of a clipped net
+	 * (issue #167): the delete gesture removes a partially selected net
+	 * with {@link RemoveWire} of the whole net and re-adds each
+	 * surviving connected component through this factory. The blocks
+	 * are {@code WireEnd.save}'s exact format filtered to the surviving
+	 * subgraph: only wires in the kept set (and their probes) are
+	 * referenced, attachments to elements in the removed set are
+	 * dropped (those elements leave in the gesture's
+	 * {@link RemoveElements}), and the tri-state flag is recomputed for
+	 * the component alone, mirroring {@code WireNet.makeNet}.
+	 *
+	 * @param ends The component's wire ends, in any order; each must
+	 *            keep at least one wire.
+	 * @param keptWires The surviving wires; every kept wire of the
+	 *            given ends must connect two of them.
+	 * @param removedAnchors The elements leaving in the same gesture;
+	 *            attachments to them are not serialized.
+	 *
+	 * @return the op that adds the surviving component.
+	 *
+	 * @throws IllegalArgumentException if the arguments do not describe
+	 *             one nonempty surviving component - a planner bug, not
+	 *             hostile input, hence unchecked.
+	 */
+	public static AddWire survivors(List<WireEnd> ends,
+			Set<Wire> keptWires, Set<Element> removedAnchors) {
+
+		return NetBlocks.toSurvivorAddWire(ends, keptWires,
+				removedAnchors);
+	} // end of survivors method
+
+	/**
 	 * The vetted form of the op: the resolved anchors and parsed end
 	 * blocks validation produced.
 	 *

--- a/src/jls/collab/op/NetBlocks.java
+++ b/src/jls/collab/op/NetBlocks.java
@@ -2,16 +2,20 @@ package jls.collab.op;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
 import jls.elem.Element;
 import jls.elem.ElementId;
 import jls.elem.LogicElement;
+import jls.elem.Output;
 import jls.elem.Put;
+import jls.elem.Wire;
 import jls.elem.WireEnd;
 
 /**
@@ -122,6 +126,143 @@ final class NetBlocks {
 			}
 		}
 	} // end of toAddWire method
+
+	/**
+	 * Serialize one surviving connected component of a clipped net as
+	 * an {@link AddWire} op: the second half of the
+	 * RemoveWire-plus-AddWire-survivors composition the delete gesture
+	 * uses when a selection removes only part of a net. The blocks are
+	 * written in {@code WireEnd.save}'s exact format, filtered to the
+	 * surviving subgraph: only wires in the kept set (and their probes)
+	 * are referenced, attach lines are dropped for ends whose put's
+	 * element is among the removed anchors (those elements leave in the
+	 * gesture's {@link RemoveElements}), and the tri-state flag is
+	 * recomputed for the component alone - tri-state iff a surviving
+	 * attachment drives it from a tri-state output, mirroring
+	 * {@code WireNet.makeNet}.
+	 *
+	 * Unlike {@link #toAddWire} this writes the blocks directly from
+	 * the live ends without ever touching their save-time {@code int}
+	 * ids (which HDL export consumes for element ordering and
+	 * synthesized net names), so there is nothing to restore and
+	 * serializing a component leaves no observable trace.
+	 *
+	 * @param survivorEnds The component's wire ends, in any order; each
+	 *            must keep at least one wire.
+	 * @param keptWires The surviving wires; every kept wire of the
+	 *            given ends must connect two of them.
+	 * @param removedAnchors The elements leaving in the same gesture;
+	 *            attachments to them are not serialized.
+	 *
+	 * @return the op that adds the surviving component.
+	 *
+	 * @throws IllegalArgumentException if the arguments do not describe
+	 *             one nonempty surviving component - a planner bug, not
+	 *             hostile input, hence unchecked.
+	 */
+	static AddWire toSurvivorAddWire(List<WireEnd> survivorEnds,
+			Set<Wire> keptWires, Set<Element> removedAnchors) {
+
+		if (survivorEnds.isEmpty()) {
+			throw new IllegalArgumentException(
+					"a survivor component needs at least one wire end");
+		}
+		if (keptWires.isEmpty()) {
+			throw new IllegalArgumentException(
+					"a survivor component needs at least one kept wire");
+		}
+		List<WireEnd> ends = new ArrayList<WireEnd>(survivorEnds);
+		ends.sort(Comparator.comparing(Element::getStableId));
+
+		// the surviving attachment anchors, in stable-id order, and the
+		// component's recomputed tri-state flag (WireNet.makeNet:
+		// tri-state iff a tri-state output still drives it)
+		List<Element> anchors = new ArrayList<Element>();
+		boolean triState = false;
+		for (WireEnd end : ends) {
+			Put p = end.getPut();
+			if (p == null) {
+				continue;
+			}
+			LogicElement owner = p.getElement();
+			if (owner == null) {
+				throw new IllegalArgumentException("a survivor end is "
+						+ "attached to an in-progress connection");
+			}
+			if (removedAnchors.contains(owner)) {
+				continue;
+			}
+			if (!anchors.contains(owner)) {
+				anchors.add(owner);
+			}
+			if (p instanceof Output out && out.isTriState()) {
+				triState = true;
+			}
+		}
+		anchors.sort(Comparator.comparing(Element::getStableId));
+
+		// the op's local numbering: anchors 0..k-1, ends k..k+n-1, both
+		// in stable-id order - computed in side maps, never written
+		// into the elements
+		Map<WireEnd, Integer> localId =
+				new HashMap<WireEnd, Integer>();
+		int base = anchors.size();
+		for (int i = 0; i < ends.size(); i += 1) {
+			localId.put(ends.get(i), base + i);
+		}
+		List<ElementId> attach = new ArrayList<ElementId>(anchors.size());
+		for (Element anchor : anchors) {
+			attach.add(anchor.getStableId());
+		}
+
+		List<String> blocks = new ArrayList<String>(ends.size());
+		for (WireEnd end : ends) {
+			StringBuilder block = new StringBuilder();
+			block.append("ELEMENT WireEnd\n");
+			block.append(" int id ").append(localId.get(end))
+					.append('\n');
+			block.append(" int x ").append(end.getX()).append('\n');
+			block.append(" int y ").append(end.getY()).append('\n');
+			block.append(" String sid \"").append(end.getStableId())
+					.append("\"\n");
+			if (triState) {
+				block.append(" int tristate 1\n");
+			}
+			Put p = end.getPut();
+			LogicElement owner = p == null ? null : p.getElement();
+			if (p != null && owner != null
+					&& !removedAnchors.contains(owner)) {
+				block.append(" String put \"").append(p.getName())
+						.append("\"\n");
+				block.append(" ref attach ")
+						.append(anchors.indexOf(owner)).append('\n');
+			}
+			boolean keptOne = false;
+			for (Wire wire : end.getWires()) {
+				if (!keptWires.contains(wire)) {
+					continue;
+				}
+				Integer other = localId.get(wire.getOtherEnd(end));
+				if (other == null) {
+					throw new IllegalArgumentException("a kept wire "
+							+ "leads outside the survivor component");
+				}
+				block.append(" ref wire ").append(other).append('\n');
+				if (wire.hasProbe()) {
+					block.append(" probe ").append(other).append(" \"")
+							.append(wire.getProbe()).append("\"\n");
+				}
+				keptOne = true;
+			}
+			if (!keptOne) {
+				throw new IllegalArgumentException("a survivor wire "
+						+ "end needs at least one kept wire");
+			}
+			block.append("END\n");
+			blocks.add(block.toString());
+		}
+		return new AddWire(attach, blocks);
+	} // end of toSurvivorAddWire method
 
 	/**
 	 * Parse one wire-end block strictly: exactly the line sequence

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -69,6 +69,7 @@ import jls.JLSInfo;
 import jls.MenuAcceleratorPolicy;
 import jls.TellUser;
 import jls.Util;
+import jls.collab.op.AddWire;
 import jls.collab.op.AttachProbe;
 import jls.collab.op.CircuitOp;
 import jls.collab.op.FlipElement;
@@ -837,25 +838,30 @@ public abstract class SimpleEditor extends JPanel {
 
 	/**
 	 * The model half of the delete-selection gesture (issue #167): map a
-	 * selection to the op plan that expresses it - one {@link RemoveWire}
-	 * per attached wire net wholly covered by the selection, in stable-id
-	 * order, then one {@link RemoveElements} over the then-unwired
-	 * elements, with jump starts expanded to their same-name jump ends
-	 * exactly as the editor's removal cascade does. A net is wholly
-	 * covered when every one of its wires is in the (expanded) selection;
-	 * its wire ends then follow by the same cascade the inline deletion
-	 * uses, so attached ends (which are never selectable) and unselected
-	 * dangling ends need no separate coverage. Swing-free so it is
-	 * unit-testable headless (the {@link #startWireGesture} precedent);
-	 * the caller owns submission and repaint.
+	 * selection to the op plan that expresses it. Per affected wire net,
+	 * one {@link RemoveWire} of the whole net followed immediately by
+	 * one {@link AddWire#survivors} per surviving connected component -
+	 * a selection that clips a net travels as remove-whole-net plus
+	 * re-add-survivors, so a wholly covered net contributes just its
+	 * RemoveWire. The per-net groups arrive in stable-id order of their
+	 * RemoveWire address (each addressed by its lowest-id end, each
+	 * component ordered by its lowest end stable id), then one
+	 * {@link RemoveElements} over the then-unwired elements, with jump
+	 * starts expanded to their same-name jump ends exactly as the
+	 * editor's removal cascade does. The removed wires are the selected
+	 * wires plus the wires incident to selected wire ends; an end
+	 * keeping at least one wire survives, an end keeping none follows
+	 * the same cascade the inline deletion uses, so attached ends
+	 * (which are never selectable) and unselected dangling ends need no
+	 * separate coverage. Swing-free so it is unit-testable headless
+	 * (the {@link #startWireGesture} precedent); the caller owns
+	 * submission and repaint.
 	 *
-	 * No plan (null) means the selection cannot yet be expressed in the
-	 * op vocabulary and must take the inline fallback: an affected net
-	 * only partially covered by the selection (the
-	 * RemoveWire-plus-AddWire-survivors composition is a follow-up per
-	 * docs/operation-layer.md), a subcircuit (its op kind is deferred),
-	 * in-progress wiring, or anything uneditable in the cascade (the
-	 * caller's guard already dialogs on uneditable selections).
+	 * No plan (null) means the selection cannot be expressed in the op
+	 * vocabulary and must take the inline fallback: a subcircuit (its
+	 * op kind is deferred), in-progress wiring, or anything uneditable
+	 * in the cascade (the caller's guard already dialogs on uneditable
+	 * selections).
 	 *
 	 * @param circuit The circuit being edited.
 	 * @param selected The current selection; not modified.
@@ -914,11 +920,14 @@ public abstract class SimpleEditor extends JPanel {
 			return null;
 		}
 
-		// every affected net must be wholly covered and removable, and
-		// each becomes one RemoveWire addressed by its lowest-id end
-		List<RemoveWire> wireOps = new ArrayList<RemoveWire>(nets.size());
+		// each affected net travels as RemoveWire of the whole net
+		// (addressed by its lowest-id end) plus, when the selection only
+		// clips it, one AddWire per surviving connected component
+		List<List<CircuitOp>> netGroups =
+				new ArrayList<List<CircuitOp>>(nets.size());
 		for (WireNet net : nets) {
 			WireEnd anchor = null;
+			Set<Wire> survivors = new java.util.LinkedHashSet<Wire>();
 			for (WireEnd end : net.getAllEnds()) {
 				if (end.isUneditable())
 					return null;
@@ -930,8 +939,7 @@ public abstract class SimpleEditor extends JPanel {
 				for (Wire wire : end.getWires()) {
 					if (wire.isUneditable())
 						return null;
-					if (!group.contains(wire))
-						return null;
+					survivors.add(wire);
 				}
 				if (anchor == null ||
 						end.getStableId().compareTo(anchor.getStableId()) < 0)
@@ -939,9 +947,58 @@ public abstract class SimpleEditor extends JPanel {
 			}
 			if (anchor == null)
 				return null;
-			wireOps.add(new RemoveWire(anchor.getStableId()));
+
+			// removed wires: the selected ones plus every wire incident
+			// to a selected wire end
+			for (Element el : group) {
+				if (el instanceof Wire wire)
+					survivors.remove(wire);
+				else if (el instanceof WireEnd end)
+					survivors.removeAll(end.getWires());
+			}
+
+			List<CircuitOp> netOps = new ArrayList<CircuitOp>();
+			netOps.add(new RemoveWire(anchor.getStableId()));
+			if (!survivors.isEmpty()) {
+
+				// partition the survivor graph into its connected
+				// components, seeded in stable-id order so the plan is
+				// deterministic; attachments to group elements are
+				// dropped (they leave in the RemoveElements below)
+				List<WireEnd> survivorEnds = new ArrayList<WireEnd>();
+				for (WireEnd end : net.getAllEnds()) {
+					for (Wire wire : end.getWires()) {
+						if (survivors.contains(wire)) {
+							survivorEnds.add(end);
+							break;
+						}
+					}
+				}
+				survivorEnds.sort(
+						java.util.Comparator.comparing(Element::getStableId));
+				Set<WireEnd> seen = new HashSet<WireEnd>();
+				for (WireEnd start : survivorEnds) {
+					if (!seen.add(start))
+						continue;
+					List<WireEnd> component = new ArrayList<WireEnd>();
+					component.add(start);
+					for (int at = 0; at < component.size(); at += 1) {
+						for (Wire wire : component.get(at).getWires()) {
+							if (!survivors.contains(wire))
+								continue;
+							WireEnd other =
+									wire.getOtherEnd(component.get(at));
+							if (seen.add(other))
+								component.add(other);
+						}
+					}
+					netOps.add(AddWire.survivors(component,survivors,group));
+				}
+			}
+			netGroups.add(netOps);
 		}
-		wireOps.sort(java.util.Comparator.comparing(RemoveWire::id));
+		netGroups.sort(java.util.Comparator.comparing(
+				ops -> ((RemoveWire) ops.get(0)).id()));
 
 		// the then-unwired elements travel as one RemoveElements
 		List<ElementId> ids = new ArrayList<ElementId>();
@@ -951,7 +1008,9 @@ public abstract class SimpleEditor extends JPanel {
 		}
 		java.util.Collections.sort(ids);
 
-		List<CircuitOp> plan = new ArrayList<CircuitOp>(wireOps);
+		List<CircuitOp> plan = new ArrayList<CircuitOp>();
+		for (List<CircuitOp> netOps : netGroups)
+			plan.addAll(netOps);
 		if (!ids.isEmpty())
 			plan.add(new RemoveElements(ids));
 		return plan.isEmpty() ? null : plan;
@@ -4728,11 +4787,13 @@ public abstract class SimpleEditor extends JPanel {
 					 *
 					 * The delete gesture is migrated behind the OpSink
 					 * seam (issue #167): when the selection maps to an
-					 * op plan it is submitted as one batch (one undo
-					 * snapshot); selections the vocabulary cannot yet
-					 * express - partially selected nets, subcircuits -
-					 * fall back to the inline removal below, still under
-					 * snapshot undo.
+					 * op plan - including clipped nets, which travel as
+					 * RemoveWire of the whole net plus AddWire per
+					 * surviving component - it is submitted as one
+					 * batch (one undo snapshot); the few selections the
+					 * vocabulary cannot yet express - subcircuits,
+					 * in-progress wiring - fall back to the inline
+					 * removal below, still under snapshot undo.
 					 */
 					private void remove() {
 
@@ -4753,8 +4814,8 @@ public abstract class SimpleEditor extends JPanel {
 							return;
 						}
 
-						// the inline fallback (partial nets et al.):
-						// remove each element
+						// the inline fallback (subcircuits, in-progress
+						// wiring): remove each element
 						for (Element el : selected) {
 							el.remove(circuit); // elements remove themselves
 						}

--- a/test/jls/collab/op/CircuitOpTest.java
+++ b/test/jls/collab/op/CircuitOpTest.java
@@ -18,6 +18,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -1122,6 +1123,81 @@ class CircuitOpTest {
 										.apply(unwired, graphics()));
 		assertEquals(unwiredBefore, save(unwired),
 				"a rejected wire add must not change the circuit");
+	}
+
+	/** The wire end with the given stable id. */
+	private static WireEnd endBySid(Circuit circuit, String sid) {
+		return (WireEnd) find(circuit, el -> el instanceof WireEnd
+				&& el.getStableId().toString().equals(sid));
+	}
+
+	/** The wire between the two ends with the given stable ids. */
+	private static Wire wireBetween(Circuit circuit, String sidA,
+			String sidB) {
+		WireEnd a = endBySid(circuit, sidA);
+		WireEnd b = endBySid(circuit, sidB);
+		for (Wire wire : a.getWires()) {
+			if (wire.getOtherEnd(a) == b) {
+				return wire;
+			}
+		}
+		throw new AssertionError(
+				"fixture lacks a wire " + sidA + "-" + sidB);
+	}
+
+	/**
+	 * The survivor factory (issue #167, the delete gesture's clipped-net
+	 * composition) rejects arguments that do not describe one nonempty
+	 * surviving component - planner bugs, hence unchecked, unlike the
+	 * OpRejected validation the produced op still runs at apply time.
+	 */
+	@Test
+	void survivorFactoryRejectsMalformedComponents() throws Exception {
+		Circuit circuit = loadText(fanOutText());
+		WireEnd we1 = endBySid(circuit, "we:1");
+		WireEnd we2 = endBySid(circuit, "we:2");
+		WireEnd we3 = endBySid(circuit, "we:3");
+		Wire probed = wireBetween(circuit, "we:1", "we:2");
+		assertThrows(IllegalArgumentException.class,
+				() -> AddWire.survivors(List.of(), Set.of(probed),
+						Set.of()),
+				"an empty end set must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> AddWire.survivors(List.of(we1, we2), Set.of(),
+						Set.of()),
+				"an empty kept set must be rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> AddWire.survivors(List.of(we1), Set.of(probed),
+						Set.of()),
+				"a kept wire leading outside the component must be "
+						+ "rejected");
+		assertThrows(IllegalArgumentException.class,
+				() -> AddWire.survivors(List.of(we1, we2, we3),
+						Set.of(probed), Set.of()),
+				"an end keeping no wire must be rejected");
+	}
+
+	/**
+	 * A survivors-produced op is ordinary op vocabulary: it serializes
+	 * through the save-format idiom and round-trips byte-identically
+	 * through the strict reader (P3 for the factory's output).
+	 */
+	@Test
+	void survivorsOpSerializationRoundTrips() throws Exception {
+		Circuit circuit = loadText(fanOutText());
+		WireEnd we1 = endBySid(circuit, "we:1");
+		WireEnd we2 = endBySid(circuit, "we:2");
+		Wire probed = wireBetween(circuit, "we:1", "we:2");
+		AddWire op = AddWire.survivors(List.of(we1, we2),
+				Set.of(probed), Set.of());
+		assertEquals(2, op.attach().size(),
+				"both surviving anchors must travel");
+		String text = serialize(op);
+		CircuitOp parsed = CircuitOpReader.read(new Scanner(text));
+		assertEquals(op, parsed,
+				"parsed op must equal the one that was saved");
+		assertEquals(text, serialize(parsed),
+				"save -> read -> save must be byte-identical");
 	}
 
 	@Test

--- a/test/jls/edit/DeleteGestureTest.java
+++ b/test/jls/edit/DeleteGestureTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import jls.Circuit;
 import jls.JLSInfo;
+import jls.collab.op.AddWire;
 import jls.collab.op.CircuitOp;
 import jls.collab.op.OpRejected;
 import jls.collab.op.OpSink;
@@ -27,7 +28,9 @@ import jls.collab.op.RemoveWire;
 import jls.elem.Element;
 import jls.elem.JumpStart;
 import jls.elem.Pin;
+import jls.elem.SubCircuit;
 import jls.elem.Wire;
+import jls.elem.WireEnd;
 
 /**
  * The delete-selection gesture's migration behind the OpSink seam
@@ -39,11 +42,12 @@ import jls.elem.Wire;
  * <ul>
  * <li>P1 - the op-plan path produces the same canonical bytes (#166)
  * as the inline {@code el.remove(circuit)} loop it replaces, for
- * unwired selections, fully-wired selections, and the jump-start
- * cascade;</li>
- * <li>fallback - a partially selected net has no plan, so the gesture
- * takes the inline path unchanged (the RemoveWire-plus-AddWire
- * composition for clipped nets is a follow-up);</li>
+ * unwired selections, fully-wired selections, the jump-start cascade,
+ * and - since the RemoveWire-plus-AddWire-survivors composition - for
+ * selections that only clip a net, on constructed and on
+ * save/load-restored circuits alike;</li>
+ * <li>fallback - only subcircuits, in-progress wiring, and uneditable
+ * cascades still have no plan and take the inline path unchanged;</li>
  * <li>undo granularity - a plan submitted through a batch
  * {@link OpSink#submitAll} records exactly one markChanged per
  * gesture, however many ops the plan holds.</li>
@@ -90,6 +94,88 @@ class DeleteGestureTest {
 				+ " String orient \"LEFT\"\nEND\nENDCIRCUIT\n";
 	}
 
+	/**
+	 * A three-segment chain between an input pin and an output pin:
+	 * pin:1 - we:1 - we:2 - we:3 - we:4 - pin:2. With {@code triState},
+	 * the driving pin and the whole net are tri-state.
+	 */
+	private static String chainText(boolean triState) {
+		String tri = triState ? " int tristate 1\n" : "";
+		return "CIRCUIT chain\n"
+				+ "ELEMENT InputPin\n" + tri
+				+ " int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 600\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n" + tri
+				+ " String put \"output\"\n ref attach 0\n ref wire 3\n"
+				+ "END\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n" + tri
+				+ " ref wire 2\n ref wire 4\nEND\n"
+				+ "ELEMENT WireEnd\n int id 4\n int x 420\n int y 120\n"
+				+ " String sid \"we:3\"\n" + tri
+				+ " ref wire 3\n ref wire 5\nEND\n"
+				+ "ELEMENT WireEnd\n int id 5\n int x 540\n int y 120\n"
+				+ " String sid \"we:4\"\n" + tri
+				+ " String put \"input\"\n ref attach 1\n ref wire 4\n"
+				+ "END\nENDCIRCUIT\n";
+	}
+
+	/**
+	 * A three-end net: an attached driving end that fans out to an
+	 * attached end (over a probed wire) and to a dangling end (the
+	 * CircuitOpTest fixture).
+	 */
+	private static String fanOutText() {
+		return "CIRCUIT fan\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n String put \"output\"\n"
+				+ " ref attach 0\n ref wire 3\n probe 3 \"tap\"\n"
+				+ " ref wire 4\nEND\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n String put \"input\"\n"
+				+ " ref attach 1\n ref wire 2\n probe 2 \"tap\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 4\n int x 180\n int y 240\n"
+				+ " String sid \"we:3\"\n ref wire 2\nEND\n"
+				+ "ENDCIRCUIT\n";
+	}
+
+	/**
+	 * A jump start wired to a one-segment dangling net, plus its
+	 * same-name unwired jump end.
+	 */
+	private static String wiredJumpText() {
+		return "CIRCUIT jumpnet\n"
+				+ "ELEMENT JumpStart\n int id 0\n int x 180\n int y 120\n"
+				+ " String sid \"js:1\"\n String name \"js\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orientation \"LEFT\"\nEND\n"
+				+ "ELEMENT JumpEnd\n int id 1\n int x 420\n int y 240\n"
+				+ " String sid \"je:2\"\n String name \"js\"\n"
+				+ " int bits 1\n String orientation \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n"
+				+ " String put \"input\"\n ref attach 0\n ref wire 3\n"
+				+ "END\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n ref wire 2\nEND\n"
+				+ "ENDCIRCUIT\n";
+	}
+
 	/** A jump start and its same-name jump end, both unwired. */
 	private static String jumpPairText() {
 		return "CIRCUIT jumps\n"
@@ -123,6 +209,20 @@ class DeleteGestureTest {
 		return circuit;
 	}
 
+	/**
+	 * A circuit restored through a save/load round trip (issue #167
+	 * section 10: ops validated on a live circuit may behave
+	 * differently on a restored object graph).
+	 */
+	private static Circuit restored(Circuit circuit) throws Exception {
+		Circuit copy = new Circuit("");
+		assertTrue(copy.load(new Scanner(save(circuit))),
+				() -> "restore load failed: " + JLSInfo.loadError);
+		assertTrue(copy.finishLoad(SwingTextMetrics.of(graphics())),
+				() -> "restore finishLoad failed: " + JLSInfo.loadError);
+		return copy;
+	}
+
 	private static String save(Circuit circuit) {
 		StringWriter out = new StringWriter();
 		try (PrintWriter writer = new PrintWriter(out)) {
@@ -149,6 +249,40 @@ class DeleteGestureTest {
 		return selected;
 	}
 
+	/** The wire end with the given stable id. */
+	private static WireEnd endBySid(Circuit circuit, String sid) {
+		for (Element el : circuit.getElements()) {
+			if (el instanceof WireEnd end
+					&& end.getStableId().toString().equals(sid)) {
+				return end;
+			}
+		}
+		throw new AssertionError("fixture lacks wire end " + sid);
+	}
+
+	/** The wire between the two ends with the given stable ids. */
+	private static Wire wireBetween(Circuit circuit, String sidA,
+			String sidB) {
+		WireEnd a = endBySid(circuit, sidA);
+		WireEnd b = endBySid(circuit, sidB);
+		for (Wire wire : a.getWires()) {
+			if (wire.getOtherEnd(a) == b) {
+				return wire;
+			}
+		}
+		throw new AssertionError(
+				"fixture lacks a wire " + sidA + "-" + sidB);
+	}
+
+	/** A mutable selection set over the given elements. */
+	private static Set<Element> setOf(Element... elements) {
+		Set<Element> selected = new HashSet<Element>();
+		for (Element el : elements) {
+			selected.add(el);
+		}
+		return selected;
+	}
+
 	/** Apply a plan the way the editor's opSink batch does. */
 	private static void apply(Circuit circuit, List<CircuitOp> plan)
 			throws Exception {
@@ -162,6 +296,39 @@ class DeleteGestureTest {
 			Set<Element> selected) {
 		for (Element el : selected) {
 			el.remove(circuit);
+		}
+	}
+
+	/** Picks the same selection out of independently loaded circuits. */
+	private interface Selector {
+		Set<Element> select(Circuit circuit);
+	}
+
+	/**
+	 * P1 harness: the plan of the given shape, applied, byte-matches
+	 * the inline removal of the same selection - on the constructed
+	 * circuit and on a save/load-restored one (issue #167 section 10).
+	 */
+	private static void assertPlanParity(String text, Selector selector,
+			int expectedOps) throws Exception {
+		for (boolean restore : new boolean[] { false, true }) {
+			Circuit viaPlan = loadText(text);
+			Circuit inline = loadText(text);
+			if (restore) {
+				viaPlan = restored(viaPlan);
+				inline = restored(inline);
+			}
+			List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(
+					viaPlan, selector.select(viaPlan));
+			assertTrue(plan != null, "the selection must have a plan");
+			assertEquals(expectedOps, plan.size(),
+					"unexpected plan shape");
+			apply(viaPlan, plan);
+			removeInline(inline, selector.select(inline));
+			assertEquals(save(inline), save(viaPlan),
+					(restore ? "restored" : "constructed")
+							+ ": plan and inline delete must produce "
+							+ "identical bytes");
 		}
 	}
 
@@ -264,24 +431,218 @@ class DeleteGestureTest {
 	}
 
 	// ------------------------------------------------------------------
-	// fallback: selections the vocabulary cannot express yet
+	// P1, clipped nets: RemoveWire + AddWire-survivors composition
 	// ------------------------------------------------------------------
 
 	/**
-	 * A wired element selected without its net leaves the net partially
-	 * covered: no plan, so the gesture takes the inline fallback (the
-	 * clipped-net composition is a follow-up per
-	 * docs/operation-layer.md).
+	 * Deleting the middle segment of a three-segment chain splits the
+	 * net in two: the plan is RemoveWire of the whole net followed by
+	 * two survivor AddWires, ordered by each component's lowest end
+	 * stable id, and byte-matches the inline segment delete.
 	 */
 	@Test
-	void partiallySelectedNetHasNoPlan() throws Exception {
-		Circuit circuit = loadText(wiredPairText());
+	void middleSegmentDeletePlansTwoSurvivorAddWires() throws Exception {
+		Circuit circuit = loadText(chainText(false));
 		String before = save(circuit);
-		assertNull(SimpleEditor.deleteSelectionPlan(circuit,
-				select(circuit, el -> el instanceof Pin)),
-				"a partially covered net must have no plan");
+		List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(circuit,
+				setOf(wireBetween(circuit, "we:2", "we:3")));
+		assertTrue(plan != null, "a clipped net must now have a plan");
+		assertEquals(3, plan.size(),
+				"RemoveWire plus two survivor AddWires expected");
+		assertTrue(plan.get(0) instanceof RemoveWire,
+				"the whole-net removal must come first");
+		AddWire first = (AddWire) plan.get(1);
+		AddWire second = (AddWire) plan.get(2);
+		assertTrue(first.blocks().get(0).contains("\"we:1\""),
+				"the we:1/we:2 component must come first (lowest end id)");
+		assertTrue(second.blocks().get(0).contains("\"we:3\""),
+				"the we:3/we:4 component must come second");
 		assertEquals(before, save(circuit),
 				"planning must never mutate the circuit");
+		assertPlanParity(chainText(false),
+				c -> setOf(wireBetween(c, "we:2", "we:3")), 3);
+	}
+
+	/**
+	 * Deleting a leaf segment cascades like the inline path: the end
+	 * that kept no wire vanishes and detaches from its pin, and the one
+	 * surviving component re-attaches only the surviving anchor.
+	 */
+	@Test
+	void leafSegmentDeleteCascadesAndDetaches() throws Exception {
+		Circuit circuit = loadText(chainText(false));
+		List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(circuit,
+				setOf(wireBetween(circuit, "we:1", "we:2")));
+		assertTrue(plan != null, "a clipped net must now have a plan");
+		assertEquals(2, plan.size(),
+				"RemoveWire plus one survivor AddWire expected");
+		AddWire survivor = (AddWire) plan.get(1);
+		assertEquals(1, survivor.attach().size(),
+				"only the surviving pin may anchor the survivor");
+		assertEquals("pin:2", survivor.attach().get(0).toString(),
+				"the survivor must re-attach the un-deleted pin only");
+		assertEquals(3, survivor.blocks().size(),
+				"the we:2/we:3/we:4 component must survive whole");
+		assertPlanParity(chainText(false),
+				c -> setOf(wireBetween(c, "we:1", "we:2")), 2);
+	}
+
+	/**
+	 * Tri-state is recomputed per surviving component, mirroring
+	 * WireNet.makeNet: deleting the driver's side leaves a survivor
+	 * whose blocks carry no tri-state flag (and whose TriProp sinks the
+	 * inline path clears stay cleared), while deleting the far side
+	 * keeps the driver and with it the flag.
+	 */
+	@Test
+	void triStateFollowsTheSurvivingDriver() throws Exception {
+		// driver-side delete: the survivor is no longer tri-state
+		Circuit lost = loadText(chainText(true));
+		List<CircuitOp> lostPlan = SimpleEditor.deleteSelectionPlan(lost,
+				setOf(wireBetween(lost, "we:1", "we:2")));
+		assertTrue(lostPlan != null && lostPlan.size() == 2,
+				"RemoveWire plus one survivor AddWire expected");
+		for (String block : ((AddWire) lostPlan.get(1)).blocks()) {
+			assertTrue(!block.contains("tristate"),
+					"a survivor without its driver must not be tri-state");
+		}
+		assertPlanParity(chainText(true),
+				c -> setOf(wireBetween(c, "we:1", "we:2")), 2);
+
+		// far-side delete: the driver survives and so does the flag
+		Circuit kept = loadText(chainText(true));
+		List<CircuitOp> keptPlan = SimpleEditor.deleteSelectionPlan(kept,
+				setOf(wireBetween(kept, "we:3", "we:4")));
+		assertTrue(keptPlan != null && keptPlan.size() == 2,
+				"RemoveWire plus one survivor AddWire expected");
+		for (String block : ((AddWire) keptPlan.get(1)).blocks()) {
+			assertTrue(block.contains(" int tristate 1\n"),
+					"a survivor keeping its driver must stay tri-state");
+		}
+		assertPlanParity(chainText(true),
+				c -> setOf(wireBetween(c, "we:3", "we:4")), 2);
+	}
+
+	/**
+	 * A wired element deleted without its net - the case that used to
+	 * have no plan and fall back inline - now plans to RemoveWire of
+	 * the whole net, an AddWire re-adding it with the attachment to the
+	 * deleted element dropped, and the RemoveElements; the composition
+	 * byte-matches the inline detach.
+	 */
+	@Test
+	void wiredElementWithoutItsNetPlansToDetachComposition()
+			throws Exception {
+		Circuit circuit = loadText(wiredPairText());
+		String before = save(circuit);
+		List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(circuit,
+				select(circuit, el -> el instanceof Pin
+						&& "A".equals(el.getName())));
+		assertTrue(plan != null,
+				"a wired element without its net must now have a plan");
+		assertEquals(3, plan.size(),
+				"RemoveWire, survivor AddWire, RemoveElements expected");
+		assertTrue(plan.get(0) instanceof RemoveWire,
+				"the whole-net removal must come first");
+		AddWire survivor = (AddWire) plan.get(1);
+		assertEquals(List.of("pin:2"),
+				survivor.attach().stream().map(Object::toString).toList(),
+				"the deleted element's anchor must be dropped");
+		assertTrue(!survivor.blocks().get(0).contains(" String put "),
+				"the end attached to the deleted element must arrive "
+						+ "detached");
+		assertTrue(plan.get(2) instanceof RemoveElements,
+				"the element removal must come last");
+		assertEquals(before, save(circuit),
+				"planning must never mutate the circuit");
+		assertPlanParity(wiredPairText(),
+				c -> select(c, el -> el instanceof Pin
+						&& "A".equals(el.getName())), 3);
+	}
+
+	/**
+	 * Probes follow their wires: a probe on a removed wire disappears
+	 * with it, a probe on a kept wire travels in the survivor's blocks.
+	 */
+	@Test
+	void probesFollowTheirWires() throws Exception {
+		// the probed wire is removed: no probe in the survivor
+		Circuit dropped = loadText(fanOutText());
+		List<CircuitOp> droppedPlan = SimpleEditor.deleteSelectionPlan(
+				dropped, setOf(wireBetween(dropped, "we:1", "we:2")));
+		assertTrue(droppedPlan != null && droppedPlan.size() == 2,
+				"RemoveWire plus one survivor AddWire expected");
+		for (String block : ((AddWire) droppedPlan.get(1)).blocks()) {
+			assertTrue(!block.contains(" probe "),
+					"a probe on a removed wire must not survive");
+		}
+		assertPlanParity(fanOutText(),
+				c -> setOf(wireBetween(c, "we:1", "we:2")), 2);
+
+		// the unprobed wire is removed: the kept wire keeps its probe
+		Circuit kept = loadText(fanOutText());
+		List<CircuitOp> keptPlan = SimpleEditor.deleteSelectionPlan(kept,
+				setOf(wireBetween(kept, "we:1", "we:3")));
+		assertTrue(keptPlan != null && keptPlan.size() == 2,
+				"RemoveWire plus one survivor AddWire expected");
+		assertTrue(((AddWire) keptPlan.get(1)).blocks().get(0)
+				.contains(" probe 3 \"tap\"\n"),
+				"a probe on a kept wire must travel with it");
+		assertPlanParity(fanOutText(),
+				c -> setOf(wireBetween(c, "we:1", "we:3")), 2);
+	}
+
+	/**
+	 * The jump-start expansion composes with the survivor path: the
+	 * jump start leaves with its jump end while its clipped net is
+	 * re-added detached, byte-matching the inline cascade.
+	 */
+	@Test
+	void jumpStartExpansionComposesWithAPartialNet() throws Exception {
+		Circuit circuit = loadText(wiredJumpText());
+		List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(circuit,
+				select(circuit, el -> el instanceof JumpStart));
+		assertTrue(plan != null,
+				"a wired jump start must now have a plan");
+		assertEquals(3, plan.size(),
+				"RemoveWire, survivor AddWire, RemoveElements expected");
+		AddWire survivor = (AddWire) plan.get(1);
+		assertTrue(survivor.attach().isEmpty(),
+				"the survivor net must arrive dangling");
+		assertEquals(2, ((RemoveElements) plan.get(2)).ids().size(),
+				"the plan must carry the jump start and its jump end");
+		assertPlanParity(wiredJumpText(),
+				c -> select(c, el -> el instanceof JumpStart), 3);
+	}
+
+	// ------------------------------------------------------------------
+	// fallback: selections the vocabulary cannot express
+	// ------------------------------------------------------------------
+
+	/**
+	 * A subcircuit still has no plan - its op kind is deferred - so the
+	 * gesture takes the inline fallback.
+	 */
+	@Test
+	void subCircuitSelectionHasNoPlan() throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		SubCircuit sub = new SubCircuit(circuit);
+		circuit.addElement(sub);
+		assertNull(SimpleEditor.deleteSelectionPlan(circuit, setOf(sub)),
+				"a subcircuit selection must have no plan");
+	}
+
+	/**
+	 * In-progress wiring (the startwire end, no wires yet) still has no
+	 * plan; the inline path owns gesture-local cleanup.
+	 */
+	@Test
+	void inProgressWiringHasNoPlan() throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		Set<Element> selected = new HashSet<Element>();
+		SimpleEditor.startWireGesture(circuit, selected, 240, 240);
+		assertNull(SimpleEditor.deleteSelectionPlan(circuit, selected),
+				"in-progress wiring must have no plan");
 	}
 
 	/**
@@ -367,6 +728,25 @@ class DeleteGestureTest {
 		sink.submitAll(plan);
 		assertEquals(2, sink.applied, "both ops must apply");
 		assertEquals(List.of(2), sink.marks,
+				"one markChanged, after all ops, per gesture");
+	}
+
+	/**
+	 * The clipped-net composition batches the same way: however many
+	 * survivor AddWires the plan holds, one gesture records exactly one
+	 * markChanged.
+	 */
+	@Test
+	void partialNetPlanBatchesAsOneGesture() throws Exception {
+		Circuit circuit = loadText(chainText(false));
+		List<CircuitOp> plan = SimpleEditor.deleteSelectionPlan(circuit,
+				setOf(wireBetween(circuit, "we:2", "we:3")));
+		assertTrue(plan != null && plan.size() == 3,
+				"the middle-segment delete must plan to three ops");
+		BatchSink sink = new BatchSink(circuit);
+		sink.submitAll(plan);
+		assertEquals(3, sink.applied, "all three ops must apply");
+		assertEquals(List.of(3), sink.marks,
 				"one markChanged, after all ops, per gesture");
 	}
 } // end of DeleteGestureTest class


### PR DESCRIPTION
## Summary

Removes `deleteSelectionPlan`'s partial-net inline fallback (#167): a selection that clips a wire net — a middle or leaf segment of a larger net, or a wired element deleted without its wiring — now travels through the operation layer as `RemoveWire` of the whole net plus one `AddWire` per surviving connected component. Only subcircuits, in-progress wiring, and uneditable cascades still take the inline path.

## What / why

- **`AddWire.survivors(ends, keptWires, removedAnchors)`** (new additive static factory, record components untouched — #224/OpSink surface undisturbed): delegates to package-private **`NetBlocks.toSurvivorAddWire`**, which serializes one surviving component in `WireEnd.save`'s exact byte format filtered to the surviving subgraph — only kept wires (and their probes) referenced, attach lines dropped for ends whose element leaves in the gesture's `RemoveElements`, and the tri-state flag recomputed per component exactly the way `WireNet.makeNet` does (tri-state iff a surviving attachment drives from a tri-state `Output`). Unlike `toAddWire`, it computes the op's local numbering in side maps and never writes element IDs, so the save-time IDs HDL export consumes (#59 contract) are provably undisturbed; `toAddWire`'s restore-in-finally is untouched.
- **`SimpleEditor.deleteSelectionPlan`** (edits confined to the delete-plan region, its javadoc, one import, and the `remove()` caller comments): per affected net, `RemoveWire` of the whole net plus, when the selection only clips it, one `AddWire.survivors` per surviving component (BFS over the survivor wire set, seeded in stable-id order; per-net groups sorted by RemoveWire address), then `RemoveElements` — still submitted as one `OpSink.submitAll` batch, so a clipped-net delete stays exactly one undo snapshot.
- CHANGELOG + `docs/operation-layer.md` updated (mutation-site inventory rows for the two delete gestures now read **migrated**; "What lands next" item removed). Union-conflict-friendly per cycle conventions.

## Verification

Independently re-run from scratch in the worktree (nix develop, JDK 25 / Maven 3.9.11):

- `mvn verify`: **BUILD SUCCESS** — surefire aggregate `Tests run: 1202, Failures: 0, Errors: 0, Skipped: 5`, plus the separate display-tagged group `Tests run: 92, Skipped: 92` (headless, expected). Jacoco ratchet, SpotBugs, and Spotless checks all passed within the verify; no jacoco floor changes, no NullAway suppressions, no spotbugs-exclude entries.
- `DeleteGestureTest`: 16/16 — clipped-net byte parity (plan applied vs inline removal of the same selection) on constructed **and** save/load-restored circuits; middle-segment split into two survivor AddWires with deterministic ordering; leaf-segment cascade + pin detach; tri-state recompute both directions (driver removed → flag and TriProp clearing match inline; driver kept → flag survives); probes dropped with removed wires / traveling with kept wires; jump-start expansion composed with a clipped net; one `markChanged` per gesture however many ops the plan holds; subcircuit and in-progress-wiring fallbacks still plan to null.
- `CircuitOpTest`: 41/41 — survivor factory rejects malformed components (empty ends, empty kept set, kept wire leading outside the component, end keeping no wire) with `IllegalArgumentException` (planner bugs, pre-`OpRejected`); a survivors-produced op round-trips byte-identically through the strict op reader.

Adversarial review confirmed the survivor serializer matches `WireEnd.save` byte-for-byte for every planner-reachable end (fixed/trpos/width/height omissions are safe: uneditable ends bail to inline, WireEnds are never traced, and WireEnd sizes are recomputed on load), and its local numbering satisfies `NetBlocks.parseEnd`'s strict position checks.

## Caveats

- Survivor per-end wire-list ordering reproduces the loader's algorithm on canonically ordered blocks: byte-identical to the inline deletion for canonical/loaded circuits (both parity variants tested). This matches `AddWire`'s existing "indistinguishable from a loaded net" contract.
- PIT is a separate opt-in profile (`-Ppitest`), not part of `mvn verify`, so mutation coverage was not re-measured here; `jls.collab.op` is in PIT scope and #159 measures final thresholds after this merges (this PR must land first per the cycle plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GW9SQJcVqt859o6XWEb7aW