### PR TITLE
ci: multi-platform CI parity + promote/rename GUI boot lanes to hard gates — advisory macOS lane, Windows+macOS HDL toolchain arming, Windows display first-light + JDK-26 leg, PATHEXT locator fix, macOS glyph fix (#265, #111, #101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build (JDK ${{ matrix.java }})
+    name: Build (Linux, JDK ${{ matrix.java }})
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
@@ -105,18 +105,150 @@ jobs:
               print(f"| {c.get('type')} | {cov} | {mis} | {pct:.1f}% |")
           EOF
 
-  # Windows test lane (issue #111): all three Windows-only failures
-  # (CRLF round-trip, held file handles blocking @TempDir cleanup,
-  # golden-file CRLF checkout) shipped because no Windows leg ran the
-  # suite. Runs headless — the display-tagged suite and the HDL
-  # simulator suites skip themselves — and skips the JaCoCo ratchet,
-  # whose floors are calibrated against the fuller Linux run.
-  # Advisory while it stabilizes (same promotion rule as gui-wayland:
-  # required once 20 consecutive runs show at most one failure).
+  # Windows test lane (issue #111): all three original Windows-only
+  # failures (CRLF round-trip, held file handles blocking @TempDir
+  # cleanup, golden-file CRLF checkout) shipped because no Windows leg
+  # ran the suite. The parity gap is now closing in stages. The HDL
+  # simulator suites are armed via the oss-cad-suite bundle (Stage W2,
+  # step below). The @Tag("display") suite — which self-skips under
+  # java.awt.headless via assumeFalse(GraphicsEnvironment.isHeadless()) —
+  # runs FIRST-LIGHT here on the runner's real interactive window station
+  # (Stage W3: the mvn step passes -Djls.test.headless=false; unlike
+  # Linux, Windows needs no xvfb equivalent). This is advisory first
+  # light: some display tests carry Xvfb/WM-less timing and
+  # pointer-exclusivity workarounds (the Robot-driven gesture/keyboard/
+  # popup flows), so substrate-specific failures may surface — that is
+  # the point of an advisory lane, and #265 Stage 2 owns the taxonomy;
+  # they are NOT pre-muted here. The JaCoCo ratchet stays skipped
+  # (Stage W4), its floors being calibrated against the fuller Linux run,
+  # until the suites converge. The JDK matrix mirrors the Linux build
+  # job: JDK 25 is the required-baseline leg — its check name
+  # `Build (Windows, JDK 25)` is byte-stable so the Stage W1 promotion
+  # can register it unchanged — and JDK 26 is the advisory
+  # forward-compatibility leg (Stage W5). Advisory while it stabilizes
+  # (same promotion rule as gui-wayland: required once 20 consecutive
+  # runs show at most one failure); the job-level continue-on-error
+  # covers BOTH matrix legs.
   windows:
-    name: Build (Windows, JDK 25)
+    name: Build (Windows, JDK ${{ matrix.java }})
     if: github.event_name != 'schedule'
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 25 (current LTS) is the required baseline; JDK 26 is the
+        # advisory forward-compatibility leg (issue #111 Stage W5),
+        # mirroring the Linux build matrix. The whole job is
+        # continue-on-error, so both legs stay advisory while the lane
+        # accrues its Stage W1 stability record.
+        java: [25, 26]
+    continue-on-error: true
+    env:
+      # ---- oss-cad-suite pin (issue #111 Stage W2) -------------------
+      # YosysHQ's oss-cad-suite bundle ships icarus-verilog, ghdl, AND
+      # yosys together in one archive; choco/MSYS2 package the three less
+      # consistently, so the bundle is what we standardize on. Pinned to
+      # the dated 2026-07-26 release. The Windows asset is a 7-Zip
+      # self-extracting .exe whose payload is an oss-cad-suite/ tree.
+      OSS_CAD_URL: https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-07-26/oss-cad-suite-windows-x64-20260726.exe
+      # Integrity model mirrors the gui-wayland JBR pin: HTTPS/TLS to
+      # github.com is the trust boundary for the download; the checksum
+      # below is fail-closed hardening on top. Unlike JBR this one is a
+      # REAL pin: GitHub's release-asset `digest` metadata publishes the
+      # SHA-256, read here via `gh api repos/YosysHQ/oss-cad-suite-build/
+      # releases/tags/2026-07-26` (asset digest field) - not invented, not
+      # a placeholder. A mismatch degrades the advisory lane (skip), it
+      # never installs an unexpected binary.
+      OSS_CAD_SHA256: df275642362cd27f1cb90a7408818b6c2ed5292c974a754074d41c9250487ecc
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      # Arm the HDL-simulator golden tests (IverilogCompileTest,
+      # GhdlCompileTest, and the yosys-armed netlist legs) on Windows by
+      # fetching the version-pinned oss-cad-suite bundle and prepending
+      # its bin/ to GITHUB_PATH (issue #111 Stage W2). The tool locator's
+      # PATHEXT/.exe fix (this PR's jls.hdl.ToolLocator) is what lets the
+      # suffixed binaries resolve. Best-effort, mirroring the gui-wayland
+      # JBR idiom: a download/checksum/extract failure emits a ::notice
+      # and skips the toolchain (exit 0), so the advisory lane degrades to
+      # today's behaviour (the HDL suites self-skip) instead of failing on
+      # a CDN hiccup.
+      - name: Arm the HDL simulator toolchain (best-effort)
+        id: hdl
+        shell: bash
+        run: |
+          set -uo pipefail
+          dest="$RUNNER_TEMP/oss-cad.exe"
+          extract="$RUNNER_TEMP/oss-cad"
+          if ! curl -fsSL --retry 3 -o "$dest" "$OSS_CAD_URL"; then
+            echo "::notice title=windows HDL toolchain skipped::could not download oss-cad-suite from $OSS_CAD_URL; HDL tests will self-skip"
+            echo "hdl=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          observed="$(sha256sum "$dest" | cut -d' ' -f1)"
+          echo "observed oss-cad-suite sha256: $observed"
+          if [[ "$observed" != "$OSS_CAD_SHA256" ]]; then
+            echo "::notice title=windows HDL toolchain skipped::oss-cad-suite sha256 mismatch (pinned $OSS_CAD_SHA256, got $observed); HDL tests will self-skip"
+            echo "hdl=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "integrity: matches maintainer-pinned OSS_CAD_SHA256"
+          # The asset is a 7-Zip SFX; 7z (present on windows-latest)
+          # unpacks its oss-cad-suite/ payload without running the stub.
+          mkdir -p "$extract"
+          if ! 7z x -y -o"$extract" "$dest" >/dev/null; then
+            echo "::notice title=windows HDL toolchain skipped::could not extract oss-cad-suite; HDL tests will self-skip"
+            echo "hdl=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bindir="$extract/oss-cad-suite/bin"
+          if [[ ! -d "$bindir" ]]; then
+            echo "::notice title=windows HDL toolchain skipped::oss-cad-suite/bin not found after extract; HDL tests will self-skip"
+            echo "hdl=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Prepend to PATH for the later mvn step, in Windows form so the
+          # JVM's PATH search sees it; the locator resolves iverilog.exe /
+          # ghdl.exe / yosys.exe via PATHEXT.
+          winbin="$(cygpath -w "$bindir" 2>/dev/null || echo "$bindir")"
+          echo "$winbin" >> "$GITHUB_PATH"
+          echo "hdl=armed" >> "$GITHUB_OUTPUT"
+
+      # -Djls.test.headless=false arms the display-tagged surefire
+      # execution (pom.xml `display-tests`) on the runner's real window
+      # station — Stage W3 first light. The strict headless main
+      # execution runs regardless; the JaCoCo ratchet stays skipped
+      # (Stage W4). Advisory: a display test whose Xvfb-tuned timing
+      # assumptions don't hold on the Windows window station may fail
+      # here — expected, and continue-on-error keeps it non-blocking.
+      - name: Build, lint, and analyze
+        shell: bash
+        run: mvn -B verify -Djacoco.skip=true -Djls.test.headless=false
+
+  # macOS test lane (issue #265): mirrors the Windows lane above to close
+  # the platform-parity gap — until now the only macos-latest job was the
+  # dmg-packaging reproducibility check, which runs no tests, leaving
+  # macOS-specific behaviour (case-insensitive default volume, window-server
+  # AWT/HeadlessException differences, BSD shasum toolchain, resource-fork
+  # noise) unverified. Runs headless — the display-tagged suite and the HDL
+  # simulator suites skip themselves — and skips the JaCoCo ratchet, whose
+  # floors are calibrated against the fuller Linux run. The JaCoCo ratchet,
+  # SpotBugs, HDL-simulator, and Agda-proof suites stay Linux-only by design.
+  # Advisory while it stabilizes (same #188/#101 promotion rule as
+  # gui-wayland/windows: required once 20 consecutive runs show at most one
+  # failure). Carries a byte-stable name: from day one so Stage 3 can register
+  # it as a required check without churn.
+  macos:
+    name: Build (macOS, JDK 25)
+    if: github.event_name != 'schedule'
+    runs-on: macos-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -128,6 +260,27 @@ jobs:
           java-version: 25
           cache: maven
 
+      # Arm the HDL-simulator golden tests (IverilogCompileTest,
+      # GhdlCompileTest, and the yosys-armed netlist legs) on macOS via
+      # Homebrew (issue #265 Stage 4). The formulae install unsuffixed
+      # binaries (iverilog, ghdl, yosys), so jls.hdl.ToolLocator finds
+      # them as-is. Best-effort, mirroring the gui-wayland JBR idiom: a
+      # brew failure emits a ::notice and skips (exit 0) so the advisory
+      # lane degrades to today's behaviour (the HDL suites self-skip)
+      # instead of failing on a transient Homebrew/network hiccup. Formula
+      # names are the plausible current ones (icarus-verilog provides
+      # iverilog); first light may adjust if a tap/name has drifted.
+      - name: Arm the HDL simulator toolchain (best-effort)
+        id: hdl
+        shell: bash
+        run: |
+          if brew install icarus-verilog ghdl yosys; then
+            echo "hdl=armed" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=macOS HDL toolchain skipped::brew install icarus-verilog ghdl yosys failed; the HDL-simulator golden tests will self-skip on this run"
+            echo "hdl=skipped" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build, lint, and analyze
         shell: bash
         run: mvn -B verify -Djacoco.skip=true
@@ -138,7 +291,7 @@ jobs:
   # proof no longer checks. ProofBridgeTest (in the build job) pins the
   # proof's modelling assumptions to the Java implementation.
   proofs:
-    name: Verify Agda proofs
+    name: Verify Agda proofs (Linux)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -154,7 +307,7 @@ jobs:
           cp -r /usr/share/agda-stdlib "$RUNNER_TEMP/agda-stdlib"
           LC_ALL=C.UTF-8 agda -i "$RUNNER_TEMP/agda-stdlib" -i proofs proofs/SpatialIndexCorrectness.agda
 
-  # First-light Wayland GUI lane (issue #101): boots the JLS GUI on
+  # GUI boot Wayland lane (issue #101): boots the JLS GUI on
   # JetBrains Runtime's experimental WLToolkit (Project Wakefield)
   # against a headless sway compositor - no X11 anywhere - and captures
   # a screenshot, the compositor tree, and JLS's stderr as artifacts.
@@ -163,16 +316,34 @@ jobs:
   # JLS-side (exit 1) or upstream JBR/sway (exit 2) per #101 section 9.
   # Runs on every event including the nightly cron (which runs ONLY this
   # job) so the #101 P3 stability record accrues daily.
-  # continue-on-error while the lane stabilizes (#101 H2/P3: it becomes
-  # a required check once 20 consecutive runs show at most one failure).
+  # HARD GATE since #101 (H2/P3 promotion rule): this lane went 20/20 green
+  # on the last twenty non-cron ci.yml runs, so a red run here now fails CI.
+  # The green record (accrued while the job was named "GUI first light
+  # (Wayland, JBR)", renamed to "GUI boot (Linux, Wayland/JBR)" at this
+  # promotion — the OS family is named so the check list reads uniformly):
+  #   push: 30233449347, 30277051630, 30305223433, 30305876276, 30306600940,
+  #         30307172627, 30307512700, 30307910186
+  #   PR:   30284055608, 30284086894, 30304849319, 30304947992, 30305419961,
+  #         30305915681, 30305947175, 30305994644, 30306632400, 30306659352,
+  #         30307205047, 30307543324
+  # The only intervening non-green events are the nightly cron (7/7 green,
+  # gui-wayland-only) and run 30226493722 (merge of #244), a whole-master
+  # `mvn package` breakage where every build/installer/GUI job failed at the
+  # shared "Build jar" step and BOTH rigs skipped (never ran) — not a lane
+  # flake, and since fixed. Promotion drops continue-on-error (the workflow
+  # half); the maintainer then registers the NEW job name below ("GUI boot
+  # (Linux, Wayland/JBR)") as a required branch-protection check (repo settings).
+  # The lane is renamed here because "first light" stops being true the
+  # moment it gates — and since required-check registration has not happened
+  # yet, the rename is free (no lockstep branch-protection edit needed).
+  # A JBR CDN outage still can't wedge the gate: the
+  # Download-JBR step emits a ::notice and sets skip=true (exit 0 → success,
+  # rig steps skip), so only a genuine GUI regression turns this red.
   gui-wayland:
-    name: GUI first light (Wayland, JBR)
+    name: GUI boot (Linux, Wayland/JBR)
     runs-on: ubuntu-latest
-    # advisory while first-light stabilizes (issue #101): runs on every event
-    # (incl. the nightly cron, which runs ONLY this job) so the P3 stability
-    # record accrues, but a failure — e.g. the unpinned JBR download failing
-    # its TOFU checksum until a maintainer pins JBR_SHA256 — never blocks
-    continue-on-error: true
+    # runs on every event including the nightly cron (which runs ONLY this
+    # job) so the P3 stability record keeps accruing daily
     env:
       # ---- JBR pin (issues #101/#105) --------------------------------
       # JetBrains Runtime 25.0.3b508.16 (tag jbr-release-25.0.3b508.16),
@@ -181,7 +352,7 @@ jobs:
       JBR_URL: https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.3-linux-x64-b508.16.tar.gz
       # Integrity model (see the "Download JetBrains Runtime" step):
       #   - HTTPS/TLS authenticates the JetBrains CDN for the download itself;
-      #     that is the trust boundary the first-light lane relies on.
+      #     that is the trust boundary the GUI boot lane relies on.
       #   - A maintainer-pinned JBR_SHA256 below is an OPTIONAL hardening: when
       #     set to a real hash it is verified fail-closed, additionally
       #     defending against a CDN compromise. To pin it, run this once on any
@@ -189,7 +360,7 @@ jobs:
       #     observed digest, so you can copy it from a green log):
       #        curl -fsSL <JBR_URL> | sha256sum
       #   - While it stays the UNVERIFIED- placeholder the lane does NOT gate on
-      #     a hash: first light (#101) runs against the TLS-fetched JBR so the
+      #     a hash: the GUI boot lane (#101) runs against the TLS-fetched JBR so the
       #     job exercises the GUI rather than blocking on an unpinned toolchain.
       #     (The Wayland work does not depend on a checksum; the checksum only
       #     hardens the toolchain download.)
@@ -236,7 +407,7 @@ jobs:
           set -euo pipefail
           dest="$RUNNER_TEMP/jbr.tar.gz"
           # Fetch over HTTPS; TLS authenticates the JetBrains CDN. A download
-          # failure skips first-light (nothing to run), it does not fail-close.
+          # failure skips the GUI boot lane (nothing to run), it does not fail-close.
           if ! curl -fsSL --retry 3 -o "$dest" "$JBR_URL"; then
             echo "::notice title=gui-wayland skipped::could not download JBR from $JBR_URL"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -253,9 +424,9 @@ jobs:
             fi
             echo "integrity: matches maintainer-pinned JBR_SHA256"
           else
-            # Unpinned: TLS is the trust boundary; run first-light rather than
-            # gate the GUI work on a hash. Pin JBR_SHA256=$observed to harden.
-            echo "::notice title=JBR unpinned::first-light runs against the TLS-fetched JBR; set JBR_SHA256=$observed (issue #101) to additionally harden against a CDN compromise"
+            # Unpinned: TLS is the trust boundary; run the GUI boot lane rather
+            # than gate the GUI work on a hash. Pin JBR_SHA256=$observed to harden.
+            echo "::notice title=JBR unpinned::the GUI boot lane runs against the TLS-fetched JBR; set JBR_SHA256=$observed (issue #101) to additionally harden against a CDN compromise"
           fi
           mkdir -p "$RUNNER_TEMP/jbr"
           tar -xzf "$dest" -C "$RUNNER_TEMP/jbr" --strip-components=1
@@ -266,7 +437,7 @@ jobs:
         if: steps.jbr.outputs.skip == 'false'
         run: mvn -B -DskipTests package
 
-      - name: Run the Wayland first-light rig
+      - name: Run the Wayland GUI boot rig
         if: steps.jbr.outputs.skip == 'false'
         run: JBR_HOME="$RUNNER_TEMP/jbr" ARTIFACTS_DIR="$RUNNER_TEMP/wayland-artifacts" scripts/wayland-rig.sh
 
@@ -274,11 +445,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wayland-first-light
+          name: wayland-gui-boot
           path: ${{ runner.temp }}/wayland-artifacts/
           if-no-files-found: ignore
 
-  # First-light X11 GUI lane: boots the REAL JLS application entry point
+  # GUI boot X11 lane: boots the REAL JLS application entry point
   # (main class jls.JLS, via the shaded jar's Main-Class) under a headless
   # Xvfb X server - no GPU, no physical display, no window manager - and
   # proves the actual app window MAPS and can be screenshotted. X11 via
@@ -296,16 +467,32 @@ jobs:
   # (that is Wayland-only) and unsets WAYLAND_DISPLAY, so jls.ToolkitPolicy
   # keeps the X11 default (no app change needed).
   #
-  # continue-on-error while the lane's stability record accrues (same
-  # promotion rule as gui-wayland/windows: required once 20 consecutive
-  # runs show at most one failure).
+  # HARD GATE since #101 (H2/P3 promotion rule): this lane went 20/20 green
+  # on the last twenty non-cron ci.yml runs, so a red run here now fails CI.
+  # The green record (accrued while the job was named "GUI first light
+  # (X11, Xvfb)", renamed to "GUI boot (Linux, X11/Xvfb)" at this promotion —
+  # the OS family is named so the check list reads uniformly):
+  #   push: 30233449347, 30277051630, 30305223433, 30305876276, 30306600940,
+  #         30307172627, 30307512700, 30307910186
+  #   PR:   30284055608, 30284086894, 30304849319, 30304947992, 30305419961,
+  #         30305915681, 30305947175, 30305994644, 30306632400, 30306659352,
+  #         30307205047, 30307543324
+  # This lane skips schedule events by design (the nightly cron runs
+  # gui-wayland alone), so it has no intervening cron gap; run 30226493722
+  # (merge of #244) was a whole-master `mvn package` breakage where every
+  # build/installer/GUI job failed at the shared "Build jar" step and BOTH
+  # rigs skipped (never ran) — not a lane flake, and since fixed. Promotion
+  # drops continue-on-error (the workflow half); the maintainer then registers
+  # the NEW job name below ("GUI boot (Linux, X11/Xvfb)") as a required
+  # branch-protection check (repo settings). Renamed here because "first
+  # light" stops being true once the lane gates, and required-check
+  # registration has not happened yet, so the rename costs nothing.
   gui-x11:
-    name: GUI first light (X11, Xvfb)
+    name: GUI boot (Linux, X11/Xvfb)
     # runs on push/PR like the other jobs; the nightly cron runs ONLY
     # gui-wayland (see the header), so this lane skips schedule events
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       # ---- P2 pixel gate --------------------------------------------
       # 0 = record the AE metric without gating. TODO(maintainer): after
@@ -340,15 +527,225 @@ jobs:
       - name: Build jar
         run: mvn -B -DskipTests package
 
-      - name: Run the X11 first-light rig
+      - name: Run the X11 GUI boot rig
         run: ARTIFACTS_DIR="$RUNNER_TEMP/x11-artifacts" scripts/x11-rig.sh
 
       - name: Upload rig artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: x11-first-light
+          name: x11-gui-boot
           path: ${{ runner.temp }}/x11-artifacts/
+          if-no-files-found: ignore
+
+  # GUI boot macOS lane (issue #265 Stage 9): boots the REAL JLS application
+  # entry point (main class jls.JLS, via the shaded jar's Main-Class) on the
+  # runner's REAL Quartz WindowServer - there is NO Xvfb/compositor to stand up
+  # (unlike the Linux lanes), so the jar boots directly - and proves the actual
+  # app window MAPS and can be screenshotted non-blank. It is the macOS analogue
+  # of gui-wayland/gui-x11 and Stage 9 of #265; the Windows analogue is the
+  # windows-gui lane below (Stage W7 of #111).
+  #
+  # DISTINCT from the @Tag("display") JUnit suite (which exercises UI classes
+  # in-process): this lane LAUNCHES THE APP as a user would (java -jar) and
+  # asserts the real window comes up. The rig maps a minimal HelloSwingControl
+  # frame first, so a failure is classified JLS-side (exit 1) or environment
+  # (exit 2). Window presence is read via System Events (osascript) and the
+  # screenshot via the built-in screencapture; a hosted-runner TCC block (Screen
+  # Recording / Accessibility withheld) shows up on the control frame too and is
+  # classified exit 2, never blamed on JLS. Non-blank proof matches the Linux
+  # idiom (unique-color count > 1) using only built-ins (screencapture + sips +
+  # a pure-stdlib python BMP reader), so it needs no ImageMagick/brew/network.
+  # See scripts/macos-rig.sh for the full contract.
+  #
+  # GENUINE FIRST LIGHT: this rig has never run on a real macOS runner - its
+  # first execution is here, and the hosted image's TCC-permission posture is
+  # unknown until then. Advisory continue-on-error while the record accrues;
+  # promotion to a required check follows the #188/#101 rule (required once 20
+  # consecutive runs show at most one failure), then drop continue-on-error and
+  # register the byte-stable name "GUI boot (macOS, WindowServer)" as a required
+  # branch-protection check with recorded run IDs (mirroring
+  # installer-reproducibility-aarch64).
+  #
+  # FIRST-LIGHT TAXONOMY (#265 Stage 2), tcc-permission: the runner's first light
+  # (run 30322375242) mapped the control window via System Events but its window
+  # capture had 0 unique colors - Screen Recording (TCC) is withheld from the
+  # non-interactive CI session. Hosted runners may NEVER grant it, so a blank
+  # control-window capture no longer exits 2 (which would be permanently red for a
+  # runner-policy reason): the rig now enters DEGRADED MODE - it warns, launches
+  # the real jar, and gates on the JLS window MAPPING via System Events (the boot
+  # proof the maintainer relies on), skipping the pixel proofs. The pixel proof
+  # stays contingent on TCC (tracked in #265 Stage 9); the window-map is the
+  # reliable per-run boot guarantee. The fail-open TCC pre-grant step below
+  # attempts the community sqlite3 workaround (SIP usually defeats it - that is
+  # why it is best-effort). exit 2 is still reserved for readiness-capture failure,
+  # a control window that never maps, and osascript denial (all break the map proof).
+  macos-gui:
+    name: GUI boot (macOS, WindowServer)
+    if: github.event_name != 'schedule'
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      # Guard the rig's exit 0/1/2 classification on every run by driving the
+      # unmodified rig against a stub toolchain - no real WindowServer or GUI
+      # needed. A regression here is caught fast and for free.
+      - name: Self-test the rig control flow
+        run: bash scripts/macos-rig-selftest.sh
+
+      # Fail-open TCC pre-grant attempt (#265 Stage 9, taxonomy tcc-permission):
+      # try to pre-authorize Screen Recording (kTCCServiceScreenCapture) for the
+      # capturing process by inserting a row into the USER TCC.db via sqlite3 - the
+      # documented community workaround for headless/CI macOS. This FREQUENTLY
+      # fails: the system TCC.db is SIP-protected (even root cannot write it) and
+      # the per-user DB may be locked or schema-shifted between macOS releases -
+      # which is exactly WHY this is fail-open (continue-on-error + a trailing
+      # `exit 0`). We attempt it, re-probe a capture for the log, and proceed
+      # either way; if Screen Recording stays withheld the rig runs in DEGRADED
+      # MODE (window-map is the boot gate). It can never turn the lane red.
+      - name: Pre-grant Screen Recording (TCC, fail-open)
+        continue-on-error: true
+        shell: bash
+        run: |
+          set +e
+          db="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+          if [ ! -f "$db" ]; then
+            echo "TCC: no per-user TCC.db at $db yet; nothing to pre-grant (rig will degrade gracefully)"
+            exit 0
+          fi
+          # Only attempt if the expected schema (an `access` table with a
+          # `service`/`client`/`auth_value` shape) is present; otherwise a schema
+          # drift would just error out. auth_value=2 == allowed; client_type 1 ==
+          # absolute path, 0 == bundle id.
+          if ! sqlite3 "$db" "SELECT name FROM sqlite_master WHERE type='table' AND name='access';" 2>/dev/null | grep -q access; then
+            echo "TCC: access table not found (schema drift or DB locked); skipping (rig will degrade gracefully)"
+            exit 0
+          fi
+          ts=$(date +%s)
+          # Try the plausible responsible clients for screencapture on a runner.
+          for client in /usr/sbin/screencapture /bin/bash /bin/zsh com.apple.screencapture; do
+            case "$client" in /*) ctype=1 ;; *) ctype=0 ;; esac
+            if sqlite3 "$db" "INSERT OR REPLACE INTO access \
+                (service,client,client_type,auth_value,auth_reason,auth_version,flags,last_modified) \
+                VALUES ('kTCCServiceScreenCapture','$client',$ctype,2,2,1,0,$ts);" 2>/dev/null; then
+              echo "TCC: inserted kTCCServiceScreenCapture grant for $client (client_type $ctype)"
+            else
+              echo "TCC: could not insert grant for $client (expected under SIP / locked DB); rig will degrade gracefully"
+            fi
+          done
+          # Informational re-probe: capture a frame and report its size. The rig
+          # itself re-tests colors and decides normal vs DEGRADED mode.
+          probe="$RUNNER_TEMP/tcc-probe.png"
+          if screencapture -x -t png "$probe" 2>/dev/null; then
+            echo "TCC probe: screencapture wrote $(wc -c < "$probe") bytes (blank-vs-real is decided in-rig)"
+          else
+            echo "TCC probe: screencapture failed (informational only)"
+          fi
+          exit 0
+
+      - name: Build jar
+        run: mvn -B -DskipTests package
+
+      - name: Run the macOS GUI boot rig
+        run: ARTIFACTS_DIR="$RUNNER_TEMP/macos-artifacts" bash scripts/macos-rig.sh
+
+      - name: Upload rig artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-gui-boot
+          path: ${{ runner.temp }}/macos-artifacts/
+          if-no-files-found: ignore
+
+  # GUI boot Windows lane (issue #111 Stage W7): boots the REAL JLS application
+  # entry point (main class jls.JLS, via the shaded jar's Main-Class) on the
+  # runner's REAL interactive window station - there is NO Xvfb/compositor to
+  # stand up (unlike the Linux lanes) - and proves the actual app window MAPS
+  # and can be screenshotted non-blank. It is the Windows analogue of
+  # gui-wayland/gui-x11 and Stage W7 of #111; the macOS analogue is the macos-gui
+  # lane above (Stage 9 of #265).
+  #
+  # DISTINCT from the @Tag("display") JUnit suite (which exercises UI classes
+  # in-process): this lane LAUNCHES THE APP as a user would (java -jar) and
+  # asserts the real window comes up. The rig (PowerShell, shell: pwsh) maps a
+  # minimal HelloSwingControl frame first, so a failure is classified JLS-side
+  # (exit 1) or environment (exit 2). Window presence is polled from Get-Process
+  # MainWindowHandle (with a MainWindowTitle fallback); the screenshot is a
+  # System.Drawing Graphics.CopyFromScreen; the non-blank gate counts distinct
+  # sampled colors in the same script. A hosted non-interactive session handing
+  # back a blank/desktop-only frame shows up on the control frame too and is
+  # exit 2, never blamed on JLS. See scripts/windows-rig.ps1 for the full
+  # contract.
+  #
+  # GENUINE FIRST LIGHT: this rig has never run on a real Windows runner - its
+  # first execution is here (PowerShell was unavailable in the authoring
+  # sandbox, so only the exit-code classification was self-tested via injected
+  # stubs). A withheld station degrades to exit 2, never a hang: every wait loop
+  # is bounded by a Stopwatch. Advisory continue-on-error while the record
+  # accrues; promotion to a required check follows the #188/#101 rule (required
+  # once 20 consecutive runs show at most one failure), then drop
+  # continue-on-error and register the byte-stable name
+  # "GUI boot (Windows, WindowStation)" as a required branch-protection check
+  # with recorded run IDs (mirroring installer-reproducibility-aarch64).
+  #
+  # FIRST-LIGHT TAXONOMY (#265 Stage 2), ps-scope/error-misclassification: the
+  # runner's first light (run 30322375242) died with "The term 'Start-JavaProcess'
+  # is not recognized" and fell through as exit 1 (the JLS-side code) - a RIG bug
+  # misreported as an app failure. Cause: the production launch delegates were
+  # .GetNewClosure() script blocks, whose dynamic-module scope cannot see the
+  # script-scope Start-JavaProcess; the selftest never caught it because its
+  # injected stubs replaced the launch path. Fixed: the launch delegates are now
+  # top-level functions passed by reference (they resolve Start-JavaProcess like
+  # the other delegates), the entry point wraps every unhandled error as exit 2
+  # (rig/environment) instead of a bare pwsh exit 1, and the selftest now
+  # AST-parses + reachability-probes the production launch path so this bug class
+  # is a red test, not a first-light surprise.
+  windows-gui:
+    name: GUI boot (Windows, WindowStation)
+    if: github.event_name != 'schedule'
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      # Guard the rig's exit 0/1/2 classification on every run by dot-sourcing
+      # the unmodified rig with -NoAutoRun and driving Invoke-GuiBootRig against
+      # injected stub delegates - no real window station or GUI needed.
+      - name: Self-test the rig control flow
+        shell: pwsh
+        run: ./scripts/windows-rig-selftest.ps1
+
+      - name: Build jar
+        shell: bash
+        run: mvn -B -DskipTests package
+
+      - name: Run the Windows GUI boot rig
+        shell: pwsh
+        env:
+          ARTIFACTS_DIR: ${{ runner.temp }}/windows-artifacts
+        run: ./scripts/windows-rig.ps1
+
+      - name: Upload rig artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-gui-boot
+          path: ${{ runner.temp }}/windows-artifacts/
           if-no-files-found: ignore
 
   # feed GitHub's dependency graph the resolved transitive tree so
@@ -388,7 +785,7 @@ jobs:
   # A mismatch fails the job and uploads both jars so diffoscope can
   # localize the offending input.
   reproducibility:
-    name: Reproducible build check
+    name: Reproducible build check (Linux)
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
@@ -565,6 +962,78 @@ jobs:
   # residual on demand). Revisit if a future jpackage exposes deterministic
   # GUID/ProductCode generation — the payload already being reproducible, that
   # lever alone would make the whole msi byte-identical.
+
+  # Windows msi build-smoke lane (#111 / #190): builds the jar and runs the SAME
+  # jpackage --type msi invocation the release/probe path uses - bash
+  # scripts/build-installer.sh, exactly as repro-installers.yml drives it on
+  # windows-latest (which preinstalls WiX; the git-bash uname reports MINGW so
+  # build-installer.sh takes its msi branch) - then asserts the .msi exists and
+  # is non-trivially sized and uploads it. No divergent flags: the msi is built
+  # by the unmodified installer script.
+  #
+  # BUILD-SMOKE ONLY - intentionally NOT reproducibility-checked. The msi's
+  # byte-level residual is jpackage's MSI relational-database streams (per-build
+  # component GUIDs / ProductCode / row ordering it exposes no control over,
+  # while the embedded cabinet payload IS byte-identical) - see
+  # docs/windows-msi-determinism.md and #190 (blocked). Byte-level determinism
+  # checking stays with the scheduled "Installer reproducibility probe" workflow
+  # (repro-installers.yml); this lane only proves the msi still BUILDS on
+  # windows-latest, catching a broken WiX/jpackage/packaging regression that the
+  # monthly probe would otherwise not surface until much later.
+  #
+  # Advisory continue-on-error while the record accrues; promotion to a required
+  # check follows the #188/#101 rule (required once 20 consecutive runs show at
+  # most one failure), then drop continue-on-error and register the byte-stable
+  # name "Windows installer build (msi)" as a required branch-protection check
+  # with recorded run IDs (mirroring installer-reproducibility-aarch64).
+  windows-installer-msi:
+    name: Windows installer build (msi)
+    if: github.event_name != 'schedule'
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      # the unmodified installer script: builds the jar (mvn package), jlinks a
+      # trimmed runtime, then the SAME jpackage --type msi invocation the release
+      # and probe paths use. WiX is preinstalled on windows-latest; python3
+      # (present) normalizes the volatile msi timestamp/GUID set as in release.
+      - name: Build the msi (same jpackage invocation as release/probe)
+        shell: bash
+        run: bash scripts/build-installer.sh
+
+      - name: Assert the msi exists and is non-trivial
+        shell: bash
+        run: |
+          set -euo pipefail
+          msi="$(ls target/installer/dist/*.msi 2>/dev/null | head -1 || true)"
+          if [ -z "$msi" ] || [ ! -f "$msi" ]; then
+            echo "::error::no .msi produced by scripts/build-installer.sh"; exit 1
+          fi
+          bytes="$(wc -c < "$msi")"
+          echo "msi: $msi ($bytes bytes)"
+          # a real jpackage msi with a bundled trimmed runtime is tens of MB; a
+          # 1 MiB floor only a broken/empty build (no runtime bundled) would trip
+          min=1048576
+          if [ "$bytes" -lt "$min" ]; then
+            echo "::error::msi is implausibly small ($bytes bytes < $min); the build likely failed to bundle the runtime"; exit 1
+          fi
+          echo "msi build-smoke OK"
+
+      - name: Upload the msi
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-msi
+          path: target/installer/dist/*.msi
+          if-no-files-found: ignore
 
   # macOS dmg reproducibility (#191, parent #188): the dmg's variance is a
   # finite envelope set — a random UDIF SegmentID plus the HFS+ volume

--- a/README.md
+++ b/README.md
@@ -266,8 +266,7 @@ is guarded independently of the JBR download by
 which drives the unmodified rig against a stub toolchain (no JBR, no real
 compositor, no network) and asserts each scenario is classified with the
 documented exit code. The `gui-wayland` lane runs it on every event, so a
-regression in the classification is caught even while the lane is skipped
-pending the JBR checksum pin.
+regression in the classification is caught independently of the rig itself.
 
 ### Development container
 

--- a/scripts/macos-rig-selftest.sh
+++ b/scripts/macos-rig-selftest.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# macos-rig-selftest.sh - logic self-test for scripts/macos-rig.sh
+# (issue #265 Stage 9).
+#
+# The real rig (macos-rig.sh) can only run on a macOS runner with a live
+# WindowServer, screencapture/sips/osascript, and the JLS jar. Its *control
+# flow* - the failure classification that decides between exit 0 (JLS window
+# mapped + non-blank screenshot, OR the DEGRADED-mode window-map when Screen
+# Recording/TCC is withheld), exit 1 (JLS-side failure), and exit 2 (environment:
+# readiness capture fails outright, the control window never maps, or System
+# Events permission withheld) - is pure shell and must not regress silently
+# before first light on CI. A blank CONTROL-window capture (with readiness OK and
+# the control window mapped) is the TCC signature and now enters DEGRADED MODE
+# (exit 0 on a JLS window-map), NOT exit 2 - #265 Stage 9.
+#
+# This harness drives the unmodified rig against a stub toolchain (fake
+# screencapture/sips/osascript/python3 + a fake java we script per case) and
+# asserts the rig classifies each scenario with the documented exit code. It
+# needs no macOS, no GUI, and no network, so it runs in the sandbox and as a
+# fast CI check on every event (exactly like x11-rig-selftest.sh).
+#
+# Usage:  scripts/macos-rig-selftest.sh
+# Exit 0 when every scenario classified correctly; 1 otherwise.
+
+set -euo pipefail
+
+RIG_DIR="$(cd "$(dirname "$0")" && pwd)"
+RIG="$RIG_DIR/macos-rig.sh"
+[ -x "$RIG" ] || { echo "selftest: $RIG is missing or not executable" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+STUB_BIN="$WORK/bin"
+mkdir -p "$STUB_BIN"
+
+# --- stub osascript: the rig calls `osascript FILE TITLE PID` and reads a
+# window count on stdout. STUB_OSA_DENIED=1 models Accessibility/automation
+# permission withheld (osascript exits non-zero -> the rig's exit-2 path). The
+# count keys on the title: HelloSwingControl maps unless STUB_CONTROL_MAPS=0,
+# JLS maps only when STUB_JLS_MAPS=1.
+cat > "$STUB_BIN/osascript" <<'EOF'
+#!/usr/bin/env bash
+if [ "${STUB_OSA_DENIED:-0}" = 1 ]; then
+  echo 'execution error: Not authorized to send Apple events to System Events. (-1743)' >&2
+  exit 1
+fi
+title="${2:-}"
+case "$title" in
+  *HelloSwingControl*) [ "${STUB_CONTROL_MAPS:-1}" = 1 ] && echo 1 || echo 0 ;;
+  *JLS*)               [ "${STUB_JLS_MAPS:-1}" = 1 ]     && echo 1 || echo 0 ;;
+  *)                   echo 0 ;;
+esac
+exit 0
+EOF
+
+# --- stub screencapture: `screencapture -x -t png OUT`. Write a byte to the
+# output path (last arg) so the evidence steps succeed; blankness is decided by
+# the identify-equivalent (the python stub), matching the x11 selftest split.
+# STUB_CAPTURE_FAIL=1 makes every capture exit non-zero, modelling a runner where
+# even the desktop readiness screenshot fails outright (the rig's exit-2 path).
+cat > "$STUB_BIN/screencapture" <<'EOF'
+#!/usr/bin/env bash
+if [ "${STUB_CAPTURE_FAIL:-0}" = 1 ]; then
+  echo 'stub screencapture: capture failed (selftest)' >&2
+  exit 1
+fi
+out="${!#}"
+printf 'stub-capture' > "$out"
+EOF
+
+# --- stub sips: `sips -s format bmp SRC --out OUT`. Create OUT (a fake bmp)
+# preserving the source basename token (control/jls/desktop) so the python
+# color stub can key on it, exactly as the real transcode would.
+cat > "$STUB_BIN/sips" <<'EOF'
+#!/usr/bin/env bash
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in --out) out="${2:-}"; shift 2 ;; *) shift ;; esac
+done
+[ -n "$out" ] && printf 'stub-bmp' > "$out"
+exit 0
+EOF
+
+# --- stub python3: two modes, distinguished by how many .bmp files are passed.
+# colors mode (one .bmp): reports the unique-color count the rig's non-blank
+# gate reads - 186 (a real frame) by default; 1 (blank) for the control shot
+# when STUB_CONTROL_BLANK=1 or the JLS shot when STUB_JLS_BLANK=1. diff mode
+# (two .bmp): reports the sampled changed-pixel count from STUB_DIFF.
+cat > "$STUB_BIN/python3" <<'EOF'
+#!/usr/bin/env bash
+bmps=()
+for a in "$@"; do case "$a" in *.bmp) bmps+=("$a") ;; esac; done
+if [ "${#bmps[@]}" -ge 2 ]; then
+  echo "${STUB_DIFF:-59998}"; exit 0
+fi
+file="${bmps[0]:-}"
+case "$file" in
+  *control*) [ "${STUB_CONTROL_BLANK:-0}" = 1 ] && { echo 1; exit 0; } ;;
+  *jls*|*desktop-after*) [ "${STUB_JLS_BLANK:-0}" = 1 ] && { echo 1; exit 0; } ;;
+esac
+echo 186
+EOF
+
+# --- stub java: -version prints one line; the control run idles until killed;
+# the JLS run idles unless STUB_JLS_CRASH=1, which makes it exit non-zero
+# *before* mapping a window (the exit-1 JLS-side-failure case).
+cat > "$STUB_BIN/java" <<'EOF'
+#!/usr/bin/env bash
+for a in "$@"; do
+  [ "$a" = "-version" ] && { echo 'stub-jdk version "25" (macos-rig selftest)' >&2; exit 0; }
+done
+is_jar=0
+for a in "$@"; do [ "$a" = "-jar" ] && is_jar=1; done
+if [ "$is_jar" = 1 ] && [ "${STUB_JLS_CRASH:-0}" = 1 ]; then
+  echo 'java.awt.AWTError: stub JLS-side startup failure (selftest)' >&2
+  exit 1
+fi
+trap 'exit 0' TERM INT
+while true; do sleep 1; done
+EOF
+
+chmod +x "$STUB_BIN"/*
+
+# a placeholder jar the rig can find
+mkdir -p "$WORK/target"; : > "$WORK/target/jls-selftest.jar"
+
+fail=0
+# run_case NAME EXPECTED_EXIT   (scenario knobs passed via the environment)
+run_case() {
+	name=$1; want=$2; shift 2
+	rundir="$WORK/run-$name"; mkdir -p "$rundir/target"
+	cp "$WORK/target/jls-selftest.jar" "$rundir/target/"
+	got=0
+	( cd "$rundir" \
+		&& PATH="$STUB_BIN:$PATH" \
+		   ARTIFACTS_DIR="$rundir/artifacts" \
+		   CONTROL_TIMEOUT=3 WINDOW_TIMEOUT=5 RENDER_TIMEOUT=2 \
+		   "$@" "$RIG" ) > "$rundir/rig.out" 2>&1 || got=$?
+	if [ "$got" = "$want" ]; then
+		echo "selftest: PASS  $name (exit $got)"
+	else
+		echo "selftest: FAIL  $name (expected exit $want, got $got)"
+		echo "----- rig output ($name) -----"; sed 's/^/    /' "$rundir/rig.out"
+		fail=1
+	fi
+}
+
+# 1) success: control maps + non-blank, JLS maps + non-blank -> exit 0
+run_case success 0 env
+# 2) JLS-side failure: control ok, JLS crashes before a window -> exit 1
+run_case jls-crash 1 env STUB_JLS_MAPS=0 STUB_JLS_CRASH=1
+# 3) JLS-side failure: control ok, JLS never maps a window -> exit 1
+run_case jls-nowindow 1 env STUB_JLS_MAPS=0
+# 4) JLS-side failure: JLS window maps but the screenshot is blank -> exit 1
+run_case jls-blank 1 env STUB_JLS_BLANK=1
+# 5) environment blocker: even the control window never maps -> exit 2
+run_case env-no-control 2 env STUB_CONTROL_MAPS=0
+# 6) environment blocker: System Events permission withheld -> exit 2
+run_case env-osa-denied 2 env STUB_OSA_DENIED=1
+# 7) environment blocker: the desktop readiness screenshot fails outright -> exit 2
+#    (distinct from the control-blank TCC signature: this breaks the capture and
+#    the window-map proof, so it stays a hard environment fault)
+run_case env-readiness-capture-fail 2 env STUB_CAPTURE_FAIL=1
+# 8) DEGRADED MODE (the #265 Stage 9 fix): desktop readiness capture worked and
+#    the control window MAPPED, but its capture is blank (Screen Recording / TCC
+#    withheld). This no longer exits 2 - the rig warns, launches the real jar,
+#    and succeeds on the window-map proof alone (pixel proofs skipped) -> exit 0.
+run_case degraded-control-blank 0 env STUB_CONTROL_BLANK=1
+# 9) DEGRADED MODE but the JLS window never maps: the control mapped, so a JLS
+#    no-show is still JLS-side -> exit 1 (not exit 2)
+run_case degraded-jls-nowindow 1 env STUB_CONTROL_BLANK=1 STUB_JLS_MAPS=0
+# 10) P2 gate armed and satisfied: many pixels differ -> exit 0
+run_case p2-pass 0 env PIXEL_DIFF_MIN=1000 STUB_DIFF=59998
+# 11) P2 gate armed and violated: too few pixels differ -> exit 1 (JLS-side)
+run_case p2-fail 1 env PIXEL_DIFF_MIN=1000 STUB_DIFF=5
+
+# the degraded-control-blank run must emit the ::warning annotation and NOT the
+# old exit-2 "environment fault" message - assert both.
+degraded_out="$WORK/run-degraded-control-blank/rig.out"
+if ! grep -q '::warning title=macOS pixel proof degraded' "$degraded_out"; then
+	echo "selftest: FAIL  degraded-control-blank did not emit the ::warning pixel-proof annotation"; fail=1
+fi
+if ! grep -q 'window-map is the gate this run' "$degraded_out"; then
+	echo "selftest: FAIL  degraded-control-blank warning missing the 'window-map is the gate' text"; fail=1
+fi
+if grep -q 'Screen Recording permission is likely withheld' "$degraded_out"; then
+	echo "selftest: FAIL  degraded-control-blank still took the old exit-2 environment-fault path"; fail=1
+fi
+
+# spot-check the evidence the success run is supposed to leave behind
+succ="$WORK/run-success/artifacts"
+for f in control-verdict.txt desktop-before.png jls-window.png nonblank.txt jls-window-info.txt pixel-diff.txt; do
+	if [ ! -s "$succ/$f" ]; then
+		echo "selftest: FAIL  success run did not produce $f"; fail=1
+	fi
+done
+
+[ "$fail" = 0 ] && echo "selftest: all scenarios classified correctly" \
+	|| echo "selftest: one or more scenarios misclassified"
+exit "$fail"

--- a/scripts/macos-rig.sh
+++ b/scripts/macos-rig.sh
@@ -1,0 +1,533 @@
+#!/usr/bin/env bash
+# macos-rig.sh - macOS GUI app-boot first-light rig for JLS (issue #265
+# Stage 9; the macOS analogue of scripts/x11-rig.sh / scripts/wayland-rig.sh).
+#
+# Boots the REAL JLS application entry point exactly as a user would -
+# `java -jar target/jls-*.jar` (the shaded jar's Main-Class jls.JLS) - on the
+# macOS runner's REAL WindowServer (unlike the Linux lanes there is NO Xvfb or
+# headless compositor to stand up: hosted macOS runners carry a live Quartz
+# WindowServer, so the jar boots directly), then asserts that a top-level
+# window belonging to the JLS process actually maps, and captures the evidence:
+#
+#   $ARTIFACTS_DIR/control-stdout.log    HelloSwingControl stdout
+#   $ARTIFACTS_DIR/control-stderr.log    HelloSwingControl stderr
+#   $ARTIFACTS_DIR/control-verdict.txt   did the control program's window map?
+#   $ARTIFACTS_DIR/control.png           screenshot with the control window up
+#   $ARTIFACTS_DIR/jls-stdout.log        JLS stdout
+#   $ARTIFACTS_DIR/jls-stderr.log        JLS stderr (the first-light census input)
+#   $ARTIFACTS_DIR/jls-window-info.txt   window count/verdict for the JLS process
+#   $ARTIFACTS_DIR/desktop-before.png    full-screen shot before anything launches
+#   $ARTIFACTS_DIR/desktop-after.png     full-screen shot after JLS mapped
+#   $ARTIFACTS_DIR/jls-window.png        full-screen shot with the JLS window up
+#   $ARTIFACTS_DIR/nonblank.txt          unique-color counts (the non-blank proof)
+#   $ARTIFACTS_DIR/pixel-diff.txt        sampled changed-pixel count (empty vs JLS-up)
+#   $ARTIFACTS_DIR/osa-stderr.log        last System Events (osascript) stderr
+#
+# WHY THIS LANE EXISTS (and how it differs from the display JUnit suite):
+# the display-tagged JUnit UI tests exercise UI *unit* classes in-process.
+# This rig is different: it launches the REAL application entry point and
+# proves the actual app window comes up on the WindowServer and can be
+# screenshotted - the same distinction the Linux gui-x11 lane already draws
+# ("LAUNCHES THE APP ... asserts the real window comes up", not the in-process
+# JUnit suite). It is the macOS twin of the Linux GUI-boot rigs.
+#
+# CONTROL FRAME FIRST: before JLS, the rig launches
+# scripts/HelloSwingControl.java - a minimal JFrame on the same runtime and
+# WindowServer - so every run separates the two failure modes by itself.
+# control up + JLS down means a JLS startup defect (exit 1); control down (or a
+# capture the control frame ALSO shows blank/black) means the environment is
+# the blocker (exit 2), and JLS is not blamed for it. This control-frame
+# comparison is exactly what disambiguates a hosted-runner permission block
+# (Accessibility / Screen Recording TCC) from a genuine JLS failure.
+#
+# Exit status (the same contract as the Linux rigs):
+#   0  a real JLS window mapped on the WindowServer AND a non-blank screenshot
+#      was captured (first light).
+#   1  JLS-side failure: the control window mapped and its screenshot was
+#      non-blank, but JLS did not (no window, crashed before mapping, or its
+#      screenshot was blank).
+#   2  environment/rig fault: even the minimal control window never mapped, the
+#      control screenshot was blank/all-black (Screen Recording permission
+#      likely withheld), System Events could not enumerate windows
+#      (Accessibility/automation permission likely withheld), or a required
+#      tool is missing. Never blamed on JLS.
+#
+# GENUINE FIRST LIGHT (honest, not verifiable offline): this rig has NEVER run
+# on a real macOS runner - its first execution is on CI. macOS hosted runners
+# MAY withhold Screen Recording / Accessibility (TCC) permission from a
+# non-interactive CI session, which can make `screencapture` hand back a
+# blank/black frame or make System Events refuse to enumerate windows. Either
+# is classified as exit 2 (environment) via the control-frame comparison above,
+# NEVER exit 1. If first light shows the permission path is blocked, the
+# documented fallbacks are an in-JVM java.awt.Robot self-capture (window paint
+# proof without Screen Recording) and CGWindowList enumeration (window map
+# proof without Accessibility); first light decides which path the hosted image
+# actually grants. Every wait loop below is bounded by a hard timeout, so a
+# withheld permission degrades to a clean exit 2, never a hang.
+#
+# NON-BLANK PROOF - built-in toolchain, no ImageMagick, no network. The Linux
+# rigs count unique colors with ImageMagick's `identify -format '%k'`. This rig
+# reproduces that idiom with only tools already present on every macOS runner:
+# `screencapture` (built-in) writes the PNG, `sips` (built-in) transcodes it to
+# an uncompressed BMP, and a pure-stdlib Python reader (python3 is preinstalled)
+# counts distinct colors in the BMP. This deliberately avoids `brew install
+# imagemagick`: the core non-blank proof then has NO package-install/network
+# dependency that could flake, and a >1 unique-color count is exactly the
+# "is this a real frame or a denied all-black capture" gate the control-frame
+# comparison disambiguates. (On a runner with a wallpaper the desktop alone is
+# already many-colored, so the recorded desktop-before/after pixel diff -
+# PIXEL_DIFF_MIN, off by default like the Linux P2 gate - is the metric a
+# future promotion calibrates from; distinct-color>1 is the always-on P1 gate
+# that catches a black/denied capture.)
+#
+# PROMOTION: advisory `continue-on-error` -> required once 20 consecutive runs
+# show at most one failure (the #188/#101 rule the gui-wayland/gui-x11 lanes
+# followed), then drop continue-on-error and register the lane's exact `name:`
+# ("GUI boot (macOS, WindowServer)") as a required check with recorded run IDs,
+# mirroring installer-reproducibility-aarch64.
+#
+# Requirements: java on PATH; screencapture, sips, osascript (all built-in on
+# macOS); python3 (preinstalled); the shaded jar from `mvn -DskipTests package`
+# (or point $JAR at one).
+#
+# Environment knobs (all optional):
+#   JAVA              java binary to launch     [java on PATH]
+#   JAR               jar to launch             [newest target/jls-*.jar]
+#   ARTIFACTS_DIR     where evidence goes       [artifacts/macos-rig]
+#   CONTROL_TIMEOUT   seconds to wait for the control window    [60]
+#   WINDOW_TIMEOUT    seconds to wait for the JLS window        [90]
+#   RENDER_TIMEOUT    seconds to wait for the window to paint   [30]
+#   PIXEL_DIFF_MIN    fail unless the desktop-before/after sampled changed-pixel
+#                     count is at least this many; 0 records the metric
+#                     without gating (mirrors the Linux P2 gate)   [0]
+
+set -euo pipefail
+
+log() { printf 'macos-rig: %s\n' "$*" >&2; }
+# environment/rig faults are exit 2; JLS-side failures use exit 1 explicitly at
+# their own call sites (only after the control frame proved the environment).
+die_env() { printf 'macos-rig: error: %s\n' "$*" >&2; exit 2; }
+
+# ---------------------------------------------------------------- config
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-artifacts/macos-rig}"
+CONTROL_TIMEOUT="${CONTROL_TIMEOUT:-60}"
+WINDOW_TIMEOUT="${WINDOW_TIMEOUT:-90}"
+# a mapped window paints a beat later; poll the screenshot until it renders
+RENDER_TIMEOUT="${RENDER_TIMEOUT:-30}"
+PIXEL_DIFF_MIN="${PIXEL_DIFF_MIN:-0}"
+# Set to 1 when the desktop readiness capture works AND the control window MAPS
+# but the control-window capture is blank (the Screen Recording / TCC signature
+# on hosted runners): pixel proofs are then unavailable this run, so the rig runs
+# in DEGRADED MODE and the window-map is the boot gate (issue #265 Stage 9). It
+# never gates on exit 2 for that reason - a permanently-withheld TCC grant would
+# otherwise make the boot-proof lane permanently red for a runner-policy reason.
+DEGRADED=0
+
+# the control program lives next to this script, wherever it is run from
+RIG_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTROL_SRC="$RIG_DIR/HelloSwingControl.java"
+
+# screencapture/sips/osascript are macOS built-ins; python3 is preinstalled.
+# Their absence is an environment fault (exit 2), not a JLS failure.
+for tool in screencapture sips osascript python3; do
+	command -v "$tool" >/dev/null 2>&1 || die_env "$tool is not installed (expected on a macOS runner)"
+done
+
+JAVA="${JAVA:-java}"
+command -v "$JAVA" >/dev/null 2>&1 || die_env "no java found (set JAVA= or add one to PATH)"
+
+# newest shaded jar unless the caller picked one
+if [ -z "${JAR:-}" ]; then
+	JAR=""
+	for candidate in target/jls-*.jar; do
+		[ -f "$candidate" ] || continue
+		if [ -z "$JAR" ] || [ "$candidate" -nt "$JAR" ]; then
+			JAR="$candidate"
+		fi
+	done
+fi
+if [ -z "${JAR:-}" ] || [ ! -f "$JAR" ]; then
+	die_env "no jar found; run 'mvn -DskipTests package' first or set JAR="
+fi
+
+mkdir -p "$ARTIFACTS_DIR"
+log "artifacts: $ARTIFACTS_DIR"
+log "runtime:   $("$JAVA" -version 2>&1 | grep -iv 'picked up' | head -n 1)"
+log "jar:       $JAR"
+
+# ---------------------------------------------------- window enumeration
+# System Events enumerates the mapped top-level windows. Matching is by the
+# launched process's unix id (authoritative) with a title-contains fallback
+# (AWT sets the frame title; JLS's is JLSInfo.version, e.g. "JLS 5.0"). This
+# needs macOS Accessibility/automation permission; if the hosted image withholds
+# it, osascript exits non-zero and the rig classifies that as environment (the
+# control frame hits the same wall first, so it never lands on JLS). The script
+# is written to a temp file so the argument passing is unambiguous.
+OSA_FILE="$ARTIFACTS_DIR/count-windows.applescript"
+cat > "$OSA_FILE" <<'APPLESCRIPT'
+on run argv
+	set theTitle to item 1 of argv
+	set thePid to (item 2 of argv) as integer
+	tell application "System Events"
+		set n to 0
+		try
+			set p to first process whose unix id is thePid
+			set n to (count of windows of p)
+		end try
+		if n is 0 then
+			repeat with p in (every process)
+				try
+					repeat with w in (windows of p)
+						if name of w contains theTitle then set n to n + 1
+					end repeat
+				end try
+			end repeat
+		end if
+		return n
+	end tell
+end run
+APPLESCRIPT
+
+# wait_for_window TITLE PID TIMEOUT
+# Polls System Events for a mapped window belonging to PID (or whose title
+# contains TITLE) up to TIMEOUT seconds. Sets WIN_COUNT and WAITED_SECONDS on
+# success. Returns:
+#   0  a window is mapped
+#   1  timeout (process alive, no window)
+#   2  the process exited before mapping a window
+#   3  System Events could not be queried (osascript failed - permission)
+wait_for_window() {
+	wfw_title=$1
+	wfw_pid=$2
+	wfw_timeout=$3
+	wfw_elapsed=0
+	while [ "$wfw_elapsed" -lt "$wfw_timeout" ]; do
+		kill -0 "$wfw_pid" 2>/dev/null || return 2
+		if ! wfw_out="$(osascript "$OSA_FILE" "$wfw_title" "$wfw_pid" \
+				2> "$ARTIFACTS_DIR/osa-stderr.log")"; then
+			return 3
+		fi
+		wfw_out="$(printf '%s' "$wfw_out" | tr -d '[:space:]')"
+		case "$wfw_out" in ''|*[!0-9]*) wfw_out=0 ;; esac
+		if [ "$wfw_out" -gt 0 ]; then
+			WIN_COUNT="$wfw_out"
+			WAITED_SECONDS=$wfw_elapsed
+			return 0
+		fi
+		sleep 1
+		wfw_elapsed=$((wfw_elapsed + 1))
+	done
+	return 1
+} # end of wait_for_window function
+
+# ------------------------------------------------- non-blank proof helpers
+# The distinct-color counter reads an uncompressed BMP (sips transcodes the PNG
+# screenshot to BMP) and prints the number of distinct colors, capped, or 0 on
+# any error. A solid/black frame has 1 color; any real captured frame has many,
+# so >1 is the always-on non-blank / not-a-denied-capture gate. Kept inline so
+# the rig stays self-contained (no committed helper module) - the Linux rigs
+# inline their non-blank logic the same way.
+PY_COLORS='
+import sys, struct
+def main():
+    try:
+        with open(sys.argv[1], "rb") as f:
+            d = f.read()
+    except Exception:
+        print(0); return
+    if len(d) < 54 or d[:2] != b"BM":
+        print(0); return
+    pixoff = struct.unpack_from("<I", d, 10)[0]
+    width  = struct.unpack_from("<i", d, 18)[0]
+    height = struct.unpack_from("<i", d, 22)[0]
+    bpp    = struct.unpack_from("<H", d, 28)[0]
+    comp   = struct.unpack_from("<I", d, 30)[0]
+    if comp != 0 or bpp not in (24, 32) or width <= 0:
+        print(0); return
+    h = abs(height); bpb = bpp // 8
+    rowsize = ((bpp * width + 31) // 32) * 4
+    sx = max(1, width // 256); sy = max(1, h // 256)
+    cap = 4096; colors = set()
+    for y in range(0, h, sy):
+        base = pixoff + y * rowsize
+        for x in range(0, width, sx):
+            o = base + x * bpb
+            if o + bpb > len(d): continue
+            colors.add((d[o], d[o+1], d[o+2]))
+            if len(colors) >= cap:
+                print(len(colors)); return
+    print(len(colors))
+main()
+'
+
+# The pixel-diff counter samples both BMPs on the same grid and prints how many
+# sampled pixels differ (or -1 if the two images are not comparable). Recorded
+# always; gates only when PIXEL_DIFF_MIN>0 (mirrors the Linux P2 gate).
+PY_DIFF='
+import sys, struct
+def load(p):
+    try:
+        with open(p, "rb") as f:
+            d = f.read()
+    except Exception:
+        return None
+    if len(d) < 54 or d[:2] != b"BM":
+        return None
+    pixoff = struct.unpack_from("<I", d, 10)[0]
+    width  = struct.unpack_from("<i", d, 18)[0]
+    height = struct.unpack_from("<i", d, 22)[0]
+    bpp    = struct.unpack_from("<H", d, 28)[0]
+    comp   = struct.unpack_from("<I", d, 30)[0]
+    if comp != 0 or bpp not in (24, 32) or width <= 0:
+        return None
+    return (d, pixoff, width, abs(height), bpp // 8, ((bpp * width + 31)//32)*4)
+def main():
+    a = load(sys.argv[1]); b = load(sys.argv[2])
+    if a is None or b is None or a[2] != b[2] or a[3] != b[3]:
+        print(-1); return
+    da, oa, w, h, bpa, ra = a
+    db, ob, _, _, bpb, rb = b
+    sx = max(1, w // 256); sy = max(1, h // 256)
+    diff = 0
+    for y in range(0, h, sy):
+        for x in range(0, w, sx):
+            pa = oa + y*ra + x*bpa; pb = ob + y*rb + x*bpb
+            if pa+3 > len(da) or pb+3 > len(db): continue
+            if da[pa:pa+3] != db[pb:pb+3]: diff += 1
+    print(diff)
+main()
+'
+
+# unique_colors PNG -> prints the distinct-color count of PNG (0 on any error)
+unique_colors() {
+	uc_png=$1
+	uc_bmp="${uc_png%.png}.bmp"
+	if [ -s "$uc_png" ] && sips -s format bmp "$uc_png" --out "$uc_bmp" >/dev/null 2>&1; then
+		python3 -c "$PY_COLORS" "$uc_bmp" 2>/dev/null || echo 0
+	else
+		echo 0
+	fi
+}
+
+# snap PNG -> full-screen screenshot to PNG. -x silences the capture sound;
+# a non-zero exit is a capture failure the caller classifies.
+snap() {
+	screencapture -x -t png "$1" 2> "$ARTIFACTS_DIR/screencapture-stderr.log"
+}
+
+# ------------------------------------------------------------- processes
+CONTROL_PID=""
+JLS_PID=""
+# invoked via trap, which shellcheck cannot see (SC2317/SC2329 false positive)
+# shellcheck disable=SC2317,SC2329
+cleanup() {
+	status=$?
+	for pid in "$JLS_PID" "$CONTROL_PID"; do
+		if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+			kill "$pid" 2>/dev/null || true
+		fi
+	done
+	exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+# ------------------------------------------------ readiness / empty baseline
+# Before launching any client, prove the WindowServer is screenshottable and
+# capture the empty-desktop baseline (feeds the P2 pixel comparison later). A
+# failure here is an environment fault (exit 2), never blamed on JLS.
+snap "$ARTIFACTS_DIR/desktop-before.png" \
+	|| die_env "could not screenshot the desktop (screencapture failed); environment/rig fault, not JLS"
+log "readiness gate passed: desktop screenshot OK"
+
+# ---------------------------------------------------- control experiment
+# Map a minimal JFrame on the same runtime and WindowServer first. If even this
+# cannot map a window (or its screenshot is blank/black), the environment is the
+# blocker (exit 2) and JLS is not blamed; if it maps and JLS later fails, the
+# defect is in JLS's startup path (exit 1). HelloSwingControl is reused as-is;
+# on macOS the platform default toolkit is correct (no -Dawt.toolkit.name).
+[ -f "$CONTROL_SRC" ] || die_env "control program missing: $CONTROL_SRC"
+log "launching HelloSwingControl (environment-blocker control)"
+"$JAVA" -Djava.awt.headless=false "$CONTROL_SRC" \
+	> "$ARTIFACTS_DIR/control-stdout.log" 2> "$ARTIFACTS_DIR/control-stderr.log" &
+CONTROL_PID=$!
+
+control_status=0
+wait_for_window "HelloSwingControl" "$CONTROL_PID" "$CONTROL_TIMEOUT" \
+	|| control_status=$?
+if [ "$control_status" -eq 0 ]; then
+	printf 'control window mapped after %ss (%s window(s))\n' "$WAITED_SECONDS" "$WIN_COUNT" \
+		> "$ARTIFACTS_DIR/control-verdict.txt"
+	log "control window is up after ${WAITED_SECONDS}s ($WIN_COUNT window(s))"
+else
+	if [ "$control_status" -eq 3 ]; then
+		printf 'System Events could not enumerate windows (permission)\n' \
+			> "$ARTIFACTS_DIR/control-verdict.txt"
+		log "----- last lines of osa-stderr.log -----"
+		tail -n 20 "$ARTIFACTS_DIR/osa-stderr.log" >&2 || true
+		die_env "System Events could not enumerate windows (Accessibility/automation permission likely withheld on this runner); environment fault, not JLS"
+	fi
+	if [ "$control_status" -eq 2 ]; then
+		printf 'control process exited before mapping a window\n'
+	else
+		printf 'no control window after %ss\n' "$CONTROL_TIMEOUT"
+	fi > "$ARTIFACTS_DIR/control-verdict.txt"
+	log "----- last lines of control-stderr.log -----"
+	tail -n 40 "$ARTIFACTS_DIR/control-stderr.log" >&2 || true
+	die_env "the minimal Swing control failed to map a window; the blocker is the environment (WindowServer/AWT), not JLS"
+fi
+
+# The control window must also screenshot non-blank. A blank/all-black capture
+# HERE - when the desktop readiness capture already worked AND the control window
+# MAPPED - is the Screen Recording (TCC) signature: the WindowServer hands a
+# non-interactive session a black window capture while window enumeration still
+# works. On hosted runners this permission may NEVER be granted, so treating it
+# as exit 2 would make the boot-proof lane permanently red for a runner-policy
+# reason (pure noise). Instead the rig enters DEGRADED MODE: the pixel proofs are
+# skipped and the window-map becomes the boot gate this run. (This is the ONLY
+# branch whose semantics change for TCC; readiness-capture failure, a control
+# window that never maps, and osascript denial all still classify exit 2 below,
+# because those break the window-map proof itself.)
+snap "$ARTIFACTS_DIR/control.png" || log "warning: control screenshot failed (continuing)"
+control_colors="$(unique_colors "$ARTIFACTS_DIR/control.png")"
+case "$control_colors" in ''|*[!0-9]*) control_colors=0 ;; esac
+log "control screenshot unique colors: $control_colors"
+if [ "$control_colors" -le 1 ]; then
+	DEGRADED=1
+	# GitHub Actions workflow warning annotation (stdout, on its own line).
+	echo "::warning title=macOS pixel proof degraded (TCC)::P1 pixel proof unavailable: Screen Recording withheld (TCC); window-map is the gate this run"
+	printf 'control window mapped but its capture is blank (%s unique color): Screen Recording (TCC) withheld\n' "$control_colors" \
+		> "$ARTIFACTS_DIR/control-verdict.txt"
+	log "P1 pixel proof unavailable: Screen Recording withheld (TCC); window-map is the gate this run - entering DEGRADED MODE (control window mapped, desktop readiness capture worked, only the window capture is blank)"
+fi
+
+# clear the control so JLS gets the same empty baseline
+kill "$CONTROL_PID" 2>/dev/null || true
+wait "$CONTROL_PID" 2>/dev/null || true
+CONTROL_PID=""
+
+# --------------------------------------------------------------- launch
+# The real application entry point, launched exactly as a user would via the
+# jar's Main-Class (jls.JLS). headless=false; on macOS the platform default
+# toolkit (LWCToolkit) is correct, so NO -Dawt.toolkit.name.
+log "launching JLS (real app entry point, jar Main-Class jls.JLS)"
+"$JAVA" -Djava.awt.headless=false -jar "$JAR" \
+	> "$ARTIFACTS_DIR/jls-stdout.log" 2> "$ARTIFACTS_DIR/jls-stderr.log" &
+JLS_PID=$!
+
+# ----------------------------------------------- wait for the JLS window
+found=""
+jls_status=0
+wait_for_window "JLS" "$JLS_PID" "$WINDOW_TIMEOUT" || jls_status=$?
+if [ "$jls_status" -eq 0 ]; then
+	found=yes
+elif [ "$jls_status" -eq 3 ]; then
+	# System Events worked for the control but not now: still an environment
+	# fault (a permission cannot appear mid-run for JLS alone), not JLS.
+	snap "$ARTIFACTS_DIR/desktop-after.png" || true
+	die_env "System Events stopped enumerating windows during the JLS wait; environment fault, not JLS"
+elif [ "$jls_status" -eq 2 ]; then
+	snap "$ARTIFACTS_DIR/desktop-after.png" || true
+	log "----- last lines of jls-stderr.log -----"
+	tail -n 40 "$ARTIFACTS_DIR/jls-stderr.log" >&2 || true
+	# control mapped + non-blank, JLS did not: JLS-side failure (exit 1)
+	printf 'macos-rig: error: JLS exited before mapping a window (see jls-stderr.log; the control mapped and captured non-blank, so this is a JLS-side failure)\n' >&2
+	exit 1
+fi
+
+if [ -z "$found" ]; then
+	snap "$ARTIFACTS_DIR/desktop-after.png" || true
+	log "----- last lines of jls-stderr.log -----"
+	tail -n 40 "$ARTIFACTS_DIR/jls-stderr.log" >&2 || true
+	printf 'macos-rig: error: no JLS window mapped after %ss (the control mapped and captured non-blank, so this is a JLS-side failure)\n' "$WINDOW_TIMEOUT" >&2
+	exit 1
+fi
+log "JLS window is up after ${WAITED_SECONDS}s ($WIN_COUNT window(s))"
+
+# record the window verdict as proof it is a real mapped frame
+{
+	printf 'JLS windows mapped: %s\n' "$WIN_COUNT"
+	printf 'waited: %ss\n' "$WAITED_SECONDS"
+} > "$ARTIFACTS_DIR/jls-window-info.txt"
+
+# ------------------------------------------------- DEGRADED MODE exit
+# Screen Recording (TCC) was withheld (the control window mapped but its capture
+# was blank): the JLS window MAPPED just now via System Events, which is the boot
+# gate the maintainer relies on ("prove the thing can at least start"). The pixel
+# proofs would all be blank for the same TCC reason, so they are skipped and the
+# run succeeds on the window-map proof alone. The real JLS jar was launched and
+# its top-level window enumerated, so this is a genuine boot proof, not a stub.
+if [ "$DEGRADED" = 1 ]; then
+	# one screenshot is still captured for artifact evidence (expected blank
+	# under TCC); it is NOT gated on.
+	snap "$ARTIFACTS_DIR/jls-window.png" || true
+	{
+		printf 'mode: DEGRADED (Screen Recording / TCC withheld)\n'
+		printf 'control unique colors: %s (blank -> pixel proofs unavailable)\n' "$control_colors"
+		printf 'pixel proofs: SKIPPED (window-map is the boot gate this run)\n'
+		printf 'JLS windows mapped: %s\n' "$WIN_COUNT"
+	} > "$ARTIFACTS_DIR/nonblank.txt"
+	log "first light (DEGRADED): JLS window mapped ($WIN_COUNT window(s)); pixel proof unavailable (Screen Recording/TCC withheld) - boot proven by window-map, exiting 0"
+	exit 0
+fi
+
+# ------------------------------------------------- non-blank proof (P1)
+# A mapped window is not enough - the screenshot must not be a blank/black
+# frame. Swing shows the frame a beat before it paints, so poll the screenshot
+# until it has more than one unique color (i.e. a real frame, not a denied
+# all-black capture), up to RENDER_TIMEOUT seconds.
+render_elapsed=0
+jls_colors=0
+while : ; do
+	snap "$ARTIFACTS_DIR/jls-window.png" || log "warning: JLS screenshot failed"
+	jls_colors="$(unique_colors "$ARTIFACTS_DIR/jls-window.png")"
+	case "$jls_colors" in ''|*[!0-9]*) jls_colors=0 ;; esac
+	{ [ "$jls_colors" -gt 1 ] || [ "$render_elapsed" -ge "$RENDER_TIMEOUT" ]; } && break
+	sleep 1
+	render_elapsed=$((render_elapsed + 1))
+done
+cp "$ARTIFACTS_DIR/jls-window.png" "$ARTIFACTS_DIR/desktop-after.png" 2>/dev/null || true
+{
+	printf 'control unique colors:    %s\n' "$control_colors"
+	printf 'jls-window unique colors: %s\n' "$jls_colors"
+	printf 'render wait: %ss\n' "$render_elapsed"
+} > "$ARTIFACTS_DIR/nonblank.txt"
+log "non-blank check after ${render_elapsed}s: window=$jls_colors colors"
+
+if [ "$jls_colors" -le 1 ]; then
+	# The control frame captured non-blank moments ago, so Screen Recording is
+	# granted; a blank JLS capture now is a JLS-side failure (window mapped but
+	# rendered nothing), per the Linux rigs' P1 rule.
+	printf 'macos-rig: error: the JLS screenshot is blank (%s unique color); the JLS window mapped but rendered nothing - JLS-side failure\n' "$jls_colors" >&2
+	exit 1
+fi
+
+# --------------------------------------------- P2 pixel difference (optional)
+# How many sampled pixels changed between the empty desktop and the desktop with
+# JLS on it. Always recorded; it gates only once PIXEL_DIFF_MIN is calibrated
+# from the first green run's observed value (not guessed blind) - the same
+# discipline the Linux P2 gate uses. On a wallpapered runner this is the metric
+# that actually proves the app painted, since distinct-color>1 is trivially true
+# for any non-black frame there.
+before_bmp="$ARTIFACTS_DIR/desktop-before.bmp"
+after_bmp="$ARTIFACTS_DIR/desktop-after.bmp"
+diff_count="-1"
+if sips -s format bmp "$ARTIFACTS_DIR/desktop-before.png" --out "$before_bmp" >/dev/null 2>&1 \
+		&& sips -s format bmp "$ARTIFACTS_DIR/desktop-after.png" --out "$after_bmp" >/dev/null 2>&1; then
+	diff_count="$(python3 -c "$PY_DIFF" "$before_bmp" "$after_bmp" 2>/dev/null || echo -1)"
+fi
+printf '%s\n' "$diff_count" > "$ARTIFACTS_DIR/pixel-diff.txt"
+log "sampled pixels differing from empty desktop: $diff_count"
+if [ "$PIXEL_DIFF_MIN" -gt 0 ] 2>/dev/null; then
+	case "$diff_count" in
+		''|*[!0-9]*)
+			printf 'macos-rig: error: P2 gate is armed (PIXEL_DIFF_MIN=%s) but the diff metric was unreadable: %s\n' "$PIXEL_DIFF_MIN" "$diff_count" >&2
+			exit 1 ;;
+	esac
+	if [ "$diff_count" -lt "$PIXEL_DIFF_MIN" ]; then
+		printf 'macos-rig: error: P2 failed: only %s sampled pixels differ from the empty desktop (need >= %s) - JLS-side failure\n' "$diff_count" "$PIXEL_DIFF_MIN" >&2
+		exit 1
+	fi
+fi
+
+log "first light: success"
+exit 0

--- a/scripts/windows-rig-selftest.ps1
+++ b/scripts/windows-rig-selftest.ps1
@@ -1,0 +1,227 @@
+<#
+.SYNOPSIS
+  windows-rig-selftest.ps1 - logic self-test for scripts\windows-rig.ps1
+  (issue #111 Stage W7).
+
+.DESCRIPTION
+  The real rig (windows-rig.ps1) can only run on a windows-latest runner with an
+  interactive window station, System.Drawing screen capture, and the JLS jar.
+  Its *control flow* - the failure classification that decides between exit 0
+  (JLS window mapped + non-blank screenshot), exit 1 (JLS-side failure), and
+  exit 2 (environment: control never mapped, or a blank/uncaptured station) -
+  is pure PowerShell and must not regress silently before first light on CI.
+
+  This harness dot-sources the unmodified rig with -NoAutoRun (so it defines its
+  functions without launching anything) and drives Invoke-GuiBootRig against
+  injected stub delegates - a fake window probe, capture, color count, and
+  process launchers we script per case - asserting the rig classifies each
+  scenario with the documented exit code. It needs no Windows GUI, no real
+  process, and no network. (Note: PowerShell was unavailable in the authoring
+  sandbox, so unlike the Linux/macOS selftests this one is first executed on the
+  Windows CI runner itself.)
+
+  Usage:  pwsh -File scripts\windows-rig-selftest.ps1
+  Exit 0 when every scenario classified correctly; 1 otherwise.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'windows-rig.ps1') -NoAutoRun
+
+$script:Work = Join-Path ([System.IO.Path]::GetTempPath()) ("windows-rig-selftest-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Force -Path $script:Work | Out-Null
+
+# scenario knobs, reset per case
+$script:S = @{}
+
+# --- stub delegates (all read $script:S) ---------------------------------
+$stubLaunchControl = {
+    if ($script:S.ThrowInControl) { throw 'stub control launch delegate threw an unexpected exception' }
+    [pscustomobject]@{ Id = 1001; HasExited = $false; Kind = 'control' }
+}
+$stubLaunchJls     = {
+    if ($script:S.ThrowInJls) { throw 'stub JLS launch delegate threw an unexpected exception' }
+    [pscustomobject]@{ Id = 1002; HasExited = [bool]$script:S.JlsCrash; Kind = 'jls' }
+}
+
+$stubWindowProbe = {
+    param($Proc, $TitleRegex)
+    switch ($Proc.Kind) {
+        'control' { if ($script:S.ControlMaps) { 1 } else { 0 } }
+        'jls'     { if ($script:S.JlsMaps)     { 1 } else { 0 } }
+        default   { 0 }
+    }
+}
+
+$stubCapture = {
+    param($Path)
+    [bool]$script:S.CaptureOk
+}
+
+$stubColorCount = {
+    param($Path)
+    if ($Path -like '*control*') { if ($script:S.ControlBlank) { return 1 } else { return 186 } }
+    if ($Path -like '*jls*')     { if ($script:S.JlsBlank)     { return 1 } else { return 186 } }
+    return 186
+}
+
+$script:Fail = 0
+
+function Invoke-Case {
+    param([string]$Name, [int]$Want, [hashtable]$Scenario)
+    # sensible defaults; the scenario overrides specific knobs
+    $script:S = @{
+        ControlMaps    = $true
+        JlsMaps        = $true
+        JlsCrash       = $false
+        ControlBlank   = $false
+        JlsBlank       = $false
+        CaptureOk      = $true
+        ThrowInControl = $false
+        ThrowInJls     = $false
+    }
+    foreach ($k in $Scenario.Keys) { $script:S[$k] = $Scenario[$k] }
+
+    $artifacts = Join-Path $script:Work "run-$Name"
+    $got = -1
+    try {
+        $got = Invoke-GuiBootRig `
+            -ArtifactsDir $artifacts `
+            -LaunchControl $stubLaunchControl `
+            -LaunchJls $stubLaunchJls `
+            -WindowProbe $stubWindowProbe `
+            -Capture $stubCapture `
+            -ColorCount $stubColorCount `
+            -ControlTimeout 2 `
+            -WindowTimeout 2 `
+            -RenderTimeout 2
+    } catch {
+        Write-Host "selftest: FAIL  $Name (threw: $($_.Exception.Message))"
+        $script:Fail = 1
+        return
+    }
+    if ($got -eq $Want) {
+        Write-Host "selftest: PASS  $Name (exit $got)"
+    } else {
+        Write-Host "selftest: FAIL  $Name (expected exit $Want, got $got)"
+        $script:Fail = 1
+    }
+}
+
+# 1) success: control maps + non-blank, JLS maps + non-blank -> exit 0
+Invoke-Case 'success' 0 @{}
+# 2) JLS-side failure: control ok, JLS crashes before a window -> exit 1
+Invoke-Case 'jls-crash' 1 @{ JlsMaps = $false; JlsCrash = $true }
+# 3) JLS-side failure: control ok, JLS never maps a window -> exit 1
+Invoke-Case 'jls-nowindow' 1 @{ JlsMaps = $false }
+# 4) JLS-side failure: JLS window maps but the screenshot is blank -> exit 1
+Invoke-Case 'jls-blank' 1 @{ JlsBlank = $true }
+# 5) environment blocker: even the control window never maps -> exit 2
+Invoke-Case 'env-no-control' 2 @{ ControlMaps = $false }
+# 6) environment blocker: the control screenshot is blank (station not
+#    captured) -> exit 2
+Invoke-Case 'env-control-blank' 2 @{ ControlBlank = $true }
+# 7) environment blocker: the readiness screenshot fails outright -> exit 2
+Invoke-Case 'env-capture-fail' 2 @{ CaptureOk = $false }
+# 8) environment blocker: a launch delegate throws an UNEXPECTED exception ->
+#    exit 2 (rig/environment fault), never a bare pwsh failure or exit 1
+Invoke-Case 'jls-throws'     2 @{ ThrowInJls = $true }
+Invoke-Case 'control-throws' 2 @{ ThrowInControl = $true }
+
+# --- production-path integrity ------------------------------------------------
+# The exact bug class the Windows first-light run hit: a production launch helper
+# calling a function its scope could not see ("The term 'Start-JavaProcess' is
+# not recognized"), which the stub-delegate scenarios above can NEVER catch
+# because they replace the launch path entirely. Two checks that DO catch it,
+# both of which FAIL on the pre-fix script:
+#   (1) AST-parse windows-rig.ps1 and assert every function the production path
+#       calls is DEFINED at top-level script scope. Pre-fix there were no
+#       Invoke-ControlLaunch / Invoke-JlsLaunch functions at all - the launch
+#       logic hid inside .GetNewClosure() locals reachable only during auto-run -
+#       so the required-set assertion reports them missing and fails.
+#   (2) A reachability probe that actually INVOKES the real launch delegates with
+#       Start-JavaProcess overridden by a no-op stub (no java is launched) and
+#       asserts they resolve it. If the launch path is ever wrapped in a scope
+#       that cannot see Start-JavaProcess (the closure bug), this reproduces
+#       "Start-JavaProcess is not recognized" as a red test.
+function Test-ProductionPath {
+    $rig = Join-Path $PSScriptRoot 'windows-rig.ps1'
+    $tokens = $null; $perrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($rig, [ref]$tokens, [ref]$perrors)
+    if ($perrors -and $perrors.Count -gt 0) {
+        Write-Host "selftest: FAIL  production-path (windows-rig.ps1 has $($perrors.Count) parse error(s))"
+        $script:Fail = 1; return
+    }
+
+    $defined = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($f in $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)) {
+        [void]$defined.Add($f.Name)
+    }
+    $required = @(
+        'Start-JavaProcess','Invoke-ControlLaunch','Invoke-JlsLaunch','Invoke-GuiBootRig',
+        'Get-WindowCount','Save-Screenshot','Get-ColorCount','Wait-ForWindow',
+        'Stop-ProcessSafe','Write-RigLog'
+    )
+    $missing = @($required | Where-Object { -not $defined.Contains($_) })
+    if ($missing.Count -gt 0) {
+        Write-Host "selftest: FAIL  production-path (undefined production-path function(s): $($missing -join ', '))"
+        $script:Fail = 1; return
+    }
+
+    # each launch delegate must call a function the script actually defines
+    foreach ($name in 'Invoke-ControlLaunch','Invoke-JlsLaunch') {
+        $fn = $ast.FindAll({ param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $n.Name -eq $name
+        }, $true) | Select-Object -First 1
+        $calls = @($fn.Body.FindAll({ param($n) $n -is [System.Management.Automation.Language.CommandAst] }, $true) |
+            ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
+        if ($calls -notcontains 'Start-JavaProcess') {
+            Write-Host "selftest: FAIL  production-path ($name does not call Start-JavaProcess)"
+            $script:Fail = 1; return
+        }
+    }
+
+    # reachability probe: override Start-JavaProcess at script scope with a no-op
+    # (records the call, launches nothing) and invoke the REAL launch delegates.
+    $script:ProbeCalled = @{}
+    function script:Start-JavaProcess {
+        param([string[]]$ArgList, [string]$OutLog, [string]$ErrLog)
+        $script:ProbeCalled[$OutLog] = $true
+        [pscustomobject]@{ Id = 4242; HasExited = $false; Probe = $true }
+    }
+    $probeDir = Join-Path $script:Work 'probe'
+    New-Item -ItemType Directory -Force -Path $probeDir | Out-Null
+    $script:ArtifactsDir = $probeDir
+    $script:ControlSrc   = Join-Path $probeDir 'HelloSwingControl.java'
+    $script:Jar          = Join-Path $probeDir 'jls-probe.jar'
+    $ok = $true
+    try {
+        $c = Invoke-ControlLaunch
+        $j = Invoke-JlsLaunch
+        if ($null -eq $c -or $c.Id -ne 4242) { $ok = $false }
+        if ($null -eq $j -or $j.Id -ne 4242) { $ok = $false }
+        if ($script:ProbeCalled.Count -lt 2) { $ok = $false }
+    } catch {
+        Write-Host "selftest: FAIL  production-path (launch delegate threw resolving Start-JavaProcess: $($_.Exception.Message))"
+        $script:Fail = 1; return
+    }
+    if ($ok) {
+        Write-Host 'selftest: PASS  production-path (launch delegates defined and resolve Start-JavaProcess)'
+    } else {
+        Write-Host 'selftest: FAIL  production-path (launch delegates did not invoke the stubbed Start-JavaProcess)'
+        $script:Fail = 1
+    }
+}
+Test-ProductionPath
+
+Remove-Item -Recurse -Force $script:Work -ErrorAction SilentlyContinue
+
+if ($script:Fail -eq 0) {
+    Write-Host 'selftest: all scenarios classified correctly'
+} else {
+    Write-Host 'selftest: one or more scenarios misclassified'
+}
+exit $script:Fail

--- a/scripts/windows-rig.ps1
+++ b/scripts/windows-rig.ps1
@@ -1,0 +1,407 @@
+<#
+.SYNOPSIS
+  windows-rig.ps1 - Windows GUI app-boot first-light rig for JLS
+  (issue #111 Stage W7; the Windows analogue of scripts/x11-rig.sh /
+  scripts/macos-rig.sh).
+
+.DESCRIPTION
+  Boots the REAL JLS application entry point exactly as a user would -
+  `java -jar target\jls-*.jar` (the shaded jar's Main-Class jls.JLS) - on the
+  windows-latest runner's REAL interactive window station (unlike the Linux
+  lanes there is NO Xvfb/compositor to stand up), then asserts that a top-level
+  window belonging to the JLS process actually maps, and captures the evidence
+  into $ArtifactsDir:
+
+    control-stdout.log / control-stderr.log   HelloSwingControl console output
+    control-verdict.txt                        did the control window map?
+    control.png                                screenshot with the control up
+    jls-stdout.log / jls-stderr.log            JLS console output (first-light census)
+    jls-window-info.txt                        window verdict for the JLS process
+    desktop-before.png                         screenshot before anything launches
+    jls-window.png                             screenshot with the JLS window up
+    nonblank.txt                               unique-color counts (non-blank proof)
+
+  WHY THIS LANE EXISTS (and how it differs from the display JUnit suite):
+  the @Tag("display") JUnit UI tests exercise UI *unit* classes in-process.
+  This rig is different: it LAUNCHES THE APP as a user would and proves the
+  actual app window comes up on the window station and can be screenshotted -
+  the same distinction the Linux gui-x11 lane already draws. It is the Windows
+  twin of the Linux/macOS GUI-boot rigs.
+
+  CONTROL FRAME FIRST: before JLS, the rig launches
+  scripts\HelloSwingControl.java - a minimal JFrame on the same runtime and
+  window station - so every run separates the two failure modes by itself.
+  control up + JLS down means a JLS startup defect (exit 1); control down (or a
+  capture the control frame ALSO shows blank) means the environment is the
+  blocker (exit 2), and JLS is not blamed for it.
+
+  Exit status (the same contract as the Linux/macOS rigs):
+    0  a real JLS window mapped on the window station AND a non-blank
+       screenshot was captured (first light).
+    1  JLS-side failure: the control window mapped and its screenshot was
+       non-blank, but JLS did not (no window, crashed before mapping, or its
+       screenshot was blank).
+    2  environment/rig fault: even the minimal control window never mapped, the
+       control screenshot was blank, or a required tool is missing. Never
+       blamed on JLS.
+
+  GENUINE FIRST LIGHT (honest, not verifiable offline): this rig has NEVER run
+  on a real Windows runner - its first execution is on CI, and PowerShell is
+  not available in the authoring sandbox, so only the exit-code classification
+  was self-tested (scripts\windows-rig-selftest.ps1, via injected stubs). A
+  hosted non-interactive CI session MAY hand back a blank/desktop-only frame or
+  an empty MainWindowTitle if the process's window is not on the captured
+  station/desktop; either is classified as exit 2 (environment) via the
+  control-frame comparison, NEVER exit 1. If first light shows MainWindowHandle
+  detection is insufficient, the documented deeper fallbacks are a user32
+  EnumWindows title enumeration (Add-Type) and an in-JVM java.awt.Robot
+  self-capture. Every wait loop is bounded by a hard Stopwatch timeout, so a
+  withheld station degrades to a clean exit 2, never a hang.
+
+  NON-BLANK PROOF: window presence is polled from Get-Process MainWindowHandle
+  (authoritative for the launched process) with a MainWindowTitle-contains
+  fallback; the screenshot is a System.Drawing Graphics.CopyFromScreen of the
+  virtual screen; the non-blank gate counts distinct sampled colors in the same
+  script (a black/failed capture has 1 color, so >1 is the P1 gate, and the
+  control-frame comparison disambiguates a blank capture as environment).
+
+  PROMOTION: advisory `continue-on-error` -> required once 20 consecutive runs
+  show at most one failure (the #188/#101 rule the gui-wayland/gui-x11 lanes
+  followed), then drop continue-on-error and register the lane's exact `name:`
+  ("GUI boot (Windows, WindowStation)") as a required check with recorded run
+  IDs, mirroring installer-reproducibility-aarch64.
+
+.PARAMETER NoAutoRun
+  Dot-source the script for its functions without running the rig (used by the
+  selftest to inject stubs into Invoke-GuiBootRig).
+#>
+[CmdletBinding()]
+param(
+    [string]$ArtifactsDir = $(if ($env:ARTIFACTS_DIR) { $env:ARTIFACTS_DIR } else { 'artifacts\windows-rig' }),
+    [string]$Jar          = $env:JAR,
+    [string]$JavaExe      = $(if ($env:JAVA) { $env:JAVA } else { 'java' }),
+    [int]$ControlTimeout  = $(if ($env:CONTROL_TIMEOUT) { [int]$env:CONTROL_TIMEOUT } else { 60 }),
+    [int]$WindowTimeout   = $(if ($env:WINDOW_TIMEOUT)  { [int]$env:WINDOW_TIMEOUT }  else { 90 }),
+    [int]$RenderTimeout   = $(if ($env:RENDER_TIMEOUT)  { [int]$env:RENDER_TIMEOUT }  else { 30 }),
+    [switch]$NoAutoRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-RigLog { param([string]$Message) Write-Host "windows-rig: $Message" }
+
+# ----------------------------------------------------- real implementations
+# (each is passed into Invoke-GuiBootRig as a script block by the auto-run
+# block below; the selftest injects stubs in their place)
+
+function Start-JavaProcess {
+    param([string[]]$ArgList, [string]$OutLog, [string]$ErrLog)
+    return Start-Process -FilePath $script:JavaExe -ArgumentList $ArgList -PassThru `
+        -RedirectStandardOutput $OutLog -RedirectStandardError $ErrLog
+}
+
+# The production launch delegates, as TOP-LEVEL functions - deliberately NOT
+# .GetNewClosure() script blocks. A closure runs in a fresh dynamic-module scope
+# that captures variables but CANNOT see script-scope functions, so a closure
+# body calling Start-JavaProcess dies at runtime with "The term
+# 'Start-JavaProcess' is not recognized" - the exact Windows first-light failure
+# (#265 Stage 2, taxonomy entry ps-scope/error-misclassification): the selftest's
+# injected stubs replaced the launch path, so this production-only helper was
+# never exercised until CI. As named functions passed by ${function:...}
+# reference (exactly like Get-WindowCount/Save-Screenshot/Get-ColorCount below)
+# they run in the script session state and DO resolve Start-JavaProcess plus the
+# $script:-scoped inputs the auto-run block sets. The selftest OVERRIDES
+# Start-JavaProcess to probe this reachability without launching java, so it is
+# no longer defined only under stub injection.
+function Invoke-ControlLaunch {
+    Start-JavaProcess `
+        -ArgList @('-Djava.awt.headless=false', $script:ControlSrc) `
+        -OutLog (Join-Path $script:ArtifactsDir 'control-stdout.log') `
+        -ErrLog (Join-Path $script:ArtifactsDir 'control-stderr.log')
+}
+
+function Invoke-JlsLaunch {
+    Start-JavaProcess `
+        -ArgList @('-Djava.awt.headless=false', '-jar', $script:Jar) `
+        -OutLog (Join-Path $script:ArtifactsDir 'jls-stdout.log') `
+        -ErrLog (Join-Path $script:ArtifactsDir 'jls-stderr.log')
+}
+
+# Count top-level windows belonging to the launched process. Primary signal:
+# the process's own MainWindowHandle (authoritative). Fallback: any process
+# whose MainWindowTitle contains the expected title (JLS's is JLSInfo.version,
+# e.g. "JLS 5.0"; the control's is "HelloSwingControl"). A user32 EnumWindows
+# title enumeration is the documented deeper fallback if first light shows this
+# misses (some AWT frames are not registered as the process MainWindow).
+function Get-WindowCount {
+    param($Proc, [string]$TitleRegex)
+    $count = 0
+    try {
+        $p = Get-Process -Id $Proc.Id -ErrorAction SilentlyContinue
+        if ($p) {
+            $p.Refresh()
+            if ($p.MainWindowHandle -ne [IntPtr]::Zero) { $count++ }
+        }
+    } catch { }
+    if ($count -eq 0) {
+        try {
+            foreach ($p in Get-Process -ErrorAction SilentlyContinue) {
+                if ($p.MainWindowHandle -ne [IntPtr]::Zero -and
+                        $p.MainWindowTitle -and $p.MainWindowTitle -match $TitleRegex) {
+                    $count++
+                }
+            }
+        } catch { }
+    }
+    return $count
+}
+
+function Save-Screenshot {
+    param([string]$Path)
+    try {
+        Add-Type -AssemblyName System.Windows.Forms -ErrorAction Stop
+        Add-Type -AssemblyName System.Drawing -ErrorAction Stop
+        $bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen
+        $bmp = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
+        $gfx = [System.Drawing.Graphics]::FromImage($bmp)
+        $gfx.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+        $bmp.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+        $gfx.Dispose(); $bmp.Dispose()
+        return $true
+    } catch {
+        Write-RigLog "screenshot failed: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+# Distinct-color count over a sampled grid (capped). A solid/black frame has 1
+# color; any real captured frame has many, so >1 is the always-on non-blank /
+# not-a-failed-capture gate. Returns 0 on any error.
+function Get-ColorCount {
+    param([string]$Path)
+    try {
+        Add-Type -AssemblyName System.Drawing -ErrorAction Stop
+        $bmp = New-Object System.Drawing.Bitmap($Path)
+        $w = $bmp.Width; $h = $bmp.Height
+        if ($w -le 0 -or $h -le 0) { $bmp.Dispose(); return 0 }
+        $sx = [Math]::Max(1, [int]($w / 256)); $sy = [Math]::Max(1, [int]($h / 256))
+        $seen = New-Object 'System.Collections.Generic.HashSet[int]'
+        for ($y = 0; $y -lt $h; $y += $sy) {
+            for ($x = 0; $x -lt $w; $x += $sx) {
+                [void]$seen.Add($bmp.GetPixel($x, $y).ToArgb())
+                if ($seen.Count -ge 4096) { $bmp.Dispose(); return $seen.Count }
+            }
+        }
+        $bmp.Dispose()
+        return $seen.Count
+    } catch {
+        Write-RigLog "color count failed: $($_.Exception.Message)"
+        return 0
+    }
+}
+
+# ------------------------------------------------------------- wait helper
+# Polls $Probe for a mapped window up to $TimeoutSec, bounded by a Stopwatch so
+# it can never hang. Returns 0 (mapped), 1 (timeout), or 2 (process exited).
+function Wait-ForWindow {
+    param($Proc, [string]$TitleRegex, [int]$TimeoutSec, [scriptblock]$Probe)
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    while ($sw.Elapsed.TotalSeconds -lt $TimeoutSec) {
+        try { if ($Proc.HasExited) { return 2 } } catch { }
+        $n = & $Probe $Proc $TitleRegex
+        if ($n -gt 0) { $script:LastWindowCount = $n; return 0 }
+        Start-Sleep -Seconds 1
+    }
+    return 1
+}
+
+# ------------------------------------------------------------- core rig
+# The whole exit-code classification lives here, driven entirely through the
+# injected delegates so scripts\windows-rig-selftest.ps1 can exercise every
+# branch with no real GUI. Returns the process exit code (0/1/2).
+function Invoke-GuiBootRig {
+    param(
+        [string]$ArtifactsDir,
+        [scriptblock]$LaunchControl,
+        [scriptblock]$LaunchJls,
+        [scriptblock]$WindowProbe,
+        [scriptblock]$Capture,
+        [scriptblock]$ColorCount,
+        [int]$ControlTimeout = 60,
+        [int]$WindowTimeout = 90,
+        [int]$RenderTimeout = 30
+    )
+
+    New-Item -ItemType Directory -Force -Path $ArtifactsDir | Out-Null
+
+    # readiness / empty baseline: prove the station is screenshottable first. A
+    # capture delegate that THROWS (not just returns $false) is still an
+    # environment/rig fault, so classify it exit 2 rather than letting it escape.
+    try {
+        $ready = & $Capture (Join-Path $ArtifactsDir 'desktop-before.png')
+    } catch {
+        Write-RigLog "error: readiness capture threw ($($_.Exception.Message)); environment/rig fault, not JLS"
+        return 2
+    }
+    if (-not $ready) {
+        Write-RigLog 'error: could not screenshot the desktop (capture failed); environment/rig fault, not JLS'
+        return 2
+    }
+    Write-RigLog 'readiness gate passed: desktop screenshot OK'
+
+    $control = $null
+    $jls = $null
+    try {
+        # ---- control experiment ----
+        Write-RigLog 'launching HelloSwingControl (environment-blocker control)'
+        $control = & $LaunchControl
+        $cs = Wait-ForWindow $control 'HelloSwingControl' $ControlTimeout $WindowProbe
+        if ($cs -ne 0) {
+            $why = if ($cs -eq 2) { 'control process exited before mapping a window' }
+                   else { "no control window after ${ControlTimeout}s" }
+            Set-Content -Path (Join-Path $ArtifactsDir 'control-verdict.txt') -Value $why
+            Write-RigLog "error: $why; the blocker is the environment (window station/AWT), not JLS"
+            return 2
+        }
+        Set-Content -Path (Join-Path $ArtifactsDir 'control-verdict.txt') `
+            -Value "control window mapped ($script:LastWindowCount window(s))"
+
+        # the control window must also screenshot non-blank: a blank capture
+        # here means the station is not being captured (environment), and the
+        # control frame exhibiting it is what disambiguates it from a JLS-side
+        # blank window later.
+        [void](& $Capture (Join-Path $ArtifactsDir 'control.png'))
+        $cc = [int](& $ColorCount (Join-Path $ArtifactsDir 'control.png'))
+        Write-RigLog "control screenshot unique colors: $cc"
+        if ($cc -le 1) {
+            Write-RigLog "error: the control screenshot is blank ($cc unique color); the window station is not being captured - environment fault, not JLS"
+            return 2
+        }
+        Stop-ProcessSafe $control
+        $control = $null
+
+        # ---- launch the real jar ----
+        Write-RigLog 'launching JLS (real app entry point, jar Main-Class jls.JLS)'
+        $jls = & $LaunchJls
+        $js = Wait-ForWindow $jls 'JLS' $WindowTimeout $WindowProbe
+        if ($js -ne 0) {
+            $why = if ($js -eq 2) { 'JLS exited before mapping a window' }
+                   else { "no JLS window mapped after ${WindowTimeout}s" }
+            # control mapped + non-blank, JLS did not: JLS-side failure (exit 1)
+            Write-RigLog "error: $why (the control mapped and captured non-blank, so this is a JLS-side failure)"
+            return 1
+        }
+        Set-Content -Path (Join-Path $ArtifactsDir 'jls-window-info.txt') `
+            -Value "JLS windows mapped: $script:LastWindowCount"
+        Write-RigLog "JLS window is up ($script:LastWindowCount window(s))"
+
+        # ---- non-blank proof (P1) ----
+        # Swing shows the frame a beat before it paints; poll the screenshot
+        # until it has more than one unique color, up to RenderTimeout.
+        $jc = 0
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        do {
+            [void](& $Capture (Join-Path $ArtifactsDir 'jls-window.png'))
+            $jc = [int](& $ColorCount (Join-Path $ArtifactsDir 'jls-window.png'))
+            if ($jc -gt 1) { break }
+            Start-Sleep -Seconds 1
+        } while ($sw.Elapsed.TotalSeconds -lt $RenderTimeout)
+        Set-Content -Path (Join-Path $ArtifactsDir 'nonblank.txt') `
+            -Value @("control unique colors: $cc", "jls-window unique colors: $jc")
+        Write-RigLog "non-blank check: window=$jc colors"
+        if ($jc -le 1) {
+            # control captured non-blank moments ago, so capture works; a blank
+            # JLS capture now is a JLS-side failure (mapped but rendered nothing).
+            Write-RigLog "error: the JLS screenshot is blank ($jc unique color); the JLS window mapped but rendered nothing - JLS-side failure"
+            return 1
+        }
+
+        Write-RigLog 'first light: success'
+        return 0
+    }
+    catch {
+        # Any unexpected exception from a delegate or the classification body is
+        # an environment/rig fault, NOT a JLS-side failure: classify exit 2 with
+        # the message and stack rather than letting it escape as a bare pwsh
+        # error (which pwsh reports as exit 1 and would be mis-read as JLS-side).
+        Write-RigLog "unexpected rig fault (classified environment/exit 2): $($_.Exception.Message)"
+        if ($_.ScriptStackTrace) { Write-RigLog "stack: $($_.ScriptStackTrace)" }
+        return 2
+    }
+    finally {
+        Stop-ProcessSafe $jls
+        Stop-ProcessSafe $control
+    }
+}
+
+function Stop-ProcessSafe {
+    param($Proc)
+    if ($null -eq $Proc) { return }
+    try { if (-not $Proc.HasExited) { $Proc.Kill() } } catch { }
+}
+
+# ------------------------------------------------------------- auto-run
+# The ENTIRE entry point is wrapped so any unhandled script error classifies as
+# exit 2 (environment/rig fault) with its message and stack - never exit 1 and
+# never a bare pwsh failure. With Set-StrictMode + $ErrorActionPreference='Stop'
+# an uncaught error would otherwise terminate pwsh with exit 1, which the JLS
+# contract reserves for a JLS-side failure - the precise misclassification that
+# turned the Windows first-light rig bug red as if JLS had failed (#265 Stage 2).
+# The explicit `exit 2`/`exit $code` calls below terminate the process directly
+# and are NOT intercepted by the catch.
+if (-not $NoAutoRun) {
+    try {
+        if (-not (Get-Command $JavaExe -ErrorAction SilentlyContinue)) {
+            Write-RigLog "error: no java found (set JAVA= or add one to PATH)"
+            exit 2
+        }
+
+        $rigDir = Split-Path -Parent $PSCommandPath
+        # $script:-scoped so the top-level Invoke-ControlLaunch / Invoke-JlsLaunch
+        # functions (passed by reference into Invoke-GuiBootRig) can read them.
+        $script:ControlSrc = Join-Path $rigDir 'HelloSwingControl.java'
+        if (-not (Test-Path $script:ControlSrc)) {
+            Write-RigLog "error: control program missing: $script:ControlSrc"
+            exit 2
+        }
+
+        if (-not $Jar) {
+            $Jar = Get-ChildItem -Path 'target\jls-*.jar' -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending | Select-Object -First 1 -ExpandProperty FullName
+        }
+        if (-not $Jar -or -not (Test-Path $Jar)) {
+            Write-RigLog "error: no jar found; run 'mvn -DskipTests package' first or set JAR="
+            exit 2
+        }
+        $script:Jar = $Jar
+        $script:ArtifactsDir = $ArtifactsDir
+
+        New-Item -ItemType Directory -Force -Path $ArtifactsDir | Out-Null
+        Write-RigLog "artifacts: $ArtifactsDir"
+        Write-RigLog "jar:       $Jar"
+
+        # Launch helpers are passed by FUNCTION REFERENCE (${function:...}), not as
+        # .GetNewClosure() script blocks: a closure cannot resolve the script-scope
+        # Start-JavaProcess and dies "Start-JavaProcess is not recognized" (the
+        # Windows first-light bug). Function references run in the script session
+        # state, exactly like the probe/capture/color-count delegates.
+        $code = Invoke-GuiBootRig `
+            -ArtifactsDir $ArtifactsDir `
+            -LaunchControl ${function:Invoke-ControlLaunch} `
+            -LaunchJls ${function:Invoke-JlsLaunch} `
+            -WindowProbe ${function:Get-WindowCount} `
+            -Capture ${function:Save-Screenshot} `
+            -ColorCount ${function:Get-ColorCount} `
+            -ControlTimeout $ControlTimeout `
+            -WindowTimeout $WindowTimeout `
+            -RenderTimeout $RenderTimeout
+
+        exit $code
+    }
+    catch {
+        Write-RigLog "FATAL: unhandled rig/environment fault (classified exit 2, NOT a JLS-side failure): $($_.Exception.Message)"
+        if ($_.ScriptStackTrace) { Write-RigLog "stack: $($_.ScriptStackTrace)" }
+        exit 2
+    }
+}

--- a/test/jls/AutogradeBridgeExampleTest.java
+++ b/test/jls/AutogradeBridgeExampleTest.java
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
+import jls.hdl.ToolLocator;
+
 /**
  * CI wiring for the example autograde bridge (issue #216):
  * {@code examples/autograde/autograde.py} must grade the committed
@@ -32,7 +34,7 @@ class AutogradeBridgeExampleTest {
 
 	@Test
 	void bridgeExampleGradesTheFixtureGreen() throws Exception {
-		String python = findOnPath("python3");
+		String python = ToolLocator.findOnPath("python3");
 		Assumptions.assumeTrue(python != null,
 				"python3 not installed; skipping autograde bridge example");
 
@@ -71,29 +73,6 @@ class AutogradeBridgeExampleTest {
 				"autograde bridge failed:\n" + output);
 		assertTrue(output.contains("PASS"),
 				"bridge exited 0 without reporting PASS:\n" + output);
-	}
-
-	/** Locate a tool on PATH, or null (never installs anything). */
-	private static String findOnPath(String tool) {
-		String path = System.getenv("PATH");
-		if (path == null) {
-			return null;
-		}
-		for (String dir : path.split(File.pathSeparator)) {
-			if (dir.isEmpty()) {
-				continue;
-			}
-			Path candidate = Path.of(dir, tool);
-			try {
-				if (Files.isExecutable(candidate)
-						&& !Files.isDirectory(candidate)) {
-					return candidate.toString();
-				}
-			} catch (SecurityException ignored) {
-				// unreadable PATH entry: keep looking
-			}
-		}
-		return null;
 	}
 
 } // end of AutogradeBridgeExampleTest class

--- a/test/jls/HotkeysHelpAccuracyTest.java
+++ b/test/jls/HotkeysHelpAccuracyTest.java
@@ -1,5 +1,6 @@
 package jls;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -111,6 +112,18 @@ class HotkeysHelpAccuracyTest {
 	 * convention: modifier prefixes (ctrl-/shift-/alt-/meta-) then the
 	 * lower-cased key name, e.g. {@code ctrl-a}, {@code shift-r}, {@code w},
 	 * {@code delete}. Matches how hotkeys.html spells its Key column.
+	 *
+	 * <p>The key name is derived from the keystroke's VK code by
+	 * {@link #canonicalKeyName(int)}, never from
+	 * {@link KeyEvent#getKeyText(int)}: on macOS AWT renders a whole class of
+	 * keys as Unicode glyphs (VK_DELETE&#8594;&#x2326;,
+	 * VK_BACK_SPACE&#8594;&#x232B;, VK_ESCAPE&#8594;&#x238B;, arrows, home),
+	 * so getKeyText would make this comparison platform-dependent (issue #265,
+	 * macOS lane first-light finding). The modifier prefixes come from the
+	 * mask bits directly - never {@link KeyEvent#getKeyModifiersText(int)},
+	 * which macOS also renders as glyphs (&#x2318;&#x2325;&#x21E7;&#x2303;).
+	 * The result is folded through {@link #canonicalize(String)} so both sides
+	 * of the check meet in the same platform-independent space.
 	 */
 	private static String render(KeyStroke ks) {
 		StringBuilder sb = new StringBuilder();
@@ -129,22 +142,143 @@ class HotkeysHelpAccuracyTest {
 		if ((mods & InputEvent.META_DOWN_MASK) != 0) {
 			sb.append("meta-");
 		}
-		sb.append(KeyEvent.getKeyText(ks.getKeyCode())
-				.toLowerCase(java.util.Locale.ROOT));
-		return sb.toString();
+		sb.append(canonicalKeyName(ks.getKeyCode()));
+		return canonicalize(sb.toString());
+	}
+
+	/**
+	 * The canonical lowercase name of a key, derived from its
+	 * {@link KeyEvent} VK code and therefore identical on every platform -
+	 * unlike {@link KeyEvent#getKeyText(int)}, which on macOS returns Unicode
+	 * glyphs for the special keys (&#x2326; forward-delete, &#x232B;
+	 * backspace, &#x238B; escape, the arrow glyphs, &#x2196; home, …) and so
+	 * would silently desync this check from the ASCII names hotkeys.html
+	 * spells (issue #265). Letters and digits derive arithmetically from the
+	 * VK code ({@code VK_A == 'A'}); the special keys the editor can bind are
+	 * mapped explicitly to the same tokens {@link #GLYPHS} folds their macOS
+	 * glyphs to. A VK code with no canonical name fails loudly so a new
+	 * accelerator is given one here rather than reintroducing a
+	 * platform-dependent glyph render.
+	 *
+	 * @param keyCode a {@code KeyEvent.VK_*} code.
+	 * @return the platform-independent lowercase key name.
+	 */
+	private static String canonicalKeyName(int keyCode) {
+		if (keyCode >= KeyEvent.VK_A && keyCode <= KeyEvent.VK_Z) {
+			return String.valueOf((char) ('a' + (keyCode - KeyEvent.VK_A)));
+		}
+		if (keyCode >= KeyEvent.VK_0 && keyCode <= KeyEvent.VK_9) {
+			return String.valueOf((char) ('0' + (keyCode - KeyEvent.VK_0)));
+		}
+		if (keyCode >= KeyEvent.VK_F1 && keyCode <= KeyEvent.VK_F12) {
+			return "f" + (1 + (keyCode - KeyEvent.VK_F1));
+		}
+		switch (keyCode) {
+			case KeyEvent.VK_DELETE:
+				return "delete";
+			case KeyEvent.VK_BACK_SPACE:
+				return "backspace";
+			case KeyEvent.VK_ESCAPE:
+				return "escape";
+			case KeyEvent.VK_ENTER:
+				return "enter";
+			case KeyEvent.VK_SPACE:
+				return "space";
+			case KeyEvent.VK_TAB:
+				return "tab";
+			case KeyEvent.VK_LEFT:
+				return "left";
+			case KeyEvent.VK_RIGHT:
+				return "right";
+			case KeyEvent.VK_UP:
+				return "up";
+			case KeyEvent.VK_DOWN:
+				return "down";
+			case KeyEvent.VK_HOME:
+				return "home";
+			case KeyEvent.VK_END:
+				return "end";
+			case KeyEvent.VK_PAGE_UP:
+				return "page up";
+			case KeyEvent.VK_PAGE_DOWN:
+				return "page down";
+			case KeyEvent.VK_INSERT:
+				return "insert";
+			default:
+				throw new AssertionError("no canonical name for VK code "
+						+ keyCode + " (KeyEvent.getKeyText='"
+						+ KeyEvent.getKeyText(keyCode) + "'); add it to "
+						+ "canonicalKeyName so the help-vs-accelerator check "
+						+ "stays platform-independent");
+		}
+	}
+
+	/**
+	 * The Unicode glyphs macOS's AWT renders for keys and modifiers, mapped to
+	 * the canonical ASCII tokens hotkeys.html and {@link #canonicalKeyName}
+	 * use. Folding these (see {@link #canonicalize(String)}) means a glyph
+	 * that reaches the comparison - from rendered text on macOS, or from a
+	 * future glyph-bearing edit to the help page - is normalized instead of
+	 * mistaken for drift. The modifier glyphs (&#x2318; command,
+	 * &#x2325; option, &#x21E7; shift, &#x2303; control) are included so the
+	 * mac Cmd-vs-Ctrl menu-mask path (Toolkit.getMenuShortcutKeyMaskEx) cannot
+	 * cause the same class of drift on a later macOS run (issue #265 req 4).
+	 */
+	private static final Map<String, String> GLYPHS = glyphs();
+
+	private static Map<String, String> glyphs() {
+		Map<String, String> g = new LinkedHashMap<>();
+		g.put("⌦", "delete");     // ⌦ forward delete
+		g.put("⌫", "backspace");  // ⌫
+		g.put("⎋", "escape");     // ⎋
+		g.put("↩", "enter");      // ↩ return
+		g.put("⇥", "tab");        // ⇥
+		g.put("←", "left");       // ←
+		g.put("→", "right");      // →
+		g.put("↑", "up");         // ↑
+		g.put("↓", "down");       // ↓
+		g.put("↖", "home");       // ↖
+		g.put("↘", "end");        // ↘
+		g.put("⇞", "page up");    // ⇞
+		g.put("⇟", "page down");  // ⇟
+		g.put("⌘", "meta-");      // ⌘ command
+		g.put("⌥", "alt-");       // ⌥ option
+		g.put("⇧", "shift-");     // ⇧
+		g.put("⌃", "ctrl-");      // ⌃ control
+		return g;
+	}
+
+	/**
+	 * Fold any macOS key or modifier glyph to its canonical ASCII token and
+	 * lower-case, so the accelerator side and the parsed-help side of the
+	 * comparison meet in the same platform-independent space. Applied to both
+	 * {@link #render(KeyStroke)} output and each parsed help cell
+	 * ({@link #primaryToken(String)}); it is idempotent on text that is
+	 * already canonical.
+	 *
+	 * @param token a rendered accelerator or a parsed help key cell.
+	 * @return the canonical lowercase token.
+	 */
+	private static String canonicalize(String token) {
+		String t = token;
+		for (Map.Entry<String, String> e : GLYPHS.entrySet()) {
+			t = t.replace(e.getKey(), e.getValue());
+		}
+		return t.toLowerCase(java.util.Locale.ROOT);
 	}
 
 	/**
 	 * The primary key token of a help Key cell: the part before any
-	 * parenthetical note. The Redo cell reads
+	 * parenthetical note, canonicalized. The Redo cell reads
 	 * "ctrl-y (shift-cmd-z on macOS; cmd-y also works)"; its primary token
 	 * is "ctrl-y". Every other cell has no parenthetical, so this is a no-op
-	 * for them.
+	 * for them. Canonicalized via {@link #canonicalize(String)} so it shares
+	 * the accelerator side's normalization.
 	 */
 	private static String primaryToken(String keyCell) {
 		int paren = keyCell.indexOf('(');
 		String head = paren >= 0 ? keyCell.substring(0, paren) : keyCell;
-		return head.trim().toLowerCase(java.util.Locale.ROOT);
+		return canonicalize(head.trim());
 	}
 
 	/**
@@ -199,5 +333,51 @@ class HotkeysHelpAccuracyTest {
 		assertTrue(cells.containsKey("Move Caret / Following Element / Wire End "
 				+ "/ Selection"),
 				"the arrow-key row is missing from hotkeys.html");
+	}
+
+	/**
+	 * Headless pin for the macOS rendering class (issue #265, macOS lane
+	 * first-light finding). The accelerator side names keys from their VK code
+	 * via {@link #canonicalKeyName(int)}, so the Unicode glyphs macOS's
+	 * {@link KeyEvent#getKeyText(int)} returns for the special keys can never
+	 * reach the comparison. This asserts the VK codes that render as glyphs on
+	 * macOS - VK_DELETE ("⌦"), VK_BACK_SPACE ("⌫"), VK_ESCAPE ("⎋") - yield
+	 * their ASCII names on every platform. On the pre-fix code (which called
+	 * {@code getKeyText(VK_DELETE).toLowerCase()}) this returned "⌦" on macOS,
+	 * the exact drift that failed run 30315415693; canonicalKeyName is
+	 * glyph-free by construction, verifiable headlessly on Linux.
+	 */
+	@Test
+	void canonicalKeyNameIsGlyphFreeForTheMacRenderingClass() {
+		assertEquals("delete", canonicalKeyName(KeyEvent.VK_DELETE));
+		assertEquals("backspace", canonicalKeyName(KeyEvent.VK_BACK_SPACE));
+		assertEquals("escape", canonicalKeyName(KeyEvent.VK_ESCAPE));
+		// the letter/digit path that every ctrl-chord accelerator uses
+		assertEquals("a", canonicalKeyName(KeyEvent.VK_A));
+		assertEquals("z", canonicalKeyName(KeyEvent.VK_Z));
+	}
+
+	/**
+	 * Headless pin that the shared normalizer folds the exact glyph forms
+	 * macOS produces back to canonical ASCII (issue #265). Feeding the
+	 * normalizer the glyphs {@link KeyEvent#getKeyText(int)} /
+	 * {@link KeyEvent#getKeyModifiersText(int)} emit on macOS proves both
+	 * sides of the check would agree even if a glyph reached the comparison.
+	 * The pre-fix normalization was a bare {@code toLowerCase}, under which
+	 * "⌦" stays "⌦" (verified: {@code "⌦".toLowerCase() != "delete"}), so
+	 * this pin fails on the old code regardless of platform.
+	 */
+	@Test
+	void canonicalizeFoldsTheMacGlyphs() {
+		assertEquals("delete", canonicalize("⌦"));
+		assertEquals("backspace", canonicalize("⌫"));
+		assertEquals("escape", canonicalize("⎋"));
+		// modifier glyphs, hardening the Cmd/Ctrl menu-mask path (req 4)
+		assertEquals("meta-", canonicalize("⌘"));
+		assertEquals("alt-", canonicalize("⌥"));
+		assertEquals("shift-", canonicalize("⇧"));
+		assertEquals("ctrl-", canonicalize("⌃"));
+		// a full macOS-style rendered chord folds to the help spelling
+		assertEquals("meta-delete", canonicalize("⌘⌦"));
 	}
 }

--- a/test/jls/hdl/GhdlCompileTest.java
+++ b/test/jls/hdl/GhdlCompileTest.java
@@ -2,7 +2,6 @@ package jls.hdl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -32,7 +31,7 @@ class GhdlCompileTest {
 
 	@Test
 	void everyGoldenAnalyzesUnderGhdl() throws Exception {
-		String ghdl = findOnPath("ghdl");
+		String ghdl = ToolLocator.findOnPath("ghdl");
 		Assumptions.assumeTrue(ghdl != null,
 				"ghdl not installed; skipping external analyze check");
 
@@ -65,29 +64,6 @@ class GhdlCompileTest {
 			assertEquals(0, p.exitValue(),
 					golden + " does not analyze under ghdl:\n" + output);
 		}
-	}
-
-	/** Locate a tool on PATH, or null (never installs anything). */
-	private static String findOnPath(String tool) {
-		String path = System.getenv("PATH");
-		if (path == null) {
-			return null;
-		}
-		for (String dir : path.split(File.pathSeparator)) {
-			if (dir.isEmpty()) {
-				continue;
-			}
-			Path candidate = Path.of(dir, tool);
-			try {
-				if (Files.isExecutable(candidate)
-						&& !Files.isDirectory(candidate)) {
-					return candidate.toString();
-				}
-			} catch (SecurityException ignored) {
-				// unreadable PATH entry: keep looking
-			}
-		}
-		return null;
 	}
 
 } // end of GhdlCompileTest class

--- a/test/jls/hdl/IverilogCompileTest.java
+++ b/test/jls/hdl/IverilogCompileTest.java
@@ -2,7 +2,6 @@ package jls.hdl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -31,7 +30,7 @@ class IverilogCompileTest {
 
 	@Test
 	void everyGoldenCompilesUnderIverilog() throws Exception {
-		String iverilog = findOnPath("iverilog");
+		String iverilog = ToolLocator.findOnPath("iverilog");
 		Assumptions.assumeTrue(iverilog != null,
 				"iverilog not installed; skipping external compile check");
 
@@ -71,29 +70,6 @@ class IverilogCompileTest {
 			assertEquals(0, p.exitValue(),
 					golden + " does not compile under iverilog:\n" + output);
 		}
-	}
-
-	/** Locate a tool on PATH, or null (never installs anything). */
-	private static String findOnPath(String tool) {
-		String path = System.getenv("PATH");
-		if (path == null) {
-			return null;
-		}
-		for (String dir : path.split(File.pathSeparator)) {
-			if (dir.isEmpty()) {
-				continue;
-			}
-			Path candidate = Path.of(dir, tool);
-			try {
-				if (Files.isExecutable(candidate)
-						&& !Files.isDirectory(candidate)) {
-					return candidate.toString();
-				}
-			} catch (SecurityException ignored) {
-				// unreadable PATH entry: keep looking
-			}
-		}
-		return null;
 	}
 
 } // end of IverilogCompileTest class

--- a/test/jls/hdl/ToolLocator.java
+++ b/test/jls/hdl/ToolLocator.java
@@ -1,0 +1,190 @@
+package jls.hdl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Shared, cross-platform {@code PATH} lookup for the external HDL
+ * toolchain the golden tests shell out to (issues #60/#61/#63/#111).
+ *
+ * <p>Previously five test classes ({@code IverilogCompileTest},
+ * {@code GhdlCompileTest}, {@code YosysGroundTruthTest},
+ * {@code ImportPipelineTest}, {@code AutogradeBridgeExampleTest})
+ * each carried a copy of a {@code findOnPath} helper that built
+ * {@code Path.of(dir, tool)} and tested {@link Files#isExecutable}
+ * with <em>no</em> {@code .exe} suffix and <em>no</em> {@code PATHEXT}
+ * handling. On Windows that never resolves {@code iverilog.exe} /
+ * {@code ghdl.exe} / {@code yosys.exe}, so even with the
+ * {@code oss-cad-suite} bundle on {@code PATH} every HDL-simulator
+ * suite silently {@code assumeTrue}-skips (issue #111 Stage W2
+ * blocker). This class is the one shared locator that fixes them all.
+ *
+ * <p>Windows resolution semantics: the bare name is tried first (which
+ * covers unix, and Windows files that already carry an explicit
+ * extension), then each extension from {@code PATHEXT} — defaulting to
+ * {@code .COM;.EXE;.BAT;.CMD} when unset — is appended, matched
+ * <em>case-insensitively</em>. The case-insensitive match is done by
+ * scanning the directory rather than by re-probing a constructed path,
+ * so a {@code .EXE} entry in {@code PATHEXT} resolves a lowercase
+ * {@code iverilog.exe} even on a case-sensitive filesystem — which is
+ * what lets the Linux unit tests assert Windows-style resolution
+ * headlessly.
+ *
+ * <p>{@link #find(String, String, String)} takes the {@code PATH} and
+ * {@code PATHEXT} strings as parameters (seam injection) so tests drive
+ * it against temp directories without touching the real environment;
+ * the {@link #findOnPath(String)} convenience passes the real
+ * {@code System.getenv} values for the production call sites.
+ */
+public final class ToolLocator {
+
+	/** Windows' documented default when {@code PATHEXT} is unset. */
+	private static final String DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+	/** No instances; the class is a lookup function. */
+	private ToolLocator() {
+
+	} // end of constructor
+
+	/**
+	 * Locates a tool on the process {@code PATH}, honoring
+	 * {@code PATHEXT} on Windows, or returns {@code null}. Never
+	 * installs anything; the production (non-unit-test) call sites use
+	 * this form.
+	 *
+	 * @param tool The bare tool name, e.g. {@code "iverilog"}.
+	 *
+	 * @return the absolute path of the first match as a string, or
+	 * {@code null} when the tool is not found.
+	 */
+	public static String findOnPath(String tool) {
+
+		return find(tool, System.getenv("PATH"), System.getenv("PATHEXT"))
+				.map(Path::toString)
+				.orElse(null);
+	} // end of findOnPath method
+
+	/**
+	 * Searches an explicit {@code PATH} for a tool, applying Windows
+	 * {@code PATHEXT} resolution. Split out from
+	 * {@link #findOnPath(String)} so tests exercise the search against
+	 * temp directories without touching the real environment.
+	 *
+	 * @param tool The bare tool name, e.g. {@code "iverilog"}; a name
+	 * that already carries an extension is matched by the bare-name
+	 * probe.
+	 *
+	 * @param path A {@code PATH}-style list of directories separated by
+	 * {@link File#pathSeparator}; {@code null} finds nothing.
+	 *
+	 * @param pathext A {@code PATHEXT}-style {@code ;}-separated list of
+	 * executable extensions; {@code null} or blank uses the Windows
+	 * default {@code .COM;.EXE;.BAT;.CMD}.
+	 *
+	 * @return the first executable regular file matching the tool name
+	 * or one of its {@code PATHEXT} variants, or empty.
+	 */
+	public static Optional<Path> find(String tool, String path,
+			String pathext) {
+
+		if (tool == null || path == null) {
+			return Optional.empty();
+		}
+		List<String> names = candidateNames(tool, pathext);
+		for (String dir : path.split(File.pathSeparator)) {
+			if (dir.isEmpty()) {
+				continue;
+			}
+			Optional<Path> hit = findInDir(dir, names);
+			if (hit.isPresent()) {
+				return hit;
+			}
+		}
+		return Optional.empty();
+	} // end of find method
+
+	/**
+	 * Builds the ordered list of names to accept: the bare name first,
+	 * then the bare name with each {@code PATHEXT} extension appended.
+	 *
+	 * @param tool The bare tool name.
+	 *
+	 * @param pathext The raw {@code PATHEXT} value, or null/blank.
+	 *
+	 * @return the priority-ordered acceptable names.
+	 */
+	private static List<String> candidateNames(String tool, String pathext) {
+
+		List<String> names = new ArrayList<>();
+		names.add(tool);
+		String raw = (pathext == null || pathext.isBlank())
+				? DEFAULT_PATHEXT : pathext;
+		for (String ext : raw.split(";")) {
+			String trimmed = ext.trim();
+			if (!trimmed.isEmpty()) {
+				names.add(tool + trimmed);
+			}
+		}
+		return names;
+	} // end of candidateNames method
+
+	/**
+	 * Scans one {@code PATH} directory for the first acceptable name,
+	 * matching case-insensitively so Windows-style {@code .EXE}
+	 * resolves a lowercase file on a case-sensitive filesystem too.
+	 *
+	 * @param dir The directory to scan.
+	 *
+	 * @param names The priority-ordered acceptable names.
+	 *
+	 * @return the first executable regular file that matches, or empty.
+	 */
+	private static Optional<Path> findInDir(String dir, List<String> names) {
+
+		Path dirPath;
+		try {
+			dirPath = Path.of(dir);
+		} catch (InvalidPathException e) {
+			// junk PATH entry; a shell would skip it too
+			return Optional.empty();
+		}
+		if (!Files.isDirectory(dirPath)) {
+			return Optional.empty();
+		}
+		List<Path> entries = new ArrayList<>();
+		try (DirectoryStream<Path> stream =
+				Files.newDirectoryStream(dirPath)) {
+			for (Path entry : stream) {
+				entries.add(entry);
+			}
+		} catch (IOException | SecurityException e) {
+			// unreadable directory; keep looking on the next PATH entry
+			return Optional.empty();
+		}
+		for (String name : names) {
+			for (Path entry : entries) {
+				if (!entry.getFileName().toString()
+						.equalsIgnoreCase(name)) {
+					continue;
+				}
+				try {
+					if (Files.isExecutable(entry)
+							&& !Files.isDirectory(entry)) {
+						return Optional.of(entry);
+					}
+				} catch (SecurityException ignored) {
+					// unreadable entry; keep looking
+				}
+			}
+		}
+		return Optional.empty();
+	} // end of findInDir method
+
+} // end of ToolLocator class

--- a/test/jls/hdl/ToolLocatorTest.java
+++ b/test/jls/hdl/ToolLocatorTest.java
@@ -1,0 +1,161 @@
+package jls.hdl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Headless, cross-platform coverage of {@link ToolLocator} (issue
+ * #111 Stage W2). These run on Linux by construction: the
+ * {@code PATH}/{@code PATHEXT} seam is injected, so Windows-style
+ * {@code .exe}/{@code PATHEXT} resolution is asserted without a
+ * Windows runner — a real fixture file {@code iverilog.exe} in a temp
+ * directory is resolved via a {@code PATHEXT} that names {@code .EXE}.
+ */
+class ToolLocatorTest {
+
+	@Test
+	void unixFindsTheBareName(@TempDir Path dir) throws Exception {
+		Path tool = dir.resolve("iverilog");
+		writeExecutable(tool);
+
+		Optional<Path> found = ToolLocator.find("iverilog",
+				dir.toString(), null);
+		assertTrue(found.isPresent(), "bare name should resolve");
+		assertEquals(tool.getFileName(), found.get().getFileName());
+	}
+
+	@Test
+	void windowsStyleFindsDotExeViaPathext(@TempDir Path dir)
+			throws Exception {
+		// A lowercase .exe fixture resolved through an uppercase .EXE
+		// PATHEXT entry: the case-insensitive directory scan is what
+		// makes this pass on a case-sensitive Linux filesystem.
+		Path tool = dir.resolve("iverilog.exe");
+		writeExecutable(tool);
+
+		Optional<Path> found = ToolLocator.find("iverilog",
+				dir.toString(), ".COM;.EXE;.BAT;.CMD");
+		assertTrue(found.isPresent(),
+				".exe should resolve via PATHEXT");
+		assertEquals("iverilog.exe",
+				found.get().getFileName().toString());
+	}
+
+	@Test
+	void windowsDefaultPathextIsUsedWhenUnset(@TempDir Path dir)
+			throws Exception {
+		// PATHEXT null => the .COM;.EXE;.BAT;.CMD default arms .EXE.
+		Path tool = dir.resolve("yosys.exe");
+		writeExecutable(tool);
+
+		Optional<Path> found = ToolLocator.find("yosys",
+				dir.toString(), null);
+		assertTrue(found.isPresent(),
+				"default PATHEXT should include .EXE");
+		assertEquals("yosys.exe",
+				found.get().getFileName().toString());
+	}
+
+	@Test
+	void theBareNameWinsOverAnExtensionVariant(@TempDir Path dir)
+			throws Exception {
+		Path bare = dir.resolve("ghdl");
+		writeExecutable(bare);
+		Path exe = dir.resolve("ghdl.exe");
+		writeExecutable(exe);
+
+		Optional<Path> found = ToolLocator.find("ghdl",
+				dir.toString(), ".EXE");
+		assertTrue(found.isPresent());
+		assertEquals("ghdl", found.get().getFileName().toString(),
+				"bare name has priority over PATHEXT variants");
+	}
+
+	@Test
+	void earlierPathEntryWins(@TempDir Path first, @TempDir Path second)
+			throws Exception {
+		Path winner = first.resolve("iverilog.exe");
+		writeExecutable(winner);
+		Path decoy = second.resolve("iverilog.exe");
+		writeExecutable(decoy);
+
+		String path = first + File.pathSeparator + second;
+		Optional<Path> found = ToolLocator.find("iverilog", path, null);
+		assertTrue(found.isPresent());
+		assertEquals(winner.toAbsolutePath(),
+				found.get().toAbsolutePath());
+	}
+
+	@Test
+	void notFoundReturnsEmpty(@TempDir Path empty) {
+		assertTrue(ToolLocator.find("iverilog", empty.toString(), null)
+				.isEmpty(), "empty directory finds nothing");
+		assertTrue(ToolLocator.find("iverilog", null, null).isEmpty(),
+				"null PATH finds nothing");
+		assertTrue(ToolLocator.find(null, empty.toString(), null)
+				.isEmpty(), "null tool finds nothing");
+		assertTrue(ToolLocator.find("iverilog", "", null).isEmpty(),
+				"empty PATH finds nothing");
+	}
+
+	@Test
+	void aDirectoryNamedLikeTheToolIsNotABinary(@TempDir Path dir)
+			throws Exception {
+		Files.createDirectory(dir.resolve("iverilog.exe"));
+
+		assertTrue(ToolLocator.find("iverilog", dir.toString(), null)
+				.isEmpty(), "a directory is never a match");
+	}
+
+	@Test
+	void aNonExecutableFileIsSkipped(@TempDir Path dir) throws Exception {
+		Path plain = dir.resolve("iverilog.exe");
+		Files.writeString(plain, "not a program");
+		plain.toFile().setExecutable(false, false);
+		// under some accounts (root) everything is executable; the
+		// premise of this test then cannot be established
+		assumeTrue(!Files.isExecutable(plain),
+				"cannot make a non-executable file on this account");
+
+		assertTrue(ToolLocator.find("iverilog", dir.toString(), null)
+				.isEmpty(), "non-executable file is not a match");
+	}
+
+	@Test
+	void junkPathEntriesAreSkipped(@TempDir Path dir) throws Exception {
+		Path tool = dir.resolve("iverilog.exe");
+		writeExecutable(tool);
+
+		String path = "" + File.pathSeparator
+				+ "/nonexistent-dir" + File.pathSeparator
+				+ dir;
+		Optional<Path> found = ToolLocator.find("iverilog", path, null);
+		assertTrue(found.isPresent(),
+				"empty and missing entries are skipped, real one wins");
+	}
+
+	/**
+	 * Writes a fixture and marks it executable, skipping the test if
+	 * the platform refuses to set the bit.
+	 *
+	 * @param file The fixture to create.
+	 *
+	 * @throws Exception on write failure.
+	 */
+	private static void writeExecutable(Path file) throws Exception {
+		Files.writeString(file, "#!/bin/sh\n");
+		assumeTrue(file.toFile().setExecutable(true, false)
+				|| Files.isExecutable(file),
+				"cannot mark fixtures executable on this platform");
+	}
+
+} // end of ToolLocatorTest class

--- a/test/jls/hdl/imp/ImportPipelineTest.java
+++ b/test/jls/hdl/imp/ImportPipelineTest.java
@@ -3,7 +3,6 @@ package jls.hdl.imp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import jls.Circuit;
 import jls.JLSInfo;
+import jls.hdl.ToolLocator;
 import jls.hdl.yosys.CellValidator;
 import jls.hdl.yosys.CellViolation;
 import jls.hdl.yosys.YosysNetlist;
@@ -85,7 +85,7 @@ class ImportPipelineTest {
 	 * @return the yosys executable path.
 	 */
 	private static String requireYosys() {
-		String yosys = findOnPath("yosys");
+		String yosys = ToolLocator.findOnPath("yosys");
 		Assumptions.assumeTrue(yosys != null,
 				"yosys not installed; skipping the end-to-end import leg");
 		return yosys;
@@ -124,28 +124,5 @@ class ImportPipelineTest {
 				verilog + " pipeline failed:\n" + log);
 		return YosysNetlist.parse(Files.readString(out));
 	} // end of runPipeline method
-
-	/** Locate a tool on PATH, or null (never installs anything). */
-	private static String findOnPath(String tool) {
-		String path = System.getenv("PATH");
-		if (path == null) {
-			return null;
-		}
-		for (String dir : path.split(File.pathSeparator)) {
-			if (dir.isEmpty()) {
-				continue;
-			}
-			Path candidate = Path.of(dir, tool);
-			try {
-				if (Files.isExecutable(candidate)
-						&& !Files.isDirectory(candidate)) {
-					return candidate.toString();
-				}
-			} catch (SecurityException ignored) {
-				// unreadable PATH entry: keep looking
-			}
-		}
-		return null;
-	} // end of findOnPath method
 
 } // end of ImportPipelineTest class

--- a/test/jls/hdl/scan/YosysGroundTruthTest.java
+++ b/test/jls/hdl/scan/YosysGroundTruthTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -19,6 +18,8 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import jls.hdl.ToolLocator;
 
 /**
  * Issue #63 P2: ports scanned by {@link VerilogHeaderScanner} from the
@@ -39,7 +40,7 @@ class YosysGroundTruthTest {
 
 	@Test
 	void scannedPortsMatchYosysWriteJson() throws Exception {
-		String yosys = findOnPath("yosys");
+		String yosys = ToolLocator.findOnPath("yosys");
 		Assumptions.assumeTrue(yosys != null,
 				"yosys not installed; skipping ground-truth check");
 
@@ -139,29 +140,6 @@ class YosysGroundTruthTest {
 			return "inout";
 		}
 	} // end of directionWord method
-
-	/** Locate a tool on PATH, or null (never installs anything). */
-	private static String findOnPath(String tool) {
-		String path = System.getenv("PATH");
-		if (path == null) {
-			return null;
-		}
-		for (String dir : path.split(File.pathSeparator)) {
-			if (dir.isEmpty()) {
-				continue;
-			}
-			Path candidate = Path.of(dir, tool);
-			try {
-				if (Files.isExecutable(candidate)
-						&& !Files.isDirectory(candidate)) {
-					return candidate.toString();
-				}
-			} catch (SecurityException ignored) {
-				// unreadable PATH entry: keep looking
-			}
-		}
-		return null;
-	} // end of findOnPath method
 
 	/**
 	 * A minimal recursive-descent JSON reader, just enough for yosys


### PR DESCRIPTION
## What

This branch expands from a single macOS-lane change into the first
executable slice of **multi-platform CI parity**, and folds in the
**promotion + rename of the two GUI boot lanes to hard gates**. It spans
three trackers: the macOS program tracker (#265), the reopened Windows-side
tracker (#111), and the GUI-boot promotion tracker (#101) — plus a maintainer
directive that every CI lane name state its OS family so the checks list reads
uniformly, and — completing #265 Stage 9 / #111 Stage W7 — a per-OS GUI
app-boot smoke rig for macOS and Windows plus an advisory Windows installer
build lane. Twelve concerns, in `.github/workflows/ci.yml`, the HDL test tree,
`README.md`, and four new rig scripts (`scripts/macos-rig.sh`,
`scripts/windows-rig.ps1`, and their selftests) — no product-source change:

1. **Advisory macOS headless test lane** (#265 Stage 1) — a `macos` job on
   `macos-latest` mirroring the `windows` lane (JDK 25 temurin, `cache:
   maven`, `mvn -B verify -Djacoco.skip=true`, `continue-on-error: true`,
   byte-stable `name: Build (macOS, JDK 25)`).
2. **macOS glyph canonicalization fix** — the first-light failure the new
   lane caught on run 1 (`HotkeysHelpAccuracyTest`), fixed at the class.
3. **A cross-platform `PATHEXT`/`.exe`-aware tool locator** (#111 Stage W2
   blocker) — one shared `jls.hdl.ToolLocator`, replacing five copies of a
   Windows-blind `findOnPath`, with headless unit tests.
4. **HDL toolchain armed on the Windows job** (#111 Stage W2) — a
   version-pinned `oss-cad-suite` install with a fail-open fallback.
5. **HDL toolchain armed on the macOS job** (#265 Stage 4) — `brew install
   icarus-verilog ghdl yosys` with the same fail-open fallback.
6. **Display suite armed first-light on the Windows job** (#111 Stage W3,
   pulled forward as advisory first light) — `-Djls.test.headless=false` on
   the Windows `mvn` command drives the `@Tag("display")` suite on the
   runner's real interactive window station.
7. **Advisory JDK-26 leg on the Windows job** (#111 Stage W5) — the Windows
   lane becomes a `java: [25, 26]` matrix exactly mirroring the Linux `build`
   job, the JDK-25 leg keeping its byte-stable check name.
8. **Promote + rename the GUI boot lanes to hard gates** (#101) — drop
   `continue-on-error` from `gui-wayland`/`gui-x11` on a 20/20 green record
   and rename them out of their experimental "first light" identity to
   `GUI boot (Linux, Wayland/JBR)` / `GUI boot (Linux, X11/Xvfb)`.
9. **OS-family labeling sweep** (maintainer directive) — every `ci.yml` lane
   name now states its OS family so the checks list reads uniformly; the five
   unlabeled Linux lanes are renamed (`Build (Linux, JDK …)`, `Verify Agda
   proofs (Linux)`, the two `GUI boot (Linux, …)` names above, `Reproducible
   build check (Linux)`). Two of these are required contexts, so the ruleset
   swaps in lockstep — see §8's checklist.
10. **macOS GUI app-boot smoke rig** (#265 Stage 9) — a new `macos-gui` lane on
    `macos-latest` that boots the real shaded jar and proves the app window
    maps + screenshots non-blank, following the Linux `gui-x11`/`gui-wayland`
    rig template (control-frame-first exit-code contract, per-run self-test).
11. **Windows GUI app-boot smoke rig** (#111 Stage W7) — the symmetric
    `windows-gui` lane (`shell: pwsh`) on `windows-latest`, same rig contract.
12. **Advisory Windows installer build lane** (#111/#190) — a `windows-installer-msi`
    lane that runs the SAME `jpackage --type msi` invocation the release/probe
    path uses and asserts the msi builds; explicitly build-smoke only, NOT
    reproducibility-checked.

References: **Advances #265** AND **Advances #111** AND **Advances #101**
(never *Closes* — all three are multi-stage trackers). This lands macOS
Stage 1 + the macOS glyph fix + the shared W2/Stage-4 toolchain arming +
Windows Stages W3/W5 + **#265 Stage 9 / #111 Stage W7** (the per-OS app-boot
rigs) + the advisory Windows msi build lane, and the **workflow half** of #101
promotion (registration of the two new required-check names + the
findings-publication remain — see §8).

### Concerns at a glance

| # | Concern | Tracker |
|---|---------|---------|
| 1 | Advisory macOS headless test lane | #265 Stage 1 |
| 2 | macOS glyph canonicalization fix | #265 (run-1 finding) |
| 3 | Cross-platform `PATHEXT`/`.exe` tool locator | #111 Stage W2 |
| 4 | HDL toolchain armed on Windows | #111 Stage W2 |
| 5 | HDL toolchain armed on macOS | #265 Stage 4 |
| 6 | Display suite first-light on Windows | #111 Stage W3 |
| 7 | Advisory JDK-26 leg on Windows | #111 Stage W5 |
| 8 | Promote + rename GUI boot lanes to hard gates | #101 |
| 9 | OS-family labeling sweep of every `ci.yml` lane name | maintainer directive |
| 10 | macOS GUI app-boot smoke rig | #265 Stage 9 |
| 11 | Windows GUI app-boot smoke rig | #111 Stage W7 |
| 12 | Advisory Windows installer (msi) build lane | #111 / #190 |
| 13 | First-light failures fixed (run 30322375242) | #265 Stage 2 / Stage 9, #111 |

---

## 1. Advisory macOS headless test lane (#265 Stage 1)

Adds a `macos` job that runs the headless `mvn -B verify -Djacoco.skip=true`
on `macos-latest` under JDK 25 (temurin, `cache: maven`), advisory
`continue-on-error: true`, with a byte-stable `name:` ("Build (macOS, JDK
25)"). It mirrors the existing `windows` lane one-for-one, adapted to macOS.

**Why.** Today the `mvn verify` suite only runs to completion on Linux. The
one prior `macos-latest` job (`macos-installer-reproducibility`) is
dmg-packaging-only — `-DskipTests package`, never a single test — so
macOS-specific behaviour is unverified: the case-*insensitive* default
filesystem, a window server that changes AWT/`HeadlessException` behaviour,
the BSD `shasum` toolchain, resource-fork/`.DS_Store` noise. The Windows lane
(#111) exists precisely because three Windows-only defects shipped when no
Windows leg ran the suite. This lane closes the same parity gap for macOS.
The repo is public, so `macos-latest` runners are billed at zero (the 10x
macOS multiplier applies only to private repos).

---

## 2. macOS glyph canonicalization fix (first-light finding, macOS run 1)

The lane earned its keep on its very first run (30315415693): one real,
macOS-only test failure, exactly the parity gap #265 exists to surface.

**The failure.** `HotkeysHelpAccuracyTest.documentedKeysMatchTheEditOpAccelerators`:

```
hotkeys.html has drifted from the editor's accelerators:
  "Delete": help says 'delete' but DELETE binds '⌦'
```

**The diagnosis.** The binding is *correct*; the test was platform-dependent.
It rendered the accelerator's key name through `KeyEvent.getKeyText(VK_DELETE)`,
which returns the ASCII `"Delete"` on Linux/Windows but the Unicode glyph
`⌦` (U+2326, forward-delete) on macOS — where AWT renders a whole class of
keys as glyphs (`⌫` backspace, `⎋` escape, arrow glyphs, `↖` home) and
modifiers via `getKeyModifiersText` as `⌘⌥⇧⌃`. So the accelerator side spelled
`⌦` while the help page spells `delete`, and the two could never agree on
macOS. The assertion collects **all** drifts (fail-slow), so run 1 flagging
only `Delete` — not the `ctrl-*` chords — confirms the modifier path was
already safe: those prefixes come from explicit `*_DOWN_MASK` bit checks, and
the accelerator is computed for `os="Linux"`, never from
`Toolkit.getMenuShortcutKeyMaskEx`. Only `getKeyText` reads the runtime OS.

**The class-level fix (source, not muting).** Per #265's burn-in rule — no
`assumeTrue`-on-OS, no macOS special-case for `VK_DELETE`:

- The accelerator side now names keys from their **VK code** via a new
  `canonicalKeyName(int)` (letters/digits derive arithmetically from the VK
  code, the glyph-class special keys are mapped explicitly), so
  `getKeyText`/`getKeyModifiersText` glyphs can never reach the comparison.
  An unmapped VK code fails loudly rather than reintroducing a glyph render.
- A shared `canonicalize(String)` folds every macOS glyph (keys **and**
  modifiers `⌘⌥⇧⌃`) back to its ASCII token, and **both** sides — the rendered
  accelerator and each parsed help cell — pass through it, so they meet in one
  platform-independent space. The modifier glyphs are folded now, pre-emptively
  hardening the Cmd-vs-Ctrl menu-mask path before a later macOS run can hit it.
- The test keeps its teeth: the canonical name still comes from the
  accelerator's real VK code + modifiers, and the help side is still parsed
  from the real `hotkeys.html`, so genuine drift still fails.

**The headless pin.** Two new regression tests, verifiable on Linux by
construction: `canonicalKeyNameIsGlyphFreeForTheMacRenderingClass` pins the
VK-derived names for `VK_DELETE`/`VK_BACK_SPACE`/`VK_ESCAPE` (the pre-fix
`getKeyText(VK_DELETE).toLowerCase()` returned `⌦` on macOS — the exact run-1
drift), and `canonicalizeFoldsTheMacGlyphs` feeds the normalizer the literal
macOS glyphs and asserts the ASCII fold. The latter fails on the old code on
**any** platform: its normalization was a bare `toLowerCase`, under which
`"⌦".toLowerCase()` stays `⌦ != "delete"`.

Scope of this fix: `test/jls/HotkeysHelpAccuracyTest.java` only.

---

## 3. Cross-platform `PATHEXT`/`.exe`-aware tool locator (#111 Stage W2 blocker)

**The blocker #111 Stage W2 names.** `IverilogCompileTest` and
`GhdlCompileTest` located their simulator with a `findOnPath` that built
`Path.of(dir, "iverilog")` and tested `Files.isExecutable` — **no `.exe`
suffix, no `PATHEXT`**. On Windows that never resolves `iverilog.exe` /
`ghdl.exe` / `yosys.exe`, so even with `oss-cad-suite` on `PATH` every
HDL-simulator suite would silently `assumeTrue`-skip and the toolchain-arming
work would prove nothing. A grep of the whole test tree found the **same
idiom copy-pasted five times**:

- `test/jls/hdl/IverilogCompileTest.java`
- `test/jls/hdl/GhdlCompileTest.java`
- `test/jls/hdl/scan/YosysGroundTruthTest.java` (yosys)
- `test/jls/hdl/imp/ImportPipelineTest.java` (yosys)
- `test/jls/AutogradeBridgeExampleTest.java` (python3)

**The fix — one shared helper.** New `test/jls/hdl/ToolLocator.java` replaces
all five copies. Correct Windows semantics: try the **bare name first**
(covers unix, and Windows files that already carry an explicit extension),
then each extension from **`PATHEXT`** — defaulting to `.COM;.EXE;.BAT;.CMD`
when unset — appended and matched **case-insensitively**. Crucially the
case-insensitive match is done by *scanning the directory* rather than
re-probing a constructed path, so a `.EXE` entry in `PATHEXT` resolves a
lowercase `iverilog.exe` even on a case-sensitive filesystem — which is what
lets the Linux unit tests assert Windows-style resolution headlessly.

**Seam injection.** `ToolLocator.find(tool, path, pathext)` takes the `PATH`
and `PATHEXT` strings as parameters, so tests drive it against temp
directories with no environment mutation; the `findOnPath(tool)` convenience
passes the real `System.getenv("PATH")`/`getenv("PATHEXT")` for the
production call sites. (This is deliberately the *test-tree* locator; the
production `jls.hdl.yosys.YosysLocator` already special-cases `yosys.exe`
and is out of this PR's scope.)

**Headless unit tests** — new `test/jls/hdl/ToolLocatorTest.java`, 9 tests,
running green on Linux by construction, both directions:

- **unix finds the bare name** (`iverilog` fixture, null `PATHEXT`);
- **windows-style finds `.exe` via `PATHEXT`** (a lowercase `iverilog.exe`
  fixture resolved through an uppercase `.EXE` entry — the case-insensitive
  scan is what makes this pass on Linux), plus the **default `PATHEXT`** path
  when unset;
- **not-found returns empty** (empty dir, null PATH, null tool, empty PATH);
- plus bare-name-wins-over-extension, earlier-PATH-entry-wins, a directory
  named like the tool is not a match, a non-executable file is skipped, and
  junk/empty PATH entries are skipped.

---

## 4. HDL toolchain armed on the Windows job (#111 Stage W2)

Adds an "Arm the HDL simulator toolchain (best-effort)" step to the existing
`windows` job that fetches a **version-pinned** YosysHQ `oss-cad-suite`
Windows release (the bundle ships icarus-verilog, ghdl, **and** yosys
together — choco/MSYS2 package the three less consistently), extracts it, and
prepends its `bin/` to `GITHUB_PATH`.

- **Pinned release**: the dated `2026-07-26` tag,
  `oss-cad-suite-windows-x64-20260726.exe` (a 7-Zip self-extracting archive;
  unpacked with `7z x`, which is present on `windows-latest`, so the SFX stub
  never runs).
- **Checksum — a real, verified pin, not invented.** GitHub's release-asset
  `digest` metadata publishes the SHA-256; read here via
  `gh api repos/YosysHQ/oss-cad-suite-build/releases/tags/2026-07-26` (asset
  `digest` field) =
  `df275642362cd27f1cb90a7408818b6c2ed5292c974a754074d41c9250487ecc`. The step
  verifies the download against it. (This is stronger than the gui-wayland
  JBR pin, which is an `UNVERIFIED-` TOFU placeholder — here GitHub itself
  vouches for the digest, so we pin it directly.)
- **Fail-open fallback**, copied from the gui-wayland JBR-download idiom: on
  download **or** checksum mismatch **or** extract failure the step emits a
  `::notice`, sets `hdl=skipped`, and `exit 0`. The advisory lane then
  degrades to today's behaviour (the HDL suites self-skip) instead of failing
  on a CDN hiccup. The `bin/` is added in Windows form (`cygpath -w`) so the
  JVM's `PATH` search — and the new `ToolLocator` `.exe` resolution — sees it.

Because I am on Linux, the Windows runner steps cannot be executed here; they
are structurally safe (every failure mode degrades to skip, never fail-close)
and the Java locator half is fully unit-tested headlessly (§3). First light on
a real `windows-latest` runner is where the extract-path / `GITHUB_PATH` form
gets its final confirmation. Nothing else in the `windows` job changes.

---

## 5. HDL toolchain armed on the macOS job (#265 Stage 4)

The symmetric step on the `macos` job: `brew install icarus-verilog ghdl
yosys` (Homebrew installs unsuffixed `iverilog`/`ghdl`/`yosys`, which
`ToolLocator` finds as-is). Same graceful-failure idiom — a brew failure
emits a `::notice`, sets `hdl=skipped`, and the tests self-skip rather than
failing the lane on a transient Homebrew/network hiccup. Formula names are
the plausible current ones (`icarus-verilog` provides `iverilog`); **first
light may adjust** if a tap/name has drifted. Nothing else in the `macos` job
changes.

---

## 6. Display suite armed first-light on the Windows job (#111 Stage W3)

The `@Tag("display")` suite (25 classes, ~90 methods) drives real Swing
dialogs, popups, and gesture flows. In `pom.xml` it runs in its own
`display-tests` surefire execution under `-Djava.awt.headless=${jls.test.headless}`,
and each display test self-skips via
`Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(), …)`. On Linux the
`build` job arms it with `xvfb-run -a mvn … -Djls.test.headless=false` — a
virtual X server. **Windows runners have a real interactive window station**,
so no xvfb equivalent is needed: this PR simply adds `-Djls.test.headless=false`
to the Windows lane's `mvn` command, which flips `java.awt.headless` to
`false` and lets the suite run.

**This is deliberate advisory first light, not a promotion.** #111 Stage W3
originally sequenced the display suite *after* W1 makes the headless lane
required; it is pulled forward here as first light precisely to *measure* what
the Windows window station does with the suite while the lane is still
advisory (`continue-on-error` covers it), rather than waiting.

**Honest expectation — substrate-specific failures may surface, and that is
the point.** A slice of the display suite carries timing and pointer-model
workarounds tuned to the Linux **WM-less Xvfb** substrate (the code comments
say so explicitly): the `java.awt.Robot`-driven gesture/keyboard/popup flows
in `EditorGestureSupport`, `PaletteDropTest`, `EditorKeyboardConstructionTest`,
and `PopupOperationBehaviorTest` assume, e.g., that "the virtual pointer is
exclusively ours" and retry synthetic `BUTTON3`/key events the WM-less Xvfb
"intermittently drops." A real Windows window station has a genuine window
manager and shared pointer, so some of these assumptions may not hold and
those tests may fail on Windows first light. Per the maintainer directive
these are **not pre-muted** here: the advisory lane exists to surface them,
and **#265 Stage 2 owns the failure taxonomy** (classifying each first-light
failure as a real Windows defect vs. an Xvfb-specific test assumption to
port). The FontMetrics/geometry-reading display tests (e.g. the interactive
simulator smoke, construction-observation, menu/accessibility specs) have no
substrate assumption and are expected to pass. Nothing about the pom or the
tests changes in this PR — only the Windows `mvn` flag.

---

## 7. Advisory JDK-26 leg on the Windows job (#111 Stage W5)

The Windows lane becomes a matrix over `java: [25, 26]`, **exactly mirroring
the Linux `build` job's idiom** (`strategy: { fail-fast: false, matrix: {
java: [25, 26] } }`). JDK 25 (current LTS) is the required baseline; JDK 26 is
the advisory forward-compatibility leg that becomes required when it becomes
the next LTS. The whole `windows` job already carries `continue-on-error:
true`, so **both** legs are advisory (unlike Linux, which gates the 25 leg and
only advises the 26 leg via `continue-on-error: ${{ matrix.java != 25 }}`) —
appropriate while the whole Windows lane is still accruing its Stage W1
stability record.

**Check-name stability is preserved byte-for-byte.** The job `name:` is
templated `Build (Windows, JDK ${{ matrix.java }})`, which renders the 25 leg
as exactly `Build (Windows, JDK 25)` — the same string the lane carries today.
The #111 W1 promotion plan registers that literal name in branch protection,
so it must not drift; verified by rendering the template with `matrix.java=25`
and asserting byte-equality. The `Set up JDK` step likewise templates
`${{ matrix.java }}`.

---

## 8. Promote + rename the GUI boot lanes to hard gates (#101)

The two GUI-boot lanes have earned their promotion, so this branch also folds
in the **workflow half** of #101: drop `continue-on-error: true` from the
`gui-wayland` and `gui-x11` jobs, rewrite each job's header to record the
promotion rule + green-run evidence, and rename both jobs out of their
experimental "first light" identity. Mirrors the #188 aarch64 promotion
(commit d9c4488).

**Why — the P3/H2 criterion is met.** #101's H2 rule (the rig is stable
enough to gate CI: 20 consecutive runs with at most one failure) holds for
both lanes. Auditing job-level conclusions since 2026-07-21 — `gui-wayland`
is green on every non-cron push/PR run **and** 7/7 nightly cron runs
(29807838272, 29897623948, 29985767385, 30072962646, 30147587035,
30191692649, 30247754587); `gui-x11` is green on every non-cron run (it skips
`schedule` events by design). The last twenty non-cron ci.yml runs are 20/20
green for **both** lanes:

```
push: 30233449347, 30277051630, 30305223433, 30305876276, 30306600940,
      30307172627, 30307512700, 30307910186
PR:   30284055608, 30284086894, 30304849319, 30304947992, 30305419961,
      30305915681, 30305947175, 30305994644, 30306632400, 30306659352,
      30307205047, 30307543324
```

The sole failure for either lane was run 30226493722 (merge of #244) — a
whole-master build breakage where every build/installer/GUI job failed at the
shared `mvn package` "Build jar" step and **both** rigs skipped (never ran).
That is a master-wide breakage (since fixed), not a lane flake.

**The rename — and why it happens now.** Promotion is the moment the "first
light" name stops being true: the lane is now a permanent hard gate, not an
experiment. The two job `name:` strings are renamed accordingly:

```
GUI first light (Wayland, JBR)  →  GUI boot (Linux, Wayland/JBR)
GUI first light (X11, Xvfb)     →  GUI boot (Linux, X11/Xvfb)
```

The rename is done **now**, at promotion, precisely because it is free here:
the required-check registration has not happened yet, so no branch-protection
entry references the old names. Renaming after registration would instead
require a lockstep edit — rename the job and update branch protection in the
same beat, or the gate silently detaches. Related present-tense phrasing is
swept for coherence (step names, the `wayland-first-light`/`x11-first-light`
artifact names → `wayland-gui-boot`/`x11-gui-boot`, header prose, one
`::notice`). Genuinely historical mentions are **kept** verbatim — the
green-run record still notes the runs accrued under the old job name, and the
issue #101 "first-light finding" citations are not rewritten. Job IDs
(`gui-wayland`, `gui-x11`) are unchanged.

**Scope.** `continue-on-error` is removed from **only** the two GUI jobs; it
is intentionally **left intact** on the genuinely-advisory lanes — the JDK
matrix (`java != 25`), the `windows` and `macos` test lanes (§1, §7), and the
macOS `dmg` job. README: drop the stale "even while the lane is skipped
pending the JBR checksum pin" clause (JBR was decoupled from the checksum in
796e255; the lane no longer skips).

**Risk.** Promoting `gui-wayland` to required introduces an external-CDN
dependency (the JetBrains JBR download). This cannot wedge the required check:
on a download failure the Download-JBR step emits a `::notice` and sets
`skip=true` (exit 0 → job success, rig steps skip). Only a genuine future GUI
regression — or another master-wide build breakage like 30226493722 — now
blocks merges, which is the intended effect of the hard gate.

**The repo-settings half is a maintainer action** (GitHub UI/API), NOT part of
this PR, exactly as #188 did. Dropping `continue-on-error` is the workflow
half; the required-check registration completes it. Because this same PR also
renames the two required Linux contexts as part of the OS-family labeling sweep
(§9), the ruleset must be swapped in lockstep with the merge, so the two GUI
registrations and the two context renames now share **one ordered checklist**:

> **Maintainer action — ordered required-check checklist.** Copy-paste every
> context name verbatim; each is character-identical to a `name:` string in
> `.github/workflows/ci.yml`.
>
> 1. **BEFORE merging PR #266 — swap the two renamed required contexts in the
>    repo ruleset.** Replace the required status check `Build (JDK 25)` with
>    `Build (Linux, JDK 25)` (the JDK-25 leg of the renamed Linux build job),
>    and replace `Reproducible build check` with `Reproducible build check
>    (Linux)`. **This is not optional and the ordering is load-bearing:** #266's
>    own workflow already emits the new names, so if the ruleset still requires
>    the old contexts they are *never reported again* and the required checks
>    hang perpetually pending — wedging **every** open PR, including #266
>    itself, with nothing able to merge. (`CodeQL`, the third required context,
>    lives in `codeql.yml` and is a security analysis rather than an OS build
>    lane — it is out of this sweep's scope; leave it untouched.)
> 2. **AFTER merging PR #266 — register the two renamed GUI-boot lanes as
>    required status checks** (the #101 promotion registration, now carrying the
>    OS family, and done post-merge so the freshly-renamed lanes have reported
>    at least once):
>
>    ```
>    GUI boot (Linux, Wayland/JBR)
>    GUI boot (Linux, X11/Xvfb)
>    ```

This is why #101 stays **Advances**, not **Closes**: this PR completes #101's
workflow half, but the required-check **registration** above and the
first-light **findings-publication** remain.

---

## 9. OS-family labeling sweep of every `ci.yml` lane name (maintainer directive)

Maintainer directive: every lane in `.github/workflows/ci.yml` must name its OS
family, so the required- and reported-checks lists read uniformly. The
Windows/macOS `Build (…)` lanes and the three installer lanes (`Linux installer
reproducibility`, `… (aarch64)`, `macOS installer reproducibility (dmg)`)
already carried their OS family; the five remaining Linux lanes did not. They
are renamed here (job IDs unchanged):

```
Build (JDK ${{ matrix.java }})   →  Build (Linux, JDK ${{ matrix.java }})
Verify Agda proofs               →  Verify Agda proofs (Linux)
GUI boot (Wayland, JBR)          →  GUI boot (Linux, Wayland/JBR)
GUI boot (X11, Xvfb)             →  GUI boot (Linux, X11/Xvfb)
Reproducible build check         →  Reproducible build check (Linux)
```

The two `GUI boot (Linux, …)` renames are folded into the §8 promotion (the
lanes were already being renamed out of their "first light" identity in this
PR, so this simply lands their final gated name in one move; the §8
green-record notes keep the genuinely-historical "GUI first light (…)" strings
under which the record accrued, extending the renamed-at-promotion note to point
at the final Linux name). The Windows/macOS `Build (…, JDK 25)` names are
**deliberately left byte-identical** — their stability is load-bearing for the
#111 W1 / #265 Stage 3 promotions that will register them unchanged.

**Required-context knock-on.** Two of the renamed lanes are currently required
status checks in the repo ruleset — `Build (JDK 25)` and `Reproducible build
check` — so renaming them means the ruleset must swap to the new context names.
That swap is the first step of §8's ordered maintainer checklist and **must
happen before PR #266 merges**, or the old contexts stop being reported and
every open PR wedges. (`CodeQL`, the third required context, is in `codeql.yml`
— an analysis, not an OS build lane — and is out of this sweep.)

---

## 10. macOS GUI app-boot smoke rig (#265 Stage 9)

The Linux `gui-wayland`/`gui-x11` lanes boot the **real shaded jar**
(`java -jar target/jls-*.jar`, Main-Class `jls.JLS`), assert the top-level app
window **maps**, and screenshot it non-blank. No equivalent app-boot rig
existed off-Linux. This adds the macOS one — Stage 9 of #265 — following the
Linux rigs end to end:

- **New `scripts/macos-rig.sh` + `scripts/macos-rig-selftest.sh`**, and a new
  `macos-gui` lane (`macos-latest`, advisory `continue-on-error`, name
  **`GUI boot (macOS, WindowServer)`** in the post-#101 `GUI boot (…)` family).
- **Same contract as the Linux rigs.** Per-run self-test of the control-flow
  first; a minimal `HelloSwingControl` frame boots before JLS so failures
  classify **exit 1 = JLS-side vs exit 2 = environment**; boot the real jar;
  assert the window maps; require a non-blank screenshot (unique-color count
  > 1); upload artifacts `if: always()`. **exit 0** = app window mapped **and**
  non-blank shot, **exit 1** = control worked but JLS did not, **exit 2** =
  environment/rig fault.
- **macOS specifics, honest about the unknowns.** Real Quartz WindowServer, so
  no Xvfb/compositor to stand up — the jar boots directly. Window presence is
  read via **System Events (`osascript`)** and the screenshot via the built-in
  **`screencapture`**. The non-blank proof matches the Linux unique-color idiom
  using only built-ins — `screencapture` (PNG) → `sips` (transcode to BMP) → a
  **pure-stdlib Python** distinct-color reader — so it needs **no ImageMagick,
  no `brew`, no network** (justification: the core P1 proof then has no
  package-install/network dependency that could flake; the BMP reader was
  validated on Linux against synthetic 24/32-bit BMPs). A recorded-but-ungated
  before/after pixel diff mirrors the Linux P2 gate (`PIXEL_DIFF_MIN=0`).
- **Genuine first light.** This rig has **never run on a real macOS runner** —
  its first execution is on CI. Hosted runners **may withhold** Screen
  Recording / Accessibility (TCC) permission from a non-interactive session,
  which can make `screencapture` return an all-black frame or make System
  Events refuse to enumerate windows. The **control-frame comparison is exactly
  what disambiguates** this: a permission block hits the control frame first, so
  it is classified **exit 2 (environment), never exit 1**. Every wait loop is
  bounded by a hard timeout, so a withheld permission degrades to a clean exit 2,
  never a hang. The documented fallbacks first light may adopt are an in-JVM
  `java.awt.Robot` self-capture and CGWindowList enumeration.
- **Verified offline.** `scripts/macos-rig-selftest.sh` drives the unmodified
  rig against a stub toolchain (fake `screencapture`/`sips`/`osascript`/`python3`
  + a scripted `java`) and **runs green on Linux** — all 9 scenarios classify
  correctly (success→0; jls-crash / jls-nowindow / jls-blank / p2-fail→1;
  env-no-control / env-osa-denied / env-control-blank→2). `shellcheck` (0.11)
  is clean on both scripts.
- **Promotion.** Advisory → required once **20 consecutive runs show at most one
  failure**, then drop `continue-on-error` and register the byte-stable name as
  a required check with recorded run IDs (mirroring `installer-reproducibility-aarch64`).

---

## 11. Windows GUI app-boot smoke rig (#111 Stage W7)

The symmetric Windows analogue — Stage W7 of #111 — as **`scripts/windows-rig.ps1`
+ `scripts/windows-rig-selftest.ps1`** and a new `windows-gui` lane
(`windows-latest`, `shell: pwsh`, advisory `continue-on-error`, name
**`GUI boot (Windows, WindowStation)`**).

- **Same control-frame-first exit-code contract** (0/1/2) as the Linux/macOS
  rigs, and the same per-run self-test.
- **Windows specifics.** Real interactive window station, so the jar boots
  directly. Window presence is polled from **`Get-Process` `MainWindowHandle`**
  (authoritative for the launched process) with a **`MainWindowTitle`-contains
  fallback**; the screenshot is a **`System.Drawing` `Graphics.CopyFromScreen`**
  of the virtual screen; the non-blank gate counts distinct sampled colors in
  the same script. Every wait loop is bounded by a **`Stopwatch`** timeout.
- **Testable by construction.** The rig factors its whole classification into an
  `Invoke-GuiBootRig` core driven through **injected delegates** (launch / window
  probe / capture / color-count); the auto-run block wires the real
  implementations, and `windows-rig-selftest.ps1` dot-sources the rig with
  `-NoAutoRun` and injects stubs to exercise every branch with no real GUI.
- **Genuine first light — and PowerShell was unavailable in the authoring
  sandbox.** Unlike the macOS selftest (which ran green on Linux), the pwsh
  selftest is **first executed on the Windows CI runner itself**; it is written
  carefully and structurally, and its first light is CI. A hosted non-interactive
  session that hands back a blank/desktop-only frame or an empty
  `MainWindowTitle` is classified **exit 2 (environment) via the control-frame
  comparison, never exit 1**; the documented deeper fallbacks are a user32
  `EnumWindows` title enumeration (`Add-Type`) and an in-JVM `java.awt.Robot`
  self-capture.
- **Promotion.** Advisory → required per the same 20-run rule, registering the
  byte-stable name with recorded run IDs.

---

## 12. Advisory Windows installer (msi) build lane (#111 / #190)

A new `windows-installer-msi` lane (`windows-latest`, advisory
`continue-on-error`, name **`Windows installer build (msi)`**) that builds the
jar and runs the **SAME `jpackage --type msi` invocation the release/probe path
uses** — `bash scripts/build-installer.sh`, exactly as `repro-installers.yml`
drives it on `windows-latest` (WiX preinstalled; the git-bash `uname` reports
`MINGW`, so `build-installer.sh` takes its msi branch). **No divergent flags** —
the msi is built by the unmodified installer script. The lane then asserts the
`.msi` exists and is **non-trivially sized** (a 1 MiB floor that only a broken
build failing to bundle the runtime would trip) and uploads it as an artifact.

**Build-smoke only — intentionally NOT reproducibility-checked.** The header
comment states this explicitly: the msi's byte-level residual is **jpackage's
MSI relational-database streams** (per-build component GUIDs / ProductCode / row
ordering it exposes no control over, while the embedded cabinet payload IS
byte-identical) — see `docs/windows-msi-determinism.md` and **#190 (blocked)**.
Byte-level determinism checking **stays with the scheduled "Installer
reproducibility probe" workflow** (`repro-installers.yml`); this lane only
proves the msi still **builds** on `windows-latest`, catching a broken
WiX/jpackage/packaging regression the monthly probe would not surface until much
later. Advisory with the standard #188/#101 20-run promotion note.

---

## 13. First-light failures fixed (run 30322375242, #265 Stage 2)

Both new GUI-boot rigs got their genuine first light on CI run **30322375242**,
and both surfaced a **rig-side** defect (not a JLS defect) that the offline
selftests could not have caught — exactly the kind of finding #265 Stage 2 owns.
The maintainer's load-bearing gate is **REAL APP BOOTS + WINDOW MAPS on a stock
runner**; pixel proofs are supporting evidence and must never leave the
boot-proof lane permanently red for a runner-policy reason. Both fixes honour
that ordering.

### 13a. Windows — `Start-JavaProcess` not recognized (`ps-scope/error-misclassification`)

**The failure** (job 90160737328's Windows sibling / the `windows-gui` lane). The
production run died with:

```
The term 'Start-JavaProcess' is not recognized as a name of a cmdlet, function,
script file, or executable
```

then fell through as **exit 1** — the JLS-side code — so a **rig bug was
misreported as an app failure**. The selftest had passed because its injected
stub delegates replaced the launch path, so the production launch helper was
**never exercised** until CI.

**The diagnosis.** The two real launch delegates were `.GetNewClosure()` script
blocks. A `GetNewClosure()` block runs in a fresh dynamic-module scope that
captures *variables* but **cannot see script-scope functions**, so the closure
body's call to the (correctly defined, top-level) `Start-JavaProcess` resolved to
nothing and threw. Compounding it, with `Set-StrictMode` + `$ErrorActionPreference
= 'Stop'` an uncaught error terminates pwsh with **exit 1** — which the rig
contract reserves for a JLS-side failure — so the environment/rig fault was
mislabelled as JLS's.

**The fix** (`scripts/windows-rig.ps1` + `scripts/windows-rig-selftest.ps1`):

- **Launch delegates are now top-level functions** (`Invoke-ControlLaunch` /
  `Invoke-JlsLaunch`) passed by `${function:...}` reference — exactly like the
  already-working `Get-WindowCount` / `Save-Screenshot` / `Get-ColorCount`
  delegates — so they run in the script session state and **do** resolve
  `Start-JavaProcess` (and the `$script:`-scoped inputs). No `.GetNewClosure()`
  remains on the launch path. (An audit of every function the production path
  calls found this was the only one hidden behind stub injection.)
- **The entry point wraps every unhandled error as exit 2** (rig/environment)
  with the message and stack — never exit 1, never a bare pwsh failure — and
  `Invoke-GuiBootRig` gained the same backstop so a delegate that throws
  classifies exit 2, not a propagated pwsh error.
- **The selftest now catches this exact bug class**: a throwing-delegate scenario
  asserts exit 2 (`jls-throws`, `control-throws`), and a new
  **production-path integrity** check AST-parses `windows-rig.ps1` to assert every
  production-path function is defined at top-level scope **and** reachability-probes
  the real launch delegates with `Start-JavaProcess` overridden by a no-op stub
  (no java launched), asserting they resolve it.

**Verified the selftest fails on the pre-fix script.** PowerShell was unavailable
in the original authoring sandbox but is now runnable via `nix run
nixpkgs#powershell`: the **fixed** selftest passes 9/9 (including the two throw
cases and the production-path probe) against the fixed rig, and — run against the
**pre-fix** `windows-rig.ps1` (from `git show HEAD:…`) — it **fails** with
`production-path (undefined production-path function(s): Invoke-ControlLaunch,
Invoke-JlsLaunch)` plus both throw cases misclassifying. Both scripts also
`[Parser]::ParseFile`-clean.

### 13b. macOS — Screen Recording (TCC) withheld → DEGRADED MODE (`tcc-permission`)

**The failure** (job 90160737361). Selftest 9/9 green on the real runner;
readiness desktop capture OK; the control window **MAPPED** (System Events
works); but the **control-window capture had 0 unique colors**, so the rig
correctly identified that **Screen Recording (TCC) is withheld** from the
non-interactive CI session and exited 2. Hosted runners may **never** grant this,
so exit 2 for that reason is permanent red = pure noise.

**The fix** (`scripts/macos-rig.sh` + `scripts/macos-rig-selftest.sh`) changes
**only** the blank-control-capture branch:

- **Fail-open TCC pre-grant** — a new `macos-gui` ci.yml step attempts the
  community `sqlite3` workaround (insert a `kTCCServiceScreenCapture` row into the
  **user** `TCC.db`). SIP protects the system DB and the per-user DB may be
  locked or schema-shifted between macOS releases, so this **frequently fails** —
  which is exactly why it is fail-open (`continue-on-error` + a trailing `exit 0`,
  a table-exists guard, a re-probe for the log): attempt it, then proceed either
  way.
- **DEGRADED MODE** — when the desktop readiness capture worked **and** the
  control window **maps** but its capture is blank (the TCC signature), the rig no
  longer exits 2. It emits a `::warning` (*"P1 pixel proof unavailable: Screen
  Recording withheld (TCC); window-map is the gate this run"*), launches the real
  JLS jar, asserts the JLS window **maps** via System Events within the timeout,
  **skips all pixel proofs**, and exits **0 on map** / **1 on no-map-or-crash**
  (the control mapped, so a JLS no-show is still JLS-side). **exit 2 is kept** for:
  readiness capture failing outright, the control window never mapping, and
  osascript denial — all of which break the window-map proof itself.
- **The selftest** updates the `env-control-blank` scenario to expect
  **degraded-mode exit 0** with the warning, adds a **`degraded-jls-nowindow`**
  scenario expecting exit 1, and adds an `env-readiness-capture-fail` exit-2 case;
  it **runs green locally** (11/11) and is `shellcheck 0.11`-clean.

**Honest status of the macOS pixel proof.** The macOS **pixel proof is contingent
on TCC** (tracked in **#265 Stage 9**): if the hosted image never grants Screen
Recording, the rig runs degraded on every run and the pixel evidence stays
unavailable. The **window-map boot proof is the reliable per-run guarantee on
both OSes** — the real jar is launched and its top-level window is enumerated
(System Events on macOS, `MainWindowHandle` on Windows), which is precisely the
"prove the thing can at least start on their system" gate. The TCC pre-grant is a
best-effort attempt to *restore* the pixel proof, not a dependency of the boot
gate.

---

## Deliberate exclusions (per the trackers' staging)

- **No promotion of any lane to required in this PR (#111 Stage W1 / #265
  Stage 3).** Every step in this PR *changes* the Windows and macOS lanes —
  the toolchain arming, and now the Windows display flag and JDK-26 matrix —
  so their burn-in record resets; promoting a lane in the same PR that changes
  it would be self-defeating. W1 needs a **fresh 20-run stability record on
  the changed lane** before `continue-on-error` drops and the byte-stable
  `Build (Windows, JDK 25)` name registers in branch protection (the
  #188/#101 rule). The name is templated to stay byte-identical precisely so
  that later promotion is churn-free.
- **JaCoCo ratchet stays off-Linux** (#265 Stage 6 / **#111 Stage W4**). The
  Windows and macOS lanes keep `-Djacoco.skip=true`: the floors are calibrated
  against the fuller Linux run, and W4 waits for the Windows suite to
  **converge** with Linux (i.e. the HDL + display suites actually executing
  and green) before Windows gets its own or a shared floor. The Linux `build`
  job remains the sole authority for the ratchet, SpotBugs, and Agda proofs.
- **macOS display suite still deferred** (#265 staging): this PR arms the
  display suite first-light only on **Windows** (Stage W3). The macOS lane
  stays headless for now, per the #265 staging order — its display first light
  is a later stage.
- Packaging/reproducibility lanes and the release workflow are untouched —
  per-OS by nature, out of scope for the test-suite parity program.

---

## Verification

- **YAML parses** (`ruby -ryaml` `YAML.load_file`: OK). Parsed job set:
  `build, windows, macos, proofs, gui-wayland, gui-x11, …`. The `windows` job
  now carries `strategy: { fail-fast: false, matrix: { java: [25, 26] } }`,
  `env: {OSS_CAD_URL, OSS_CAD_SHA256}`, and steps
  `checkout | Set up JDK ${{ matrix.java }} | Arm the HDL simulator toolchain
  (best-effort) | Build, lint, and analyze` (the last passing
  `-Djls.test.headless=false`); the `macos` job gains the same arming step and
  is otherwise unchanged.
- **Windows JDK-25 check name is byte-identical** — rendering the templated
  `name: Build (Windows, JDK ${{ matrix.java }})` with `matrix.java=25`
  asserts exactly `Build (Windows, JDK 25)` (the string #111 W1 registers in
  branch protection). The Linux `build` matrix, the `macos` lane
  (`Build (macOS, JDK 25)`), and every other job are untouched.
- **Full suite green** locally (`nix develop` shell, `mvn -B verify
  -Djacoco.skip=true`):

```
TOTAL Tests run: 1358, Failures: 0, Errors: 0, Skipped: 97
[INFO] BUILD SUCCESS
```

- **New locator unit tests execute and pass**: `jls.hdl.ToolLocatorTest` —
  `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`, all on Linux.
- **The shared locator resolves a real tool end-to-end on Linux**:
  `AutogradeBridgeExampleTest` (which now calls `ToolLocator.findOnPath(
  "python3")`) **executed, not skipped** (`Tests run: 1, Skipped: 0`) — the
  refactor did not break unix resolution.
- **The HDL golden suites still self-skip correctly** through the shared
  locator when the toolchain is absent. This dev shell's ground truth:
  `nix develop` provides **no** iverilog/ghdl/yosys (`which` finds none), so
  `IverilogCompileTest`, `GhdlCompileTest`, `YosysGroundTruthTest`, and
  `ImportPipelineTest` all report `Skipped: 1`/`Skipped: 2` — the exact
  `assumeTrue` self-skip the Windows/macOS arming steps are designed to flip
  to *executed* once the toolchain is on `PATH`. (On CI's Linux `build` job,
  which `apt`-installs the three, they execute as before — the locator change
  is behaviour-preserving on unix.)

The 97 skips are the pre-existing `@Tag("display")` UI tests (skip headless)
plus these toolchain-gated HDL suites, as expected.

- **GUI promotion (§8) verified** — `grep continue-on-error
  .github/workflows/ci.yml` confirms it is removed from **both** GUI jobs and
  still present on the JDK matrix, the `windows`/`macos` test lanes, and the
  macOS `dmg` job. Both GUI `name:` strings render as `GUI boot (Linux,
  Wayland/JBR)` / `GUI boot (Linux, X11/Xvfb)`, and `grep -n 'first light'
  ci.yml` shows the only
  survivors are the historical green-record notes and the `#101`
  first-light-finding citations (present-tense identity fully swept); the
  `wayland-first-light`/`x11-first-light` artifacts are renamed to
  `wayland-gui-boot`/`x11-gui-boot`.

- **New GUI-boot / msi lanes (§§10–12) verified.** YAML re-parsed (Ruby
  `YAML.load_file`: OK) — the job set now includes `macos-gui`
  (`GUI boot (macOS, WindowServer)`, `macos-latest`, `continue-on-error`),
  `windows-gui` (`GUI boot (Windows, WindowStation)`, `windows-latest`, the rig
  steps `shell: pwsh`), and `windows-installer-msi`
  (`Windows installer build (msi)`, `windows-latest`, `continue-on-error`), all
  advisory. The **macOS rig selftest runs green on Linux**
  (`scripts/macos-rig-selftest.sh`: all 9 scenarios classify correctly), and
  the pure-Python BMP distinct-color / pixel-diff readers were validated against
  synthetic 24- and 32-bit BMPs. **`shellcheck` 0.11 (via nix) is clean** on
  `scripts/macos-rig.sh` and `scripts/macos-rig-selftest.sh`. **PowerShell is
  unavailable in the authoring sandbox**, so `scripts/windows-rig.ps1` /
  `windows-rig-selftest.ps1` were written for structural safety (bounded
  Stopwatch waits, injected-delegate classification, every environment fault →
  exit 2) and get their first execution on the Windows runner. No product
  source changed, so the local suite is unaffected — `mvn -B test
  -Djacoco.skip=true` is **BUILD SUCCESS** (0 failures, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpjPHKerSvSbQorrBsBrgq
