### PR TITLE
feat(#264): scripted iCEstick bitstream handoff (Stage 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ jobs:
       # #44/#68); Dependabot keeps the pins fresh via the version comments
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pure-shell guard for the iCEstick bitstream handoff (issue #264):
+      # stubs the open iCE40 toolchain on PATH and asserts the handoff
+      # script's all-or-nothing preflight and yosys -> nextpnr-ice40 ->
+      # icepack -> programmer control flow, so that logic can't regress
+      # silently. Needs no toolchain, hardware, or network; runs once on
+      # the required LTS leg (same treatment the GUI lanes give their
+      # own *-rig-selftest.sh scripts).
+      - name: Self-test the iCEstick bitstream handoff script
+        if: matrix.java == 25
+        run: scripts/icestick-handoff-selftest.sh
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:

--- a/docs/icestick-bitstream-handoff.md
+++ b/docs/icestick-bitstream-handoff.md
@@ -1,0 +1,119 @@
+# iCEstick bitstream handoff
+
+This is the end-to-end recipe for taking a JLS circuit onto a Lattice
+iCEstick (iCE40-HX1K, TQ144 package): JLS exports the RTL and the pin
+constraints, and the open iCE40 toolchain does synthesis, place & route,
+packing, and flashing.
+
+**JLS does not build bitstreams.** It emits HDL and a constraint file and
+stops there (issue #215 H2: delegate, do not reimplement). Everything
+downstream of the export is external open-source tooling, wrapped for
+convenience by [`scripts/icestick-handoff.sh`](../scripts/icestick-handoff.sh)
+but never reimplemented inside JLS.
+
+## Prerequisites
+
+The open iCE40 flow, all from YosysHQ / project-icestorm:
+
+| Tool | Role | Where |
+|------|------|-------|
+| `yosys` | synthesis (RTL → iCE40 netlist) | <https://github.com/YosysHQ/yosys> |
+| `nextpnr-ice40` | place & route for the iCE40-HX1K | <https://github.com/YosysHQ/nextpnr> |
+| `icepack` | netlist → bitstream packing | <https://github.com/YosysHQ/icestorm> |
+| `openFPGALoader` *(preferred)* | flash the board over USB | <https://github.com/trabucayre/openFPGALoader> |
+| `iceprog` *(fallback)* | flash the board over USB | ships with project-icestorm |
+
+On many distributions these are a single package install (for example
+`apt-get install yosys nextpnr fpga-icestorm`); the [oss-cad-suite](https://github.com/YosysHQ/oss-cad-suite-build)
+bundle ships all of them, `openFPGALoader` included.
+
+The handoff script performs an all-or-nothing preflight: it reports
+*every* missing tool in one pass — each with its role and where to get
+it — and exits nonzero before running anything, mirroring `PcfEmitter`'s
+error aggregation. The programmer is only required when you pass
+`--flash`.
+
+## Step 1 — export the RTL and pin constraints from JLS
+
+JLS emits the Verilog and the iCEstick `.pcf` (see the `-export` /
+`-board` / `-pins` options wired in `JLSStart`):
+
+```sh
+jls -export design.v -board icestick -pins pins.txt design.jls
+```
+
+- `design.v` — the exported Verilog.
+- `-board icestick` — selects `Boards.ICESTICK` (iCE40-HX1K / TQ144), so
+  the emitted constraint file is a `.pcf` with `set_io` lines placed on
+  that device's real package pins.
+- `-pins pins.txt` — your port-to-pin bindings; the emitter fails with an
+  aggregated error listing every unbound or mis-bound port (issue #213
+  P3) rather than producing a partial constraint file.
+
+This produces `design.v` and, alongside it, the `.pcf` (referred to as
+`design.pcf` below).
+
+## Step 2 — hand off to the bitstream toolchain
+
+The wrapper carries the export the rest of the way:
+
+```sh
+scripts/icestick-handoff.sh design.v design.pcf
+# or, to program the board immediately after packing:
+scripts/icestick-handoff.sh --flash design.v design.pcf
+```
+
+By default the top module is the `.v` basename (`design.v` → `design`);
+override it with `-t/--top NAME`, and redirect the intermediate/output
+files with `-o/--out DIR`. The script echoes each stage command it runs
+with a `==>` prefix.
+
+### The raw commands it wraps
+
+Nothing here is JLS-specific; the wrapper only fills in the iCEstick's
+device/package flags (hard-coded to match `Boards.ICESTICK`) and the
+per-tool preflight. You can run the same flow by hand:
+
+```sh
+# synthesis: RTL -> iCE40 netlist
+yosys -p 'synth_ice40 -top design -json design.json' design.v
+
+# place & route on the iCE40-HX1K in the TQ144 package
+nextpnr-ice40 --hx1k --package tq144 \
+    --pcf design.pcf --json design.json --asc design.asc
+
+# pack the routed design into a bitstream
+icepack design.asc design.bin
+
+# flash the board (openFPGALoader preferred; iceprog is the fallback)
+openFPGALoader -b ice40_generic design.bin
+# or:
+iceprog design.bin
+```
+
+## External-tool honesty note
+
+JLS's contribution to this pipeline is exactly two files — the Verilog
+and the `.pcf` — plus the wrapper's argument bookkeeping and preflight.
+Synthesis (`yosys`), place & route (`nextpnr-ice40`), bitstream packing
+(`icepack`), and flashing (`openFPGALoader` / `iceprog`) are all external
+open-source tools, invoked, not reimplemented. The device and package
+(iCE40-HX1K / TQ144) are the only board facts the wrapper hard-codes, and
+they are the same facts `Boards.ICESTICK` uses to emit the constraints.
+
+The wrapper's control flow — the preflight and the tool-chaining — is
+regression-guarded by
+[`scripts/icestick-handoff-selftest.sh`](../scripts/icestick-handoff-selftest.sh),
+a pure-shell harness that stubs the toolchain on `PATH` and runs in CI.
+The self-test proves the *control flow*, not that the exact `yosys` /
+`nextpnr-ice40` / `icepack` arguments synthesize a real design; that is
+validated on a machine with the toolchain installed (and, for the flash
+step, with a board attached).
+
+## Manual flash version record (#215 P2)
+
+To be filled in from a real flash, once hardware is present:
+
+| Date | Board | `yosys` | `nextpnr-ice40` | `icepack` | Programmer | Result |
+|------|-------|---------|-----------------|-----------|------------|--------|
+| _TBD_ | Lattice iCEstick (iCE40-HX1K, TQ144) | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |

--- a/scripts/icestick-handoff-selftest.sh
+++ b/scripts/icestick-handoff-selftest.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# icestick-handoff-selftest.sh - logic self-test for
+# scripts/icestick-handoff.sh (issue #264).
+#
+# The real handoff (icestick-handoff.sh) can only run where the open
+# iCE40 toolchain (yosys, nextpnr-ice40, icepack, and a programmer) is
+# installed - and only reach hardware where an iCEstick is plugged in.
+# Its *control flow*, though - the all-or-nothing preflight that names
+# every missing tool in one pass, the --flash-only programmer check, and
+# the yosys -> nextpnr-ice40 -> icepack -> programmer chain - is pure
+# shell and must not regress silently.
+#
+# This harness drives the unmodified handoff script against a hermetic
+# stub PATH (fake yosys/nextpnr-ice40/icepack/openFPGALoader plus only
+# the coreutils the script itself needs) and asserts:
+#   (a) each single missing tool prints that tool's preflight message
+#       and exits nonzero;
+#   (b) all-missing lists every gap in one nonzero exit;
+#   (c) the fully-stubbed happy path reaches icepack, and with --flash
+#       reaches the programmer;
+#   (d) a missing programmer only matters under --flash.
+# It needs no real toolchain, no hardware, and no network, so it runs in
+# the sandbox and as a fast CI check.
+#
+# Usage:  scripts/icestick-handoff-selftest.sh
+# Exit 0 when every scenario behaves as documented; 1 otherwise.
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+HANDOFF="$SELF_DIR/icestick-handoff.sh"
+[ -x "$HANDOFF" ] || { echo "selftest: $HANDOFF is missing or not executable" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- a hermetic base PATH: only the coreutils the handoff script needs.
+# Restricting PATH to this dir means a tool is "missing" iff we did not
+# stub it - independent of whatever the CI runner happens to have
+# installed (the build lane installs a real yosys, for instance).
+CORE_BIN="$WORK/core"
+mkdir -p "$CORE_BIN"
+for tool in bash sh mkdir basename dirname sed cat rm; do
+	p="$(command -v "$tool" 2>/dev/null)" || {
+		echo "selftest: cannot locate '$tool' to build the hermetic PATH" >&2
+		exit 1
+	}
+	ln -sf "$p" "$CORE_BIN/$tool"
+done
+
+# fake export inputs (the script only checks they exist)
+: > "$WORK/design.v"
+: > "$WORK/design.pcf"
+
+# make_stub DIR NAME  - a fake FPGA tool that records that it ran.
+make_stub() {
+	dir="$1"; name="$2"
+	cat > "$dir/$name" <<EOF
+#!/usr/bin/env bash
+echo "$name" >> "\$STUB_LOG"
+exit 0
+EOF
+	chmod +x "$dir/$name"
+}
+
+fail=0
+
+# run_case NAME EXPECT_EXIT "flash?" "stubs..." - builds a stub bin with
+# the named FPGA tools present, runs the handoff, and records exit code,
+# combined output, and the tool-run log for the assertions that follow.
+declare OUT LOG GOT
+run_case() {
+	name="$1"; want="$2"; flash="$3"; shift 3
+	casedir="$WORK/case-$name"
+	bin="$casedir/bin"
+	mkdir -p "$bin"
+	# every case gets the coreutils; FPGA tools only if listed
+	for f in "$CORE_BIN"/*; do ln -sf "$f" "$bin/"; done
+	for tool in "$@"; do make_stub "$bin" "$tool"; done
+
+	LOG="$casedir/ran.log"; : > "$LOG"
+	OUT="$casedir/out.txt"
+	args=("$WORK/design.v" "$WORK/design.pcf")
+	[ "$flash" = flash ] && args=(--flash "${args[@]}")
+
+	GOT=0
+	PATH="$bin" STUB_LOG="$LOG" "$HANDOFF" "${args[@]}" > "$OUT" 2>&1 || GOT=$?
+
+	if [ "$GOT" != "$want" ]; then
+		echo "selftest: FAIL  $name (expected exit $want, got $GOT)"
+		echo "----- handoff output ($name) -----"; sed 's/^/    /' "$OUT"
+		fail=1
+		return 1
+	fi
+	return 0
+}
+
+# expect_out NAME "needle" - the last case's output must contain needle.
+expect_out() {
+	if ! grep -qF -- "$2" "$OUT"; then
+		echo "selftest: FAIL  $1 (output missing: $2)"
+		echo "----- handoff output -----"; sed 's/^/    /' "$OUT"
+		fail=1
+	fi
+}
+
+# expect_ran NAME "tool" / expect_not_ran - assert the run log.
+expect_ran() {
+	if ! grep -qxF -- "$2" "$LOG"; then
+		echo "selftest: FAIL  $1 (expected $2 to run; it did not)"
+		fail=1
+	fi
+}
+expect_not_ran() {
+	if grep -qxF -- "$2" "$LOG"; then
+		echo "selftest: FAIL  $1 ($2 ran but should not have)"
+		fail=1
+	fi
+}
+
+ALL_SYNTH=(yosys nextpnr-ice40 icepack)
+
+# (a) each single missing tool -> its own preflight message, nonzero exit
+if run_case miss-yosys 1 noflash nextpnr-ice40 icepack; then
+	expect_out miss-yosys "yosys - synthesis"
+fi
+if run_case miss-nextpnr 1 noflash yosys icepack; then
+	expect_out miss-nextpnr "nextpnr-ice40 - place & route"
+fi
+if run_case miss-icepack 1 noflash yosys nextpnr-ice40; then
+	expect_out miss-icepack "icepack - netlist"
+fi
+
+# (b) all synthesis tools missing -> every gap named in one exit
+if run_case miss-all 1 noflash; then
+	expect_out miss-all "yosys - synthesis"
+	expect_out miss-all "nextpnr-ice40 - place & route"
+	expect_out miss-all "icepack - netlist"
+fi
+
+# (d) a missing programmer is fine WITHOUT --flash ...
+if run_case build-only 0 noflash "${ALL_SYNTH[@]}"; then
+	expect_ran build-only icepack
+	expect_out build-only "bitstream:"
+fi
+# ... but is a hard error WITH --flash (all synth tools present)
+if run_case flash-no-prog 1 flash "${ALL_SYNTH[@]}"; then
+	expect_out flash-no-prog "openFPGALoader or iceprog"
+fi
+
+# (c) happy path with --flash: reaches icepack AND the programmer
+if run_case flash-ok 0 flash "${ALL_SYNTH[@]}" openFPGALoader; then
+	expect_ran flash-ok icepack
+	expect_ran flash-ok openFPGALoader
+fi
+# and the iceprog fallback is honoured when openFPGALoader is absent
+if run_case flash-iceprog 0 flash "${ALL_SYNTH[@]}" iceprog; then
+	expect_ran flash-iceprog iceprog
+	expect_not_ran flash-iceprog openFPGALoader
+fi
+
+[ "$fail" = 0 ] && echo "selftest: all scenarios behaved as documented" \
+	|| echo "selftest: one or more scenarios misbehaved"
+exit "$fail"

--- a/scripts/icestick-handoff.sh
+++ b/scripts/icestick-handoff.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# icestick-handoff.sh - external-tool handoff from a JLS iCEstick export
+# to a flashed bitstream (issue #264, Stage 1).
+#
+# JLS emits the RTL and the pin constraints; it does NOT synthesize,
+# place, route, pack, or flash anything (issue #215 H2: delegate, do
+# not reimplement).  This script is the thin wrapper that carries the
+# Verilog + PCF that
+#
+#     jls -export design.v -board icestick -pins pins.txt design.jls
+#
+# already produces (see JLSStart's -export/-board/-pins CLI) the rest of
+# the way, using the open iCE40 toolchain:
+#
+#     design.v + design.pcf
+#       -> yosys           (synth_ice40)              -> design.json
+#       -> nextpnr-ice40   (--hx1k --package tq144)   -> design.asc
+#       -> icepack                                    -> design.bin
+#       -> openFPGALoader / iceprog   (only with --flash)
+#
+# The iCE40-HX1K / TQ144 target is hard-coded to match Boards.ICESTICK
+# (jls.hdl.board): the same device the PCF was emitted for.
+#
+# Preflight is all-or-nothing (mirroring PcfEmitter's error
+# aggregation): every missing tool is reported in one pass with its
+# role and where to get it, then a single nonzero exit - so you fix the
+# whole gap once instead of one apt-get per failed run.
+#
+# Usage:
+#   scripts/icestick-handoff.sh [options] design.v design.pcf
+#
+# Options:
+#   -t, --top NAME    top module name (default: the .v basename)
+#   -o, --out DIR     output directory for .json/.asc/.bin
+#                     (default: alongside design.v)
+#   -f, --flash       program the board after packing (openFPGALoader,
+#                     falling back to iceprog)
+#   -h, --help        this help
+#
+# Exit 0 on success; nonzero on a missing tool, a bad argument, or a
+# failed toolchain stage.
+
+set -euo pipefail
+
+PROG="$(basename "$0")"
+
+usage() {
+	sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# --- argument parsing --------------------------------------------------
+TOP=""
+OUTDIR=""
+FLASH=0
+POSITIONAL=()
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-t|--top)   TOP="${2:-}"; shift 2 ;;
+		-o|--out)   OUTDIR="${2:-}"; shift 2 ;;
+		-f|--flash) FLASH=1; shift ;;
+		-h|--help)  usage; exit 0 ;;
+		--)         shift; while [ $# -gt 0 ]; do POSITIONAL+=("$1"); shift; done ;;
+		-*)         echo "$PROG: unknown option: $1" >&2; usage >&2; exit 2 ;;
+		*)          POSITIONAL+=("$1"); shift ;;
+	esac
+done
+
+if [ "${#POSITIONAL[@]}" -ne 2 ]; then
+	echo "$PROG: expected exactly two positional arguments (design.v design.pcf)," \
+		"got ${#POSITIONAL[@]}" >&2
+	usage >&2
+	exit 2
+fi
+
+VERILOG="${POSITIONAL[0]}"
+PCF="${POSITIONAL[1]}"
+
+for f in "$VERILOG" "$PCF"; do
+	[ -f "$f" ] || { echo "$PROG: input not found: $f" >&2; exit 2; }
+done
+
+# top module defaults to the Verilog basename (design.v -> design)
+if [ -z "$TOP" ]; then
+	TOP="$(basename "$VERILOG")"
+	TOP="${TOP%.*}"
+fi
+
+# outputs land alongside the Verilog unless -o was given
+if [ -z "$OUTDIR" ]; then
+	OUTDIR="$(cd "$(dirname "$VERILOG")" && pwd)"
+fi
+mkdir -p "$OUTDIR"
+
+BASE="$(basename "$VERILOG")"; BASE="${BASE%.*}"
+JSON="$OUTDIR/$BASE.json"
+ASC="$OUTDIR/$BASE.asc"
+BIN="$OUTDIR/$BASE.bin"
+
+# --- preflight: collect EVERY missing tool, then fail once -------------
+# Each entry names the tool, its role in the flow, and where to get it.
+missing=()
+
+need() {
+	# need TOOL "role" "where to get it"
+	command -v "$1" >/dev/null 2>&1 && return 0
+	missing+=("$1 - $2 (get it from $3)")
+}
+
+need yosys        "synthesis (RTL -> iCE40 netlist)" \
+	"YosysHQ/yosys - https://github.com/YosysHQ/yosys"
+need nextpnr-ice40 "place & route for the iCE40-HX1K" \
+	"YosysHQ/nextpnr - https://github.com/YosysHQ/nextpnr"
+need icepack      "netlist -> bitstream packing" \
+	"project-icestorm (icestorm) - https://github.com/YosysHQ/icestorm"
+
+# The programmer is only needed with --flash; without it, a missing
+# programmer must NOT block a build-only run.
+PROGRAMMER=""
+if [ "$FLASH" -eq 1 ]; then
+	if command -v openFPGALoader >/dev/null 2>&1; then
+		PROGRAMMER="openFPGALoader"
+	elif command -v iceprog >/dev/null 2>&1; then
+		PROGRAMMER="iceprog"
+	else
+		missing+=("openFPGALoader or iceprog - flashing the iCEstick over USB" \
+			"(openFPGALoader: trabucayre/openFPGALoader; iceprog ships with project-icestorm)")
+	fi
+fi
+
+if [ "${#missing[@]}" -gt 0 ]; then
+	echo "$PROG: the iCE40 toolchain is incomplete; install the following and re-run:" >&2
+	for m in "${missing[@]}"; do
+		echo "  - $m" >&2
+	done
+	exit 1
+fi
+
+# --- the flow ----------------------------------------------------------
+run() {
+	echo "==> $*"
+	"$@"
+}
+
+run yosys -p "synth_ice40 -top $TOP -json $JSON" "$VERILOG"
+run nextpnr-ice40 --hx1k --package tq144 --pcf "$PCF" --json "$JSON" --asc "$ASC"
+run icepack "$ASC" "$BIN"
+
+echo "==> bitstream: $BIN"
+
+if [ "$FLASH" -eq 1 ]; then
+	case "$PROGRAMMER" in
+		openFPGALoader) run openFPGALoader -b ice40_generic "$BIN" ;;
+		iceprog)        run iceprog "$BIN" ;;
+	esac
+	echo "==> flashed the iCEstick with $BIN via $PROGRAMMER"
+fi


### PR DESCRIPTION
## What

Stage 1 of #264: the scripted, JLS-external handoff from the iCEstick Verilog + PCF that JLS already emits to a flashed bitstream. JLS's constraint half (`Boards.ICESTICK`, `PcfEmitter`) landed on master via PR #242; this slice adds the downstream path to a bitstream — with **no JLS-side bitstream code** (#215 H2: delegate, don't reimplement).

- **`scripts/icestick-handoff.sh`** (new) — thin wrapper. Positional `design.v design.pcf` plus a top-module name (default: the `.v` basename); runs `yosys` (`synth_ice40`) → `nextpnr-ice40 --hx1k --package tq144` → `icepack`, and, under `--flash`, programs the board via `openFPGALoader` (preferred) or `iceprog` (fallback). iCE40-HX1K / TQ144 is hard-coded to match `Boards.ICESTICK`. `set -euo pipefail`, house-style header, `==>`-prefixed stage echoes. Preflight is **all-or-nothing** (mirroring `PcfEmitter`'s error aggregation): every missing tool is reported in one pass with its role and where to get it, then a single nonzero exit; the programmer is required only under `--flash`.
- **`scripts/icestick-handoff-selftest.sh`** (new) — pure-shell guard, a twin of `wayland-rig-selftest.sh`. Drives the unmodified handoff against a hermetic stub PATH and asserts: each single-missing-tool preflight message fires for its tool, the all-missing case names every gap in one exit, the programmer check triggers only under `--flash`, and the fully-stubbed happy path advances through `icepack` (and the programmer with `--flash`, honouring the `iceprog` fallback). No real toolchain, hardware, or network.
- **`docs/icestick-bitstream-handoff.md`** (new) — the recipe: prerequisites/install pointers, the exact `jls -export design.v -board icestick -pins pins.txt design.jls` command (referencing `JLSStart`'s existing `-export`/`-board`/`-pins` CLI, unmodified here), the wrapped raw `yosys`→`nextpnr-ice40`→`icepack`→`openFPGALoader`/`iceprog` commands, an external-tool honesty note, and a #215 P2 manual-flash version-record placeholder.
- **`.github/workflows/ci.yml`** (edit) — one self-contained step runs the selftest once on the required LTS leg of the `build` lane (a non-GUI lane; the GUI jobs are untouched per the adjudicator directive), so the preflight/chaining logic can't regress silently — the same treatment ci.yml gives the GUI lanes' `*-rig-selftest.sh` scripts.

## Why

Merging #213 + #215 into #264 keeps the board story aligned per target: a board is "supported" only when both the constraint half **and** the export→bitstream path exist for it. The constraint half for the iCEstick is on master; this is its handoff half.

Out of slice (Stage 2 / remaining DoD): ECP5/LPF, real CI synth smoke, hardware flash record.

## Verification

- `scripts/icestick-handoff-selftest.sh` → `selftest: all scenarios behaved as documented` (exit 0), covering per-missing-tool messages, all-missing aggregation, the `--flash`-only programmer check, the happy path through `icepack`, and the `iceprog` fallback.
- Both scripts ShellCheck-clean (run via `nix run nixpkgs#shellcheck`).
- No Java changes; full suite green in the worktree:

```
[INFO] Tests run: 1271, Failures: 0, Errors: 0, Skipped: 5
[INFO] Tests run: 92, Failures: 0, Errors: 0, Skipped: 92
[INFO] BUILD SUCCESS
```

(The 92-skipped execution is the `@Tag("display")` UI suite, expected to skip headless.)

Advances #264 (and its trackers #59/#61 board-export lineage); Stage 1 only — not a close.
