### PR TITLE
test(collab): pin listener hygiene and record §13 handshake review (#168)

### DIFF
--- a/docs/collab-handshake-review.md
+++ b/docs/collab-handshake-review.md
@@ -1,0 +1,262 @@
+# §13 Second-Reader Review: `jls.collab.net` Handshake (AES-256-GCM form)
+
+Issue #163 / #168 Completion Criterion §13 requires the collab-transport
+handshake to be reviewed against its published pattern by a second reader
+before merge. This document is that review. It reviews the construction as
+it stands on master (tip `19b1448`) in its **AES-256-GCM** cipher form (the
+cipher swap landed via PR #194, commit `9114898`; see issue #168 comment
+5013310070). The full protocol spec is the class javadoc of
+`src/jls/collab/net/Handshake.java`.
+
+- **Reviewer role:** second reader (the transport was written by another
+  agent in an earlier cycle; this is an independent read).
+- **Published pattern reviewed against:** TLS 1.3 with raw public keys /
+  the SIGMA "sign-and-MAC" construction that TLS 1.3 instantiates
+  (ephemeral (EC)DHE, `CertificateVerify`-shape identity signatures over the
+  transcript, `Finished` MACs for key confirmation), plus the TLS 1.3 /
+  Noise sequence-number nonce for the AEAD.
+- **Scope:** transcript-binding completeness, the CertificateVerify-shape
+  signatures and Finished MACs, the key schedule (per-direction application
+  keys and the SAS from the final hash), and — the AES-GCM-specific risk —
+  nonce management (no nonce reuse under any key).
+- **Verdict: CLEAN.** No defect found; no change to `Handshake.java` or
+  `Crypto.java`. Evidence with exact citations below.
+
+The protocol is three messages. The joiner is the **initiator**, the session
+starter is the **responder**.
+
+```
+m1  initiator -> responder : MAGIC, version, 32B random, X25519 ephemeral (DER)
+m2  responder -> initiator : version, 16B session id, 32B random, X25519
+                             ephemeral (DER); then AEAD-sealed under the
+                             responder handshake key: responder identity key,
+                             display name, signature over "verify responder"
+                             + transcript hash, Finished MAC over transcript
+m3  initiator -> responder : AEAD-sealed under the initiator handshake key:
+                             initiator identity key, display name, signature
+                             over "verify initiator" + transcript hash,
+                             Finished MAC over transcript
+```
+
+---
+
+## 1. Transcript-binding completeness
+
+**Claim reviewed:** each field is appended to the running transcript exactly
+once, in the same order, on both sides, so the two transcripts are
+byte-identical and every derived key/signature/MAC binds the whole exchange.
+
+The transcript is a single append-only `ByteArrayOutputStream`
+(`Handshake.java:138`); `transcriptHash()` is SHA-256 of its current contents
+(`Handshake.java:666-669`). Tracing both sides:
+
+| Step | Initiator writes | Responder writes |
+|------|------------------|------------------|
+| m1 | full m1 message, in `firstMessage()` (`:233`) | full received m1, in `acceptFirst()` (`:273`) |
+| m2 clear | received clear prefix, `transcript.write(m2, 0, clearLength)` (`:351`) | built `clearPart`, `transcript.writeBytes(clearPart)` (`:291`) |
+| responder auth | identityDer, name, signature, finished — appended in `verifyAuth(..., false)` (`:522, :523, :531, :541`) | same four, appended in `buildAuth(false)` (`:443, :444, :447, :453`) |
+| initiator auth | identityDer, name, signature, finished — appended in `buildAuth(true)` (`:443, :444, :447, :453`) | same four, appended in `verifyAuth(..., true)` (`:522, :523, :531, :541`) |
+
+Key points confirmed:
+
+- **m1 identical on both sides.** The initiator writes the exact bytes it put
+  on the wire; the responder writes the exact bytes it received. Same bytes.
+- **m2 clear prefix identical.** The responder appends the `clearPart` it
+  builds (`:283-291`); the initiator appends exactly `clearLength` bytes,
+  where `clearLength = reply.position()` after parsing version + session id +
+  random + length-prefixed ephemeral (`:333-347`) — i.e. precisely the clear
+  prefix, not the sealed part. The sealed part is deliberately **excluded**
+  from the transcript (it is redundant: its plaintext is appended field by
+  field via `verifyAuth`, and appending the ciphertext too would just bind the
+  same content under the AEAD nonce, adding nothing). This matches the TLS 1.3
+  transcript, which hashes handshake message *contents*, not record-layer
+  encryption.
+- **Auth fields appended in lockstep.** `buildAuth` appends identityDer and
+  name, then signs against the hash *at that point*, appends the signature,
+  computes the Finished MAC against the new hash, appends it. `verifyAuth`
+  mirrors exactly: it appends identityDer and name, verifies the signature
+  against the same hash, appends the signature, verifies the Finished MAC
+  against the same hash, appends it. Because appends and hash-reads interleave
+  identically, the signer's and verifier's hashes coincide at each step.
+- **Exactly once.** No field is appended on more than one code path per side;
+  each row above is the sole writer of that field on that side.
+
+**Result: complete and mirrored.** The two transcripts are byte-identical at
+every derivation point. Any tamper to any field diverges the hash on at least
+one side, which propagates into every later key, signature, and MAC — and into
+the SAS (§3). This is the property H1 requires and the tamper-every-byte
+property test (518 trials, 100% detected, per issue #168 comment 5013111304)
+exercises.
+
+## 2. CertificateVerify-shape signatures and Finished MACs
+
+**Signatures.** Each side signs `role-label || transcriptHash` with its
+long-term Ed25519 identity key (`signaturePayload`, `:648-659`; signing at
+`:445-446`). The hash covers the full transcript to that point, which includes
+**both** ephemerals, both randoms, the session id, and the signer's own
+identity key and name (appended just before signing). Binding the identity
+signature over a transcript that includes the peer's ephemeral is exactly the
+TLS 1.3 `CertificateVerify` shape and is what defeats a key-compromise /
+unknown-key-share reflection: the signature is meaningless outside this exact
+session.
+
+- **Role separation.** The initiator signs under `"JLSCOLLAB1 verify
+  initiator"` and the responder under `"JLSCOLLAB1 verify responder"`
+  (`:651-652`). Distinct, ASCII, domain-prefixed labels prevent a signature
+  produced in one role from being replayed as the other role's signature.
+- **Verification uses the *claimed* key from the same message**
+  (`parseIdentity`, `:521`, then `IdentityKey.verify(claimed, ...)` at `:524`),
+  and the authenticated key becomes `peerIdentity` only after both the
+  signature and the Finished MAC pass (`:542`). The `KnownPeers`
+  VERIFIED/UNKNOWN/KEY_CHANGED trust decision (P4) is layered on the
+  fingerprint of that authenticated key — correct: the handshake authenticates
+  "the holder of this key is live in this session," and trust-on-first-use is a
+  separate policy.
+
+**Finished MACs.** Each side computes HMAC-SHA256 over the current transcript
+hash under a per-role, per-direction finished key (`buildAuth` `:448-453`;
+verified in `verifyAuth` `:532-540`, compared with the constant-time
+`MessageDigest.isEqual`). This is the TLS 1.3 `Finished` key-confirmation step:
+it proves the peer derived the same handshake secrets (hence completed the same
+DH with the same transcript), closing the gap between "signature is valid" and
+"peer actually holds the session keys."
+
+**Ordering / downgrade.** `version` is the first field of both m1 and m2, is
+checked equal to `VERSION` before anything else (`:262-266`, `:334-338`), and —
+critically — is part of the transcript, so a downgrade tamper is caught by the
+MAC/signature even if a future multi-version negotiation is added. `MAGIC` is
+compared with the constant-time `MessageDigest.isEqual` (`:257`). The `State`
+machine (`:849-855`) enforces that each message method runs exactly once, in
+order, per role, and any rejection drives the handshake permanently to `FAILED`
+(`:308-311, :375-378, :407-410`) — rejection, never repair (#38 discipline).
+
+**Result: correct.** Signatures are transcript-bound CertificateVerify-shape
+with domain-separated role labels; Finished MACs provide key confirmation and
+use constant-time comparison.
+
+## 3. Key schedule
+
+**Claim reviewed:** handshake keys derive from the post-hello hash; the two
+per-direction application keys and the SAS secret derive from the final hash;
+directions are assigned consistently by role.
+
+All keys come from `Crypto.hkdf(sharedSecret, label, SALT, hash, length)`
+(`Crypto.java:63-84`), HKDF-SHA256 with the DH shared secret as IKM, a fixed
+per-version salt (`SALT`, `Handshake.java:84-85`), and the transcript hash
+bound into the expand `info` alongside a purpose label (`Crypto.java:66-71`).
+Two derivation points:
+
+- **Post-hello** (`deriveHandshakeKeys`, `:620-637`), from `helloHash` = hash
+  after m1 + m2-clear: `responderHandshakeKey` ("hs resp"),
+  `initiatorHandshakeKey` ("hs init"), `responderFinishedKey` ("fin resp"),
+  `initiatorFinishedKey` ("fin init"). Four distinct ASCII labels ⇒ four
+  independent 32-byte keys.
+- **Final** (`completeLink`, `:550-583`), from `finalHash` = hash after both
+  auth blocks: `initiatorToResponder` ("app i2r"), `responderToInitiator`
+  ("app r2i"), and the 8-byte `sasSecret` ("sas").
+
+**Direction assignment** (`:576-582`): a link's `sendKey`/`receiveKey` are
+`(initiatorToResponder, responderToInitiator)` for the initiator and the swap
+for the responder. So one side's send key is the other's receive key, per
+direction, with no key shared across directions. `SecureLink`'s constructor
+stores them as `sendKey`/`receiveKey` (`SecureLink.java:80-90`) and never
+crosses them.
+
+**SAS binding.** The SAS derives from `finalHash`, which covers both identity
+keys, both ephemerals, both randoms, and the session id (§1). A MITM cannot
+produce matching SAS on both sides without matching the entire transcript,
+which the CertificateVerify signatures forbid. This is the H1 property.
+
+Distinctness across the whole schedule is guaranteed by distinct HKDF labels
+*and*, between the two derivation points, distinct transcript hashes; no label
+is reused, so no two keys collide, and no handshake key is ever reused as an
+application key.
+
+**Result: correct.** Per-direction application keys and SAS derive from the
+full-transcript final hash; all keys are label- and hash-separated.
+
+## 4. Nonce management (AES-256-GCM-specific)
+
+**This is the review's highest-risk item:** AES-GCM catastrophically fails
+(loss of confidentiality *and* authentication) if a (key, nonce) pair is ever
+reused. The nonce here is a counter nonce: 4 zero bytes || big-endian 64-bit
+counter (`Crypto.nonce`, `:230-236`). Uniqueness therefore reduces to: *is the
+counter unique for every use of each key?*
+
+**Handshake phase.** Exactly two AEAD seals occur, each under a **different**
+key and each with counter `0`:
+
+- m2 sealed with `responderHandshakeKey`, counter `0` (`:299-300`); opened by
+  the initiator with the same key and counter `0` (`openAuth` → `aeadOpen(...,
+  0, ...)`, `:359, :481`).
+- m3 sealed with `initiatorHandshakeKey`, counter `0` (`:367-368`); opened by
+  the responder with the same key and counter `0` (`:404, :481`).
+
+`responderHandshakeKey` and `initiatorHandshakeKey` are distinct HKDF outputs
+(§3). Each handshake key seals **exactly one** message. Reusing counter `0` is
+safe **because the keys differ** — nonce uniqueness is a per-key property.
+There is no third seal under either key anywhere in the class. ✔ no reuse.
+
+**Data phase** (`SecureLink`). `sendCounter` and `receiveCounter` start at 0
+and increment strictly by one after every successful seal/open (`seal`
+`:157-159`; `openCiphertext` `:273-275`). `sendKey` ≠ `receiveKey` (§3), so the
+two counters index two different keys — the send stream and receive stream
+never collide even though both start at 0. Within one direction the counter is
+strictly increasing, so each (key, counter) — hence each (key, nonce) — pair is
+unique. The 64-bit counter cannot realistically wrap (2⁶⁴ frames at a 1 MiB
+cap is not reachable), and there is no reset path: the counters are only ever
+incremented, never rewound.
+
+Additional AES-GCM hygiene confirmed:
+
+- **Fail-closed on the first bad tag.** Any `AEADBadTagException` poisons the
+  link (`poison`, `:331-335`); `requireHealthy` (`:315-321`) then rejects every
+  later seal and open. Because the receive counter is **not** advanced on a
+  failed open (the increment at `:275` is after the successful `aeadOpen`
+  returns), an attacker cannot burn a nonce or desynchronize the counters with
+  a forged frame — the link is simply dead. This also gives replay/reorder/drop
+  resistance for free: a frame that is not the next expected one decrypts under
+  the wrong counter and fails the tag.
+- **Tag length pinned.** 128-bit tag (`TAG_BITS = TAG_BYTES * 8 = 128`,
+  `Crypto.java:38, 44`), the GCM maximum, applied to both seal and open.
+- **AAD domain separation.** Handshake seals bind `"JLSCOLLAB1 m2"` / `"…m3"`
+  as AAD (`aad`, `:678-682`); data frames bind `"JLSCOLLAB1 frame"`
+  (`SecureLink.java:39-40`). A handshake ciphertext cannot be replayed as a
+  data frame (different AAD *and* different key).
+- **Over-cap rejection before allocation.** `SecureLink.open` /`openFrame`
+  reject an over-cap or under-tag length *before* allocating the ciphertext
+  buffer (`SecureLink.java:193-201, 230-238`), so a hostile length prefix
+  cannot exhaust memory (#38 discipline; P2).
+
+**Result: no nonce reuse is possible** under any key, in either phase. The
+counter-nonce construction is the standard TLS 1.3 / Noise sequence-number
+nonce and is used correctly for AES-256-GCM.
+
+---
+
+## Findings
+
+None. The construction is a faithful TLS-1.3-RPK / SIGMA instantiation over
+JDK primitives:
+
+1. Transcript binding is complete, mirrored, and appended-exactly-once on both
+   sides (§1).
+2. Identity signatures are transcript-bound CertificateVerify-shape with
+   domain-separated role labels, and Finished MACs give key confirmation with
+   constant-time comparison (§2).
+3. The key schedule derives handshake keys from the post-hello hash and
+   per-direction application keys plus the SAS from the full-transcript final
+   hash, all label- and hash-separated (§3).
+4. Nonce management is safe: each handshake key seals exactly one message
+   (distinct keys, counter 0), and `SecureLink` uses a strictly-increasing
+   per-direction counter nonce over per-direction keys — no (key, nonce) pair
+   can ever repeat (§4).
+
+No change to `Handshake.java` or `Crypto.java` is warranted. The runtime
+listener-hygiene half of P3 is pinned separately by
+`test/jls/BootListenerHygieneTest.java`; the structural confinement is pinned
+by `SocketConfinementRatchetTest` and
+`ArchitectureRulesTest.socketEndpointsAreConfinedToCollabNet`.
+
+**Reviewed against pattern:** TLS 1.3 raw-public-key / SIGMA. **Verdict:
+CLEAN.**

--- a/test/jls/BootListenerHygieneTest.java
+++ b/test/jls/BootListenerHygieneTest.java
@@ -1,0 +1,295 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import jls.sim.BatchSimulator;
+
+/**
+ * The runtime complement to the network-surface confinement ratchets
+ * (issue #168, prediction P3, the listener-hygiene half): the two
+ * headless boot paths - batch simulation and the default GUI start's
+ * command-line parse - must open no network listener.
+ *
+ * <p>{@link SocketConfinementRatchetTest} (source-level) and
+ * {@code ArchitectureRulesTest.socketEndpointsAreConfinedToCollabNet}
+ * (bytecode-level) pin structurally that socket construction lives only
+ * under {@code jls.collab.net}; today the only bind sites there
+ * ({@code SessionListener}, {@code SocketSession}) are never referenced
+ * from a boot path, so nothing binds during startup. This test adds the
+ * missing behavioural pin: it drives the real headless boot cores and
+ * observes that no LISTEN socket appears.</p>
+ *
+ * <p>Two independent assertions guard each path. The portable one is an
+ * {@link org.junit.jupiter.api.Assertions#assertTimeoutPreemptively
+ * assertTimeoutPreemptively}: a future regression that put an
+ * {@code accept()} in the boot path would block forever and time out.
+ * The precise one, Linux-gated, cross-references this JVM's socket file
+ * descriptors ({@code /proc/self/fd}) with the LISTEN rows of
+ * {@code /proc/self/net/tcp} and {@code tcp6}, snapshotting the set of
+ * listening sockets this process owns before and after the boot path and
+ * asserting boot introduced none. On a platform without {@code /proc}
+ * the precise assertion is skipped and the timeout remains the pin.</p>
+ *
+ * <p>By design this test drives only the safe headless cores:
+ * {@link BatchSimulator#runSim()} (the batch boot core) and
+ * {@link JLSStart#parseCommandLine(String[])} (the GUI-branch selector).
+ * It never calls {@code JLSStart.start()} or {@code new JLSStart()},
+ * which call {@link System#exit} and, on the GUI branch, throw
+ * {@code HeadlessException}; the window's socket-freedom is already
+ * covered by the confinement ratchets and its display path is out of
+ * this slice's scope.</p>
+ */
+class BootListenerHygieneTest {
+
+    /** The Linux LISTEN state code in {@code /proc/net/tcp}'s st field. */
+    private static final String TCP_LISTEN = "0A";
+
+    /**
+     * Build a tiny circuit in the on-disk text format - one constant
+     * wired to a watched output pin - exactly as the editor saves it,
+     * mirroring {@code BatchSimulationGoldenTest}'s CircuitBuilder idiom.
+     *
+     * @return the circuit text.
+     */
+    private static String tinyCircuitText() {
+
+        StringBuilder text = new StringBuilder("CIRCUIT hygiene\n");
+        // constant, id 0
+        text.append("ELEMENT Constant\n")
+            .append(" int id 0\n")
+            .append(" int x 60\n int y 60\n")
+            .append(" int width 24\n int height 24\n")
+            .append(" Int value 1\n")
+            .append(" int base 10\n")
+            .append(" String orient \"RIGHT\"\n")
+            .append("END\n");
+        // output pin, id 1
+        text.append("ELEMENT OutputPin\n")
+            .append(" int id 1\n")
+            .append(" int x 480\n int y 120\n")
+            .append(" int width 48\n int height 24\n")
+            .append(" String name \"out\"\n")
+            .append(" int bits 1\n")
+            .append(" int watch 1\n")
+            .append(" String orient \"RIGHT\"\n")
+            .append("END\n");
+        // wire the constant's output to the pin's input as two ends
+        appendWireEnd(text, 2, 0, "output", 3);
+        appendWireEnd(text, 3, 1, "input", 2);
+        return text.append("ENDCIRCUIT\n").toString();
+    } // end of tinyCircuitText method
+
+    /**
+     * Append one attached wire end, as the editor saves it.
+     *
+     * @param text     The circuit text being built.
+     * @param id       This wire end's element id.
+     * @param attachTo The element id this end attaches to.
+     * @param put      The put name on that element.
+     * @param otherEnd The id of the wire's other end.
+     */
+    private static void appendWireEnd(StringBuilder text, int id,
+            int attachTo, String put, int otherEnd) {
+
+        text.append("ELEMENT WireEnd\n")
+            .append(" int id ").append(id).append('\n')
+            .append(" int x ").append(12 * id).append('\n')
+            .append(" int y 240\n")
+            .append(" int width 8\n int height 8\n")
+            .append(" String put \"").append(put).append("\"\n")
+            .append(" ref attach ").append(attachTo).append('\n')
+            .append(" ref wire ").append(otherEnd).append('\n')
+            .append("END\n");
+    } // end of appendWireEnd method
+
+    @Test
+    void batchModeOpensNoListener() throws Exception {
+
+        Circuit circuit = new Circuit("hygiene");
+        assertTrue(circuit.load(new Scanner(tinyCircuitText())),
+                () -> "load failed: " + JLSInfo.loadError);
+        assertTrue(circuit.finishLoad(null),
+                () -> "finishLoad failed: " + JLSInfo.loadError);
+
+        BatchSimulator sim = new BatchSimulator();
+        sim.setCircuit(circuit);
+        sim.setTimeLimit(1_000_000);
+
+        Set<Long> before = listeningSocketInodes();
+        // a future accept()-in-boot regression would block here and the
+        // preemptive timeout would fail the test; the real batch core
+        // runs to quiescence in microseconds
+        assertTimeoutPreemptively(Duration.ofSeconds(30), sim::runSim,
+                "batch simulation must run to quiescence without blocking"
+                        + " on any network accept");
+        Set<Long> after = listeningSocketInodes();
+
+        assertNoNewListeners(before, after,
+                "batch simulation boot must open no network listener");
+    } // end of batchModeOpensNoListener method
+
+    @Test
+    void defaultGuiStartOpensNoListener() throws Exception {
+
+        Path circuitFile = Files.createTempFile("jls-hygiene", ".jls");
+        Files.write(circuitFile,
+                tinyCircuitText().getBytes(StandardCharsets.UTF_8));
+
+        boolean savedBatch = JLSInfo.batch;
+        try {
+            // start clean so the assertion proves the parse selected the
+            // GUI branch, not that a prior test left the flag unset
+            JLSInfo.batch = false;
+            String[] args = { circuitFile.toString() };
+
+            Set<Long> before = listeningSocketInodes();
+            // parseCommandLine is the mode selector start() dispatches on;
+            // driving it (never start()) exercises the default-GUI decision
+            // headlessly. The timeout still guards against a parse-time bind.
+            assertTimeoutPreemptively(Duration.ofSeconds(30),
+                    () -> JLSStart.parseCommandLine(args),
+                    "command-line parsing must not block on any network"
+                            + " accept");
+            Set<Long> after = listeningSocketInodes();
+
+            assertFalse(JLSInfo.batch,
+                    "no -b flag must select the GUI branch (batch == false)");
+            assertNoNewListeners(before, after,
+                    "default GUI start's parse must open no network listener");
+        } finally {
+            JLSInfo.batch = savedBatch;
+            Files.deleteIfExists(circuitFile);
+        }
+    } // end of defaultGuiStartOpensNoListener method
+
+    /**
+     * Assert that a boot path introduced no new listening socket owned by
+     * this JVM. Linux-gated: on a platform without {@code /proc/self/net}
+     * the precise check is skipped (the surrounding timeout assertion
+     * remains the portable pin), so the test never gives a false pass by
+     * measuring nothing on a platform it cannot inspect.
+     *
+     * @param before The listening inodes owned before the boot path.
+     * @param after  The listening inodes owned after it.
+     * @param what   The message describing the pinned boot path.
+     */
+    private static void assertNoNewListeners(Set<Long> before,
+            Set<Long> after, String what) {
+
+        assumeTrue(procNetAvailable(),
+                "the /proc listener probe needs Linux /proc/self/net");
+        Set<Long> introduced = new TreeSet<Long>(after);
+        introduced.removeAll(before);
+        assertEquals(Set.of(), introduced, what
+                + " (new LISTEN socket inodes owned by this JVM: "
+                + introduced + ")");
+    } // end of assertNoNewListeners method
+
+    /**
+     * Whether this platform exposes the {@code /proc} tables the precise
+     * probe reads.
+     *
+     * @return true on Linux with {@code /proc/self/net/tcp}.
+     */
+    private static boolean procNetAvailable() {
+
+        return Files.exists(Path.of("/proc/self/net/tcp"));
+    } // end of procNetAvailable method
+
+    /**
+     * The inodes of the LISTEN sockets this JVM currently owns: the
+     * intersection of the socket inodes named by {@code /proc/self/fd}
+     * and the inodes of the LISTEN rows in {@code /proc/self/net/tcp} and
+     * {@code tcp6}. An empty set on a non-{@code /proc} platform, where
+     * the precise assertion is skipped anyway.
+     *
+     * @return the owned listening-socket inodes.
+     *
+     * @throws IOException if a {@code /proc} table cannot be read.
+     */
+    private static Set<Long> listeningSocketInodes() throws IOException {
+
+        if (!procNetAvailable()) {
+            return Set.of();
+        }
+        Set<Long> ownFdInodes = ownSocketFdInodes();
+        Set<Long> listening = new HashSet<Long>();
+        for (String table : List.of("/proc/self/net/tcp",
+                "/proc/self/net/tcp6")) {
+            Path path = Path.of(table);
+            if (!Files.exists(path)) {
+                continue;
+            }
+            for (String line : Files.readAllLines(path)) {
+                String[] cols = line.trim().split("\\s+");
+                // sl local rem st ... uid timeout inode : st is col 3,
+                // inode is col 9; the header row has no numeric st
+                if (cols.length < 10 || !TCP_LISTEN.equals(cols[3])) {
+                    continue;
+                }
+                try {
+                    long inode = Long.parseLong(cols[9]);
+                    if (ownFdInodes.contains(inode)) {
+                        listening.add(inode);
+                    }
+                } catch (NumberFormatException notARow) {
+                    // header or malformed row; skip
+                }
+            }
+        }
+        return listening;
+    } // end of listeningSocketInodes method
+
+    /**
+     * The socket inodes this JVM holds open, read from the
+     * {@code socket:[inode]} targets of {@code /proc/self/fd} symlinks.
+     *
+     * @return the socket inodes of this process's open file descriptors.
+     *
+     * @throws IOException if the fd directory cannot be listed.
+     */
+    private static Set<Long> ownSocketFdInodes() throws IOException {
+
+        Set<Long> inodes = new HashSet<Long>();
+        Path fdDir = Path.of("/proc/self/fd");
+        if (!Files.isDirectory(fdDir)) {
+            return inodes;
+        }
+        try (Stream<Path> fds = Files.list(fdDir)) {
+            fds.forEach(fd -> {
+                try {
+                    String target = Files.readSymbolicLink(fd).toString();
+                    if (target.startsWith("socket:[")
+                            && target.endsWith("]")) {
+                        inodes.add(Long.parseLong(target.substring(
+                                "socket:[".length(),
+                                target.length() - 1)));
+                    }
+                } catch (IOException | NumberFormatException vanished) {
+                    // the fd closed between listing and reading, or its
+                    // target was not a plain socket inode; skip it
+                }
+            });
+        }
+        return inodes;
+    } // end of ownSocketFdInodes method
+
+} // end of BootListenerHygieneTest class


### PR DESCRIPTION
## What

Delivers the two headless-first remainders of collab Stage 1a (#168), the
active work item of the #163 program. Two new files, one commit, both fully
headless:

1. **`test/jls/BootListenerHygieneTest.java`** — the runtime complement to the
   network-surface confinement ratchets (prediction P3, the *listener-hygiene*
   half): the two headless boot paths must open **no** network listener.
2. **`docs/collab-handshake-review.md`** — the §13 second-reader adversarial
   review of the AES-256-GCM handshake against its published pattern.

## Why

`SocketConfinementRatchetTest` (source-level) and
`ArchitectureRulesTest.socketEndpointsAreConfinedToCollabNet` (bytecode-level)
already pin *structurally* that socket construction lives only under
`jls.collab.net`, and that the only bind sites (`SessionListener`,
`SocketSession`) are never referenced from a boot path. What was missing is the
*behavioural* pin — a runtime observation that booting actually binds nothing —
and the §13 completion criterion: the handshake reviewed against its published
pattern by a second reader before merge. This PR closes both.

## Listener-hygiene test

Drives only the safe headless cores and never `JLSStart.start()` /
`new JLSStart()` (which call `System.exit` and, on the GUI branch, throw
`HeadlessException`):

- `batchModeOpensNoListener()` — builds a tiny circuit in the on-disk text
  format (the `BatchSimulationGoldenTest` idiom), loads it through the real
  loader, and runs the real `jls.sim.BatchSimulator.runSim()` inside a listener
  probe; asserts zero new listeners.
- `defaultGuiStartOpensNoListener()` — drives
  `JLSStart.parseCommandLine(new String[]{circuitFile})` (no `-b`); asserts the
  GUI branch was selected (`JLSInfo.batch == false`) and zero new listeners.

Each path carries **two independent assertions**:

- **Portable:** `assertTimeoutPreemptively(30s, …)` — a future
  `accept()`-in-boot regression would block forever and fail the test.
- **Precise (Linux-gated):** cross-references this JVM's socket file descriptors
  (`/proc/self/fd`) with the LISTEN rows of `/proc/self/net/tcp` and `tcp6`,
  snapshotting the set of listening sockets this process owns before and after
  each boot path and asserting boot introduced none. Gated with
  `assumeTrue(Files.exists("/proc/self/net/tcp"))` so a non-Linux host skips the
  precise check gracefully while the timeout remains the pin.

## §13 handshake review (AES-256-GCM form)

`docs/collab-handshake-review.md` reviews the 3-message TLS-1.3-RPK / SIGMA
construction (spec in the `Handshake` javadoc) in its AES-256-GCM cipher form
(the swap landed via PR #194). It covers, with exact code citations:

- **Transcript binding** — a side-by-side trace confirming every field is
  appended exactly once, in the same order, on both sides (byte-identical
  transcripts); the m2 clear prefix is bound and the redundant sealed part is
  correctly excluded.
- **Signatures & Finished MACs** — CertificateVerify-shape identity signatures
  over the transcript with domain-separated `verify initiator` / `verify
  responder` role labels, and HMAC-SHA256 Finished MACs compared with the
  constant-time `MessageDigest.isEqual`.
- **Key schedule** — post-hello handshake keys, per-direction application keys
  and the 8-byte SAS from the full-transcript final hash, all label- and
  hash-separated.
- **Nonce management (the AES-GCM-specific risk)** — each handshake key seals
  exactly one message under a distinct key at counter 0 (m2 under
  `responderHandshakeKey`, m3 under `initiatorHandshakeKey`), and `SecureLink`
  uses a strictly-increasing per-direction counter nonce over per-direction
  keys; the receive counter is not advanced on a failed open. No `(key, nonce)`
  pair can ever repeat.

**Verdict: CLEAN.** No defect found; no change to `Handshake.java` or
`Crypto.java`.

## Verification

```
$ nix develop --command bash -c 'mvn -Dtest=BootListenerHygieneTest,SocketConfinementRatchetTest,ArchitectureRulesTest test'
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in jls.BootListenerHygieneTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in jls.SocketConfinementRatchetTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0 -- in jls.ArchitectureRulesTest
BUILD SUCCESS

$ nix develop --command bash -c 'mvn verify'
Tests run: 1273, Failures: 0, Errors: 0, Skipped: 5      (headless group)
Tests run: 92,   Failures: 0, Errors: 0, Skipped: 92     (display group — skips headless, expected)
SpotBugs: BugInstance size is 0
BUILD SUCCESS
```

Scope: two new files only. No source under `src/` is touched (the review found
nothing to fix). Repo stays `@NullMarked` / NullAway-clean and SpotBugs-clean.

Advances #163.
