### PR TITLE
feat(hdl): accept single-port sync-write RAM in CellValidator

### DIFF
--- a/src/jls/hdl/imp/NetlistImporter.java
+++ b/src/jls/hdl/imp/NetlistImporter.java
@@ -253,7 +253,7 @@ public final class NetlistImporter {
 					+ " increment does not yet realize; the mapper so far"
 					+ " covers module ports, $not/$and/$or/$xor, $mux, and"
 					+ " constants (issue #61 - later increments add the"
-					+ " Adder, Register, TriState, reductions and"
+					+ " Adder, Register, TriState, Memory, reductions and"
 					+ " hierarchy)");
 			break;
 		}

--- a/src/jls/hdl/yosys/CellValidator.java
+++ b/src/jls/hdl/yosys/CellValidator.java
@@ -31,10 +31,14 @@ import org.jspecify.annotations.Nullable;
  * carries a message written for a student — what the construct is,
  * why JLS cannot represent it, and the rewrite that will import.</li>
  * <li><b>Memories, decided by parameters.</b> A {@code $mem}/
- * {@code $mem_v2} with no write ports and one combinational
- * (unclocked) read port is the async-read ROM that maps faithfully
- * onto JLS Memory (per the resolved 2026-07-17 decisions, imported
- * with access time 0); anything else is a teachable reject.</li>
+ * {@code $mem_v2} with one combinational (unclocked) read port
+ * imports onto JLS Memory (per the resolved decisions, with access
+ * time 0) in two shapes: no write ports is the async-read ROM, and
+ * a single rising-edge write port (a dedicated clock, rising edge)
+ * is the common student RAM that maps to Memory with synchronous
+ * write (Memory {@code sync 1}). Clocked reads, multiple read or
+ * write ports, and level-sensitive or falling-edge writes are still
+ * teachable rejects.</li>
  * <li><b>Pipeline leftovers.</b> Internal cells the pass pipeline
  * should have eliminated ({@code $sub}, {@code $eq}, {@code $pmux},
  * ...). Their appearance means a techmap rule is missing — a JLS
@@ -95,11 +99,15 @@ public final class CellValidator {
 
 	/** The teachable-reject message for unsupported memories. */
 	private static final String MEMORY_MESSAGE =
-			"clocked or multi-port memory: JLS Memory is a"
-			+ " single-port memory read asynchronously. Only"
-			+ " ROM-style arrays - initialized, read with a plain"
-			+ " assign from one place, and never written - import"
-			+ " today";
+			"clocked-read or multi-port memory: JLS Memory is a"
+			+ " single-port memory read asynchronously. A memory"
+			+ " imports only as one asynchronous read port paired with"
+			+ " either no write port (a ROM) or a single rising-edge"
+			+ " write port (a RAM). Clocked reads, extra ports, and"
+			+ " level-sensitive or falling-edge writes do not import -"
+			+ " read the array with a plain assign and, if it is"
+			+ " written, write it from one \"always @(posedge clk)\""
+			+ " block";
 
 	/** Memory cell types, decided by their parameters. */
 	private static final Set<String> MEMORY_TYPES =
@@ -218,10 +226,18 @@ public final class CellValidator {
 	} // end of check method
 
 	/**
-	 * Decides a {@code $mem}/{@code $mem_v2} cell: the async-read
-	 * ROM shape (no write ports, exactly one read port, read port
-	 * unclocked) is supported; everything else gets the memory
-	 * teaching message.
+	 * Decides a {@code $mem}/{@code $mem_v2} cell. Both accepted
+	 * shapes have exactly one unclocked ({@code RD_CLK_ENABLE == 0})
+	 * read port; then no write ports ({@code WR_PORTS == 0}) is the
+	 * async-read ROM, and one write port ({@code WR_PORTS == 1}) is
+	 * accepted only when it is a dedicated rising-edge clock
+	 * ({@code WR_CLK_ENABLE == 1} and {@code WR_CLK_POLARITY == 1}) -
+	 * the RAM that maps to Memory with synchronous write. Clocked
+	 * reads, multiple read or write ports, and level-sensitive or
+	 * falling-edge writes get the memory teaching message. The write
+	 * clock parameters are read with a default of 0 so a memory with
+	 * no clock params (an async/level-sensitive write) rejects rather
+	 * than throwing.
 	 *
 	 * @param cell The memory cell.
 	 *
@@ -233,13 +249,26 @@ public final class CellValidator {
 	private static @Nullable String checkMemory(YosysNetlist.Cell cell)
 			throws NetlistFormatException {
 
-		long writePorts = cell.param("WR_PORTS");
 		long readPorts = cell.param("RD_PORTS");
 		// one bit per read port; nonzero means some port is clocked
 		long readClockEnable = cell.param("RD_CLK_ENABLE");
-		if (writePorts == 0 && readPorts == 1
-				&& readClockEnable == 0) {
+		if (readPorts != 1 || readClockEnable != 0) {
+			return MEMORY_MESSAGE;
+		}
+		long writePorts = cell.param("WR_PORTS");
+		if (writePorts == 0) {
+			// async-read ROM: no writes at all
 			return null;
+		}
+		if (writePorts == 1) {
+			// one write port; accept only a dedicated rising-edge
+			// clock (Memory writes are rising-edge only). Absent clock
+			// params default to 0 -> level-sensitive/async -> reject.
+			long writeClockEnable = cell.param("WR_CLK_ENABLE", 0);
+			long writeClockPolarity = cell.param("WR_CLK_POLARITY", 0);
+			if (writeClockEnable == 1 && writeClockPolarity == 1) {
+				return null;
+			}
 		}
 		return MEMORY_MESSAGE;
 	} // end of checkMemory method

--- a/test/jls/hdl/imp/NetlistImporterTest.java
+++ b/test/jls/hdl/imp/NetlistImporterTest.java
@@ -235,6 +235,18 @@ class NetlistImporterTest {
 	}
 
 	@Test
+	void syncWriteRamValidatesButIsNotYetRealized() {
+		ImportException ex = assertThrows(ImportException.class,
+				() -> imp("reject_ram_sync.json"));
+		assertTrue(ex.getMessage().contains("$mem_v2"),
+				"message must name the cell: " + ex.getMessage());
+		assertTrue(ex.getMessage().contains("not yet realize"),
+				"the validator-accepted sync-write RAM must reject as a"
+						+ " not-yet-built cell, not mis-map: "
+						+ ex.getMessage());
+	}
+
+	@Test
 	void teachableRejectRelaysValidatorMessage() {
 		ImportException ex = assertThrows(ImportException.class,
 				() -> imp("reject_adff.json"));

--- a/test/jls/hdl/yosys/CellValidatorTest.java
+++ b/test/jls/hdl/yosys/CellValidatorTest.java
@@ -150,6 +150,55 @@ class CellValidatorTest {
 	}
 
 	@Test
+	void syncWriteSinglePortRamIsSupported() throws Exception {
+		YosysNetlist netlist = netlistWith("'ram': "
+				+ cell("$mem_v2", "ram.v:5.3-8.6",
+						"'WR_PORTS': 1, 'RD_PORTS': 1,"
+						+ " 'RD_CLK_ENABLE': '0',"
+						+ " 'WR_CLK_ENABLE': '1',"
+						+ " 'WR_CLK_POLARITY': '1'"));
+		assertEquals(List.of(), CellValidator.validate(netlist));
+	}
+
+	@Test
+	void fallingEdgeWriteRejected() throws Exception {
+		YosysNetlist netlist = netlistWith("'ram': "
+				+ cell("$mem_v2", "ram.v:5.3-8.6",
+						"'WR_PORTS': 1, 'RD_PORTS': 1,"
+						+ " 'RD_CLK_ENABLE': '0',"
+						+ " 'WR_CLK_ENABLE': '1',"
+						+ " 'WR_CLK_POLARITY': '0'"));
+		List<CellViolation> violations =
+				CellValidator.validate(netlist);
+		assertEquals(1, violations.size());
+		assertTrue(violations.get(0).message()
+				.contains("single-port"),
+				violations.get(0).message());
+	}
+
+	@Test
+	void levelSensitiveWriteRejected() throws Exception {
+		YosysNetlist netlist = netlistWith("'ram': "
+				+ cell("$mem_v2", "ram.v:5.3-8.6",
+						"'WR_PORTS': 1, 'RD_PORTS': 1,"
+						+ " 'RD_CLK_ENABLE': '0',"
+						+ " 'WR_CLK_ENABLE': '0',"
+						+ " 'WR_CLK_POLARITY': '1'"));
+		assertEquals(1, CellValidator.validate(netlist).size());
+	}
+
+	@Test
+	void multiWritePortRejected() throws Exception {
+		YosysNetlist netlist = netlistWith("'ram': "
+				+ cell("$mem_v2", "ram.v:5.3-8.6",
+						"'WR_PORTS': 2, 'RD_PORTS': 1,"
+						+ " 'RD_CLK_ENABLE': '0',"
+						+ " 'WR_CLK_ENABLE': '11',"
+						+ " 'WR_CLK_POLARITY': '11'"));
+		assertEquals(1, CellValidator.validate(netlist).size());
+	}
+
+	@Test
 	void writtenMemoryIsRejected() throws Exception {
 		YosysNetlist netlist = netlistWith("'ram': "
 				+ cell("$mem_v2", "",

--- a/test/resources/hdl/import/reject_ram_sync.json
+++ b/test/resources/hdl/import/reject_ram_sync.json
@@ -1,0 +1,41 @@
+{
+  "creator": "hand-written fixture (issue #61 importer test): $mem_v2 single rising-edge write port + one async read port - validator-supported (maps to Memory sync 1) but not yet realized by the mapper",
+  "modules": {
+    "rammod": {
+      "attributes": { "top": 1 },
+      "ports": {
+        "clk": { "direction": "input", "bits": [ 2 ] },
+        "we": { "direction": "input", "bits": [ 3 ] },
+        "addr": { "direction": "input", "bits": [ 4, 5 ] },
+        "wdata": { "direction": "input", "bits": [ 6, 7, 8, 9 ] },
+        "rdata": { "direction": "output", "bits": [ 10, 11, 12, 13 ] }
+      },
+      "cells": {
+        "ram_0": {
+          "hide_name": 1,
+          "type": "$mem_v2",
+          "parameters": {
+            "WIDTH": 4,
+            "SIZE": 4,
+            "ABITS": 2,
+            "RD_PORTS": 1,
+            "RD_CLK_ENABLE": "0",
+            "WR_PORTS": 1,
+            "WR_CLK_ENABLE": "1",
+            "WR_CLK_POLARITY": "1"
+          },
+          "port_directions": {
+            "RD_ADDR": "input", "RD_DATA": "output",
+            "WR_CLK": "input", "WR_ADDR": "input",
+            "WR_DATA": "input", "WR_EN": "input"
+          },
+          "connections": {
+            "RD_ADDR": [ 4, 5 ], "RD_DATA": [ 10, 11, 12, 13 ],
+            "WR_CLK": [ 2 ], "WR_ADDR": [ 4, 5 ],
+            "WR_DATA": [ 6, 7, 8, 9 ], "WR_EN": [ 3, 3, 3, 3 ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Narrows the `CellValidator` memory rule to the newly-mappable RAM shape and keeps the `NetlistImporter` honest for it. First slice of "the cell-to-element mapper reaches memories" — the binding, Yosys-free deliverable is the validator narrowing.

- **`src/jls/hdl/yosys/CellValidator.java`** — `checkMemory()` now accepts a `$mem`/`$mem_v2` whose read port is unclocked (`RD_CLK_ENABLE == 0`) and single (`RD_PORTS == 1`) in two shapes: `WR_PORTS == 0` is the existing async-read ROM, and `WR_PORTS == 1` is accepted only when it is a dedicated rising-edge write (`WR_CLK_ENABLE == 1` **and** `WR_CLK_POLARITY == 1`) — the common student RAM that maps to JLS Memory with synchronous write (`sync 1`). Clocked reads, zero/multiple read ports, multiple write ports, and level-sensitive/falling-edge writes still reject with the memory teaching message. `WR_CLK_ENABLE`/`WR_CLK_POLARITY` are read via `cell.param(name, 0)` so the existing absent-clock-param reject fixtures resolve to a clean reject rather than throwing `NetlistFormatException`. `MEMORY_MESSAGE` and the class Javadoc are updated to describe the RAM-imports-now behavior.
- **`src/jls/hdl/imp/NetlistImporter.java`** — the sync-write RAM now passes the validator but is not realized this slice, so it correctly falls to `mapCell`'s default branch. Appended `Memory` to that branch's "later increments add ..." list so the reject message stays accurate.
- **`test/jls/hdl/yosys/CellValidatorTest.java`** — four new cases: `syncWriteSinglePortRamIsSupported`, `fallingEdgeWriteRejected`, `levelSensitiveWriteRejected`, `multiWritePortRejected`. All pre-existing memory cases (ROM accept, clocked-read reject, written-without-clock reject, multi-read reject) stay green under the restructured `checkMemory`, exercising the missing-param default path.
- **`test/jls/hdl/imp/NetlistImporterTest.java` + `test/resources/hdl/import/reject_ram_sync.json`** (new) — `syncWriteRamValidatesButIsNotYetRealized` drives a single-module `$mem_v2` rising-edge-write RAM (validator-accepted) and asserts the importer rejects-not-mismaps with a message naming `$mem_v2` and "not yet realize".

## Why

Per the 2026-07-27 decision on #61 (PR #251/#199): JLS Memory gained an optional rising-edge synchronous write mode, so the single-sync-write-port + one-async-read-port shape now has a direct one-cell mapping and no longer belongs on the reject list. This slice makes the validator recognize it.

## Scope note (adjudicator directive)

Import-side only. This slice deliberately does **not** emit a JLS Memory element — realizing tri-state output, OE/CS/WE control pins absent from Yosys `$mem` cells, INIT contents, and address-bit sizing is a larger follow-up. Until then the mapper's reject-not-mismap invariant (P2) holds: the sync-write RAM validates but `mapCell` rejects it with a teachable message and builds no partial circuit. No HDL export files, `ElementRegistry`, or `LogicElement` were touched.

## Verification

`nix develop --command mvn clean verify` — BUILD SUCCESS (NullAway/@NullMarked, doclint, Spotless, coverage-ratchet, PIT gates all pass).

Targeted: `mvn -Dtest="CellValidatorTest,NetlistImporterTest,ImportPipelineTest" test`
```
Tests run: 26, Failures: 0, Errors: 0, Skipped: 2
```
(`ImportPipelineTest`'s 2 tests self-skip when Yosys is absent.)

Full suite (`mvn test`):
```
Tests run: 1276, Failures: 0, Errors: 0, Skipped: 5
```
Display-tests run: `Tests run: 92, Failures: 0, Errors: 0, Skipped: 92` (headless skip is expected).

Advances #61
