### PR TITLE
feat(module): boot compiled-in subsystems through the module runtime (#220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ All notable changes to JLS are documented here. The format follows
   `ExtensionPointCatalogTest`. Mechanism and catalog only: wiring
   `ElementRegistry`/`SimpleEditor` consumption through the registry
   is a follow-on slice of the #220 module runtime.
+- The compiled-in subsystems now boot through the module runtime
+  (#220, final DoD item of the #224 program): a new born-`@NullMarked`
+  `jls.boot` assembly layer wires JLS's built-in subsystems as
+  `JlsModule` manifests — `CoreModule` (eager; contributes every
+  `ElementRegistry.all()` descriptor to `elem.element-provider`),
+  `GuiModule` (requires core; contributes `Palette.entries()` to
+  `gui.palette-contributor`), `HdlModule` (requires core; contributes
+  the Verilog and VHDL emitters to `hdl.exporter`), and `CollabModule`
+  (requires core; the manifest for the `collab.op-observer` seam,
+  empty until a first-party sink ships) — and `JlsModules.boot()`
+  declares the four host extension points and drives them through
+  `ModuleRuntime`'s resolve → register → start path. `JLS.main` boots
+  this set once at startup, after the toolkit policy and before
+  `JLSStart`, for every run mode; the registry is populated but
+  nothing reads it for dispatch yet, so batch, HDL, and GUI behavior
+  is unchanged and stays pinned by the existing golden suite. The
+  now-unblocked registrar parameter lands on `JlsModule.register`,
+  which takes the host's `ExtensionRegistry` (issue #259); the new
+  `JlsModulesBootTest` pins deterministic topological start order
+  across shuffled inputs and asserts each seam's contributions equal
+  the live built-in tables (element registry, palette, emitters) with
+  no hardcoded counts, so new elements (#201) never break it.
 - The collab transport seam (#163, #168 Stage 1a): a new
   `jls.collab.net.Transport` interface — opaque in-order frames,
   blocking receive, null on clean close — extracted verbatim from

--- a/src/jls/JLS.java
+++ b/src/jls/JLS.java
@@ -1,5 +1,9 @@
 package jls;
 
+import jls.boot.JlsModules;
+import jls.module.ModuleActivationException;
+import jls.module.ModuleResolutionException;
+
 /**
  * Main JLS class.
  * Sets up the exception handler, then has JLSStart do the rest of the work.
@@ -43,6 +47,21 @@ public final class JLS  {
 		// untouched) but before anything can initialize AWT, because
 		// awt.toolkit.name is read exactly once, at toolkit creation
 		ToolkitPolicy.apply();
+
+		// wire the compiled-in subsystems as modules and boot them
+		// through the resolve → register → start path (issue #220):
+		// this populates the typed extension registry with every
+		// built-in contribution (elements, palette, HDL emitters) but
+		// nothing reads it for dispatch yet, so behavior is unchanged in
+		// every run mode and stays pinned by the golden suite. The
+		// compiled-in set is fixed, so a resolution or activation
+		// failure is an unrecoverable internal error, not a user fault
+		try {
+			JlsModules.boot();
+		} catch (ModuleResolutionException | ModuleActivationException e) {
+			throw new IllegalStateException(
+					"compiled-in module boot failed", e);
+		}
 
 		JLSStart.start(exHandler);
 	} // end of main method

--- a/src/jls/boot/CollabModule.java
+++ b/src/jls/boot/CollabModule.java
@@ -1,0 +1,48 @@
+package jls.boot;
+
+import java.util.Set;
+
+import jls.module.Activation;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleManifest;
+
+/**
+ * The compiled-in collaboration module (issue #220): the manifest for
+ * the op-stream layer that owns the {@code collab.op-observer} seam
+ * (grand-architecture §4.3 seam 4). JLS ships no built-in
+ * {@code OpSink} observer today — undo snapshots and replication (#171)
+ * plug in here later — so this module contributes nothing yet; it
+ * exists so the layer is a first-class citizen of the module graph
+ * rather than implicit package coupling. Requires {@link CoreModule},
+ * so it registers and starts after the model layer, and is AWT-free.
+ */
+public final class CollabModule implements JlsModule {
+
+	/** The stable module id. */
+	public static final String ID = "collab";
+
+	/** Create the collab module; it holds no per-instance state. */
+	public CollabModule() {
+	} // end of constructor
+
+	@Override
+	public ModuleManifest manifest() {
+
+		return new ModuleManifest(ID, 1, Set.of(), Set.of(CoreModule.ID),
+				Set.of(), Set.of(), Set.of(), new Activation.Eager());
+	} // end of manifest method
+
+	@Override
+	public void register(ExtensionRegistry registrar) {
+		// no built-in op observer ships today; the seam stays declared
+		// and empty until a first-party sink (undo, replication #171)
+		// contributes here
+	} // end of register method
+
+	@Override
+	public void start() {
+		// nothing to resolve at go-live
+	} // end of start method
+
+} // end of CollabModule class

--- a/src/jls/boot/CoreModule.java
+++ b/src/jls/boot/CoreModule.java
@@ -1,0 +1,53 @@
+package jls.boot;
+
+import java.util.Set;
+
+import jls.elem.ElementExtensionPoints;
+import jls.elem.ElementRegistry;
+import jls.elem.ElementType;
+import jls.module.Activation;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleManifest;
+
+/**
+ * The compiled-in circuit-model module (issue #220): the kernel every
+ * other module depends on. It contributes the shipped
+ * {@link ElementRegistry} table — one {@link ElementType} descriptor per
+ * registered element — to the {@code elem.element-provider} seam, which
+ * makes the element registry the canonical built-in instance of the
+ * extension-point mechanism (grand-architecture §4.3 seam 1). Eager, so
+ * the model layer is live from boot.
+ */
+public final class CoreModule implements JlsModule {
+
+	/** The stable module id every other compiled-in module requires. */
+	public static final String ID = "core";
+
+	/** Create the core module; all state is the static element table. */
+	public CoreModule() {
+	} // end of constructor
+
+	@Override
+	public ModuleManifest manifest() {
+
+		return new ModuleManifest(ID, 1, Set.of(), Set.of(), Set.of(),
+				Set.of(), Set.of(), new Activation.Eager());
+	} // end of manifest method
+
+	@Override
+	public void register(ExtensionRegistry registrar) {
+
+		for (ElementType type : ElementRegistry.all()) {
+			registrar.contribute(
+					ElementExtensionPoints.ELEMENT_PROVIDER, ID, type);
+		}
+	} // end of register method
+
+	@Override
+	public void start() {
+		// nothing to resolve: the model layer has no cross-module
+		// references to bind at go-live
+	} // end of start method
+
+} // end of CoreModule class

--- a/src/jls/boot/GuiModule.java
+++ b/src/jls/boot/GuiModule.java
@@ -1,0 +1,54 @@
+package jls.boot;
+
+import java.util.Set;
+
+import jls.edit.GuiExtensionPoints;
+import jls.edit.Palette;
+import jls.edit.PaletteEntry;
+import jls.module.Activation;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleManifest;
+
+/**
+ * The compiled-in GUI module (issue #220): contributes the built-in
+ * palette to the {@code gui.palette-contributor} seam
+ * (grand-architecture §4.3 seam 2) — one {@link PaletteEntry} per row of
+ * the static {@link Palette} table. Requires {@link CoreModule}, so it
+ * registers and starts after the model layer. {@link Palette} and
+ * {@link PaletteEntry} reference only {@code jls.elem}, so contributing
+ * them touches no AWT and boot stays safe in headless modes; {@code
+ * start()} likewise binds nothing Swing.
+ */
+public final class GuiModule implements JlsModule {
+
+	/** The stable module id. */
+	public static final String ID = "gui";
+
+	/** Create the GUI module; its state is the static palette table. */
+	public GuiModule() {
+	} // end of constructor
+
+	@Override
+	public ModuleManifest manifest() {
+
+		return new ModuleManifest(ID, 1, Set.of(), Set.of(CoreModule.ID),
+				Set.of(), Set.of(), Set.of(), new Activation.Eager());
+	} // end of manifest method
+
+	@Override
+	public void register(ExtensionRegistry registrar) {
+
+		for (PaletteEntry entry : Palette.entries()) {
+			registrar.contribute(
+					GuiExtensionPoints.PALETTE_CONTRIBUTOR, ID, entry);
+		}
+	} // end of register method
+
+	@Override
+	public void start() {
+		// AWT-free: the editor pulls the palette from the seam on demand;
+		// nothing here initializes Swing
+	} // end of start method
+
+} // end of GuiModule class

--- a/src/jls/boot/HdlModule.java
+++ b/src/jls/boot/HdlModule.java
@@ -1,0 +1,53 @@
+package jls.boot;
+
+import java.util.Set;
+
+import jls.hdl.HdlExtensionPoints;
+import jls.hdl.VerilogEmitter;
+import jls.hdl.VhdlEmitter;
+import jls.module.Activation;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleManifest;
+
+/**
+ * The compiled-in HDL-export module (issue #220): contributes the two
+ * built-in emitters — {@link VerilogEmitter} then {@link VhdlEmitter} —
+ * to the {@code hdl.exporter} seam (grand-architecture §4.3 seam 3),
+ * each via its public no-arg constructor and the {@code emit(HdlModel)}
+ * contract. Requires {@link CoreModule}, so it registers and starts
+ * after the model layer. The emitters are pure string builders that
+ * touch no AWT, so boot stays safe in headless HDL and batch modes.
+ */
+public final class HdlModule implements JlsModule {
+
+	/** The stable module id. */
+	public static final String ID = "hdl";
+
+	/** Create the HDL module; its state is the two stateless emitters. */
+	public HdlModule() {
+	} // end of constructor
+
+	@Override
+	public ModuleManifest manifest() {
+
+		return new ModuleManifest(ID, 1, Set.of(), Set.of(CoreModule.ID),
+				Set.of(), Set.of(), Set.of(), new Activation.Eager());
+	} // end of manifest method
+
+	@Override
+	public void register(ExtensionRegistry registrar) {
+
+		registrar.contribute(HdlExtensionPoints.EXPORTER, ID,
+				new VerilogEmitter());
+		registrar.contribute(HdlExtensionPoints.EXPORTER, ID,
+				new VhdlEmitter());
+	} // end of register method
+
+	@Override
+	public void start() {
+		// nothing to resolve: the emitters are stateless and pull their
+		// model from the caller at export time
+	} // end of start method
+
+} // end of HdlModule class

--- a/src/jls/boot/JlsModules.java
+++ b/src/jls/boot/JlsModules.java
@@ -1,0 +1,89 @@
+package jls.boot;
+
+import java.util.List;
+
+import jls.collab.op.OpExtensionPoints;
+import jls.edit.GuiExtensionPoints;
+import jls.elem.ElementExtensionPoints;
+import jls.hdl.HdlExtensionPoints;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleActivationException;
+import jls.module.ModuleResolutionException;
+import jls.module.ModuleRuntime;
+
+/**
+ * The compiled-in module assembly (issue #220, grand-architecture §4):
+ * the single place that names JLS's shipped subsystems as
+ * {@link JlsModule} manifests, declares the host's typed extension
+ * points, and boots them through {@link ModuleRuntime}'s
+ * resolve → register → start path. The application entry point calls
+ * {@link #boot()} once at startup; consumers read the accumulated
+ * contributions back through the returned runtime's
+ * {@link ModuleRuntime#extensionRegistry()}.
+ *
+ * <p>Four points are declared up front (the host publishes seams and
+ * never names a module): {@link ElementExtensionPoints#ELEMENT_PROVIDER}
+ * (core), {@link GuiExtensionPoints#PALETTE_CONTRIBUTOR} (gui),
+ * {@link HdlExtensionPoints#EXPORTER} (hdl), and
+ * {@link OpExtensionPoints#OP_OBSERVER} (collab). Four modules are
+ * wired: {@link CoreModule}, {@link GuiModule}, {@link HdlModule}, and
+ * {@link CollabModule}. Booting is side-effect-free with respect to
+ * observable behavior — the registry is populated but nothing reads it
+ * for dispatch yet — so batch, HDL, and GUI behavior is unchanged and
+ * stays pinned by the existing golden suite.</p>
+ */
+public final class JlsModules {
+
+	/** Not instantiable: a static boot entry point only. */
+	private JlsModules() {
+	} // end of constructor
+
+	/**
+	 * The host's declared extension points, in declaration order: one
+	 * per shipped subsystem seam.
+	 *
+	 * @return a fresh, empty {@link ExtensionRegistry} over the four
+	 *         declared points, ready for modules to contribute into.
+	 */
+	public static ExtensionRegistry registry() {
+
+		return new ExtensionRegistry(List.of(
+				ElementExtensionPoints.ELEMENT_PROVIDER,
+				GuiExtensionPoints.PALETTE_CONTRIBUTOR,
+				HdlExtensionPoints.EXPORTER,
+				OpExtensionPoints.OP_OBSERVER));
+	} // end of registry method
+
+	/**
+	 * The four compiled-in modules, in arbitrary order (the resolver
+	 * imposes the deterministic topological start order).
+	 *
+	 * @return a fresh list of the shipped module instances.
+	 */
+	public static List<JlsModule> modules() {
+
+		return List.of(new CoreModule(), new GuiModule(), new HdlModule(),
+				new CollabModule());
+	} // end of modules method
+
+	/**
+	 * Resolve, register, and eagerly start the four compiled-in modules
+	 * over a freshly declared extension registry. Called once at
+	 * application startup, for every run mode.
+	 *
+	 * @return the booted runtime, its
+	 *         {@link ModuleRuntime#extensionRegistry()} carrying every
+	 *         module's contributions.
+	 *
+	 * @throws ModuleResolutionException if the manifests do not resolve.
+	 * @throws ModuleActivationException if a module's registration or
+	 *             eager start throws.
+	 */
+	public static ModuleRuntime boot()
+			throws ModuleResolutionException, ModuleActivationException {
+
+		return ModuleRuntime.boot(modules(), registry());
+	} // end of boot method
+
+} // end of JlsModules class

--- a/src/jls/boot/package-info.java
+++ b/src/jls/boot/package-info.java
@@ -1,0 +1,28 @@
+/**
+ * The compiled-in module assembly (issue #220, grand-architecture §4):
+ * the wiring layer that turns JLS's built-in subsystems into
+ * {@link jls.module.JlsModule} manifests and boots them through
+ * {@link jls.module.ModuleRuntime}'s resolve → register → start path.
+ * {@link jls.boot.JlsModules} declares the host's extension points,
+ * lists the four shipped modules — {@link jls.boot.CoreModule},
+ * {@link jls.boot.GuiModule}, {@link jls.boot.HdlModule},
+ * {@link jls.boot.CollabModule} — and exposes the single {@code boot()}
+ * the application entry point calls.
+ *
+ * <p>This is the assembly tier, above both the headless core and the
+ * GUI: it deliberately imports from every layer at once (core element
+ * registry, GUI palette, HDL emitters, collab op stream) to bind them
+ * to the host's declared seams. It is therefore <em>not</em> enrolled
+ * in {@code HeadlessCoreRatchetTest} — it sits above that boundary by
+ * design, while every module it wires stays on the correct side of it.
+ * The module contributions used at boot are AWT-free, so booting is
+ * safe in headless batch and HDL modes.</p>
+ *
+ * <p>Null-marked (issue #93): every reference in this package is
+ * non-null unless annotated {@code @Nullable}, and NullAway enforces
+ * the contract at compile time on the default build.</p>
+ */
+@NullMarked
+package jls.boot;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/jls/module/JlsModule.java
+++ b/src/jls/module/JlsModule.java
@@ -4,19 +4,23 @@ package jls.module;
  * The lifecycle SPI one module implements (issue #220,
  * grand-architecture §4.2 rule 7): a static, side-effect-free
  * {@link #manifest()} the resolver reads without running module code,
- * plus the two-phase {@link #register()} / {@link #start()} pair that
- * {@link ModuleRuntime} drives. The two phases are the only cycle
- * escape hatch the model offers: every module registers before any
- * module starts, so a started module may safely resolve references to
- * anything any other module published during registration.
+ * plus the two-phase {@link #register(ExtensionRegistry)} /
+ * {@link #start()} pair that {@link ModuleRuntime} drives. The two
+ * phases are the only cycle escape hatch the model offers: every module
+ * registers before any module starts, so a started module may safely
+ * resolve references to anything any other module published during
+ * registration.
+ *
+ * <p>Registration publishes through the typed {@link ExtensionRegistry}
+ * the runtime hands each module (issue #223, grand-architecture §4.3):
+ * a module contributes its implementations to the host's declared
+ * {@link ExtensionPoint}s and never names another module — the
+ * inversion-of-control seam. The host declares the points up front; a
+ * contribution to an undeclared point fails loudly.</p>
  *
  * <p>Deliberately deferred from this slice (issue #223): sealing this
  * interface over the compiled-in module set — it is plain for now so
- * tests and future tenants can implement it freely — and the registrar
- * parameter through which {@code register()} will publish typed
- * extension points; until that parameter exists, {@code register()}
- * takes no arguments and publishes nothing beyond the module's own
- * construction.</p>
+ * tests and future tenants can implement it freely.</p>
  */
 public interface JlsModule {
 
@@ -31,11 +35,17 @@ public interface JlsModule {
 
 	/**
 	 * Phase 1: construct internal state and publish what this module
-	 * offers. Called exactly once per module, in topological order,
-	 * before <em>any</em> module's {@link #start()}. Must not touch any
-	 * other module — the other module may not have registered yet.
+	 * offers by contributing to the host's declared extension points.
+	 * Called exactly once per module, in topological order, before
+	 * <em>any</em> module's {@link #start()}. Must not touch any other
+	 * module — the other module may not have registered yet — but may
+	 * freely contribute to {@code registrar}, whose declared points the
+	 * host published before boot.
+	 *
+	 * @param registrar The host's typed extension registry to contribute
+	 *            implementations into.
 	 */
-	void register();
+	void register(ExtensionRegistry registrar);
 
 	/**
 	 * Phase 2: resolve references to other modules and go live. Called

--- a/src/jls/module/ModuleRuntime.java
+++ b/src/jls/module/ModuleRuntime.java
@@ -19,7 +19,8 @@ import java.util.TreeSet;
  * The two-phase module runner (issue #220, grand-architecture §4.2
  * rules 6-8): {@link #boot(Collection)} resolves the manifests once
  * into one deterministic topological order via {@link ModuleResolver},
- * runs phase 1 — {@link JlsModule#register()} on <em>every</em> module,
+ * runs phase 1 — {@link JlsModule#register(ExtensionRegistry)} on
+ * <em>every</em> module,
  * in that order — and then phase 2, starting only what the declared
  * {@link Activation} triggers demand:
  *
@@ -85,14 +86,26 @@ public final class ModuleRuntime {
 	private final List<String> startedIds;
 
 	/**
-	 * Wire the resolved structures; {@link #boot(Collection)} then
-	 * drives the two phases.
+	 * The typed extension registry the host published; passed to every
+	 * module during phase 1 so modules contribute their implementations
+	 * into the declared points, and readable afterwards by consumers.
+	 */
+	private final ExtensionRegistry extensionRegistry;
+
+	/**
+	 * Wire the resolved structures; {@link #boot(Collection,
+	 * ExtensionRegistry)} then drives the two phases.
 	 *
 	 * @param order The manifests in resolved topological order.
 	 * @param byId The modules keyed by their manifest id.
+	 * @param extensionRegistry The host's extension registry to hand each
+	 *            module during registration.
 	 */
 	private ModuleRuntime(List<ModuleManifest> order,
-			Map<String, JlsModule> byId) {
+			Map<String, JlsModule> byId,
+			ExtensionRegistry extensionRegistry) {
+
+		this.extensionRegistry = extensionRegistry;
 
 		modulesById = new LinkedHashMap<>();
 		manifestsById = new LinkedHashMap<>();
@@ -122,7 +135,8 @@ public final class ModuleRuntime {
 	 * {@link JlsModule#manifest()} is read exactly once; the manifests
 	 * are resolved into one deterministic order (duplicate ids, missing
 	 * or ambiguous requirements, and cycles fail loudly there); phase 1
-	 * then calls {@link JlsModule#register()} on every module in that
+	 * then calls {@link JlsModule#register(ExtensionRegistry)} on every
+	 * module in that
 	 * order; phase 2 starts the {@link Activation.Eager} modules — and,
 	 * transitively, their {@code requires} providers — in that order.
 	 *
@@ -133,10 +147,39 @@ public final class ModuleRuntime {
 	 * @throws ModuleResolutionException if the manifests do not resolve
 	 *             (propagated from {@link ModuleResolver} untouched).
 	 * @throws ModuleActivationException if a module's
-	 *             {@code register()} or an eager {@code start()}
-	 *             throws.
+	 *             {@code register(ExtensionRegistry)} or an eager
+	 *             {@code start()} throws.
 	 */
 	public static ModuleRuntime boot(Collection<JlsModule> modules)
+			throws ModuleResolutionException,
+			ModuleActivationException {
+
+		return boot(modules, new ExtensionRegistry(List.of()));
+	} // end of boot method
+
+	/**
+	 * Resolve, register, and eagerly start a module set over a host's
+	 * declared extension registry. Behaves exactly like
+	 * {@link #boot(Collection)}, except each module's
+	 * {@link JlsModule#register(ExtensionRegistry)} receives
+	 * {@code registrar}, so modules contribute their implementations into
+	 * the host's declared points during phase 1; the same registry is
+	 * then readable through {@link #extensionRegistry()}.
+	 *
+	 * @param modules The modules to run, in any order.
+	 * @param registrar The host's typed extension registry, with its
+	 *            points already declared.
+	 *
+	 * @return the booted runtime, ready to dispatch triggers.
+	 *
+	 * @throws ModuleResolutionException if the manifests do not resolve
+	 *             (propagated from {@link ModuleResolver} untouched).
+	 * @throws ModuleActivationException if a module's
+	 *             {@code register(ExtensionRegistry)} or an eager
+	 *             {@code start()} throws.
+	 */
+	public static ModuleRuntime boot(Collection<JlsModule> modules,
+			ExtensionRegistry registrar)
 			throws ModuleResolutionException,
 			ModuleActivationException {
 
@@ -151,7 +194,7 @@ public final class ModuleRuntime {
 		for (int i = 0; i < snapshot.size(); i++) {
 			byId.put(manifests.get(i).id(), snapshot.get(i));
 		}
-		ModuleRuntime runtime = new ModuleRuntime(order, byId);
+		ModuleRuntime runtime = new ModuleRuntime(order, byId, registrar);
 		runtime.registerAll();
 		runtime.startEager();
 		return runtime;
@@ -249,6 +292,22 @@ public final class ModuleRuntime {
 	} // end of demand method
 
 	/**
+	 * The typed extension registry these modules registered into. The
+	 * host declared its points before boot; every module contributed its
+	 * implementations during phase 1, so consumers read the accumulated
+	 * contributions back here in deterministic contribution (topological
+	 * register) order.
+	 *
+	 * @return the registry passed to {@link #boot(Collection,
+	 *         ExtensionRegistry)}, or the empty registry the
+	 *         {@link #boot(Collection)} overload created.
+	 */
+	public ExtensionRegistry extensionRegistry() {
+
+		return extensionRegistry;
+	} // end of extensionRegistry method
+
+	/**
 	 * The ids of every started module, in the order they started.
 	 *
 	 * @return an immutable snapshot of the start log.
@@ -273,7 +332,8 @@ public final class ModuleRuntime {
 	} // end of isStarted method
 
 	/**
-	 * Phase 1: {@link JlsModule#register()} on every module, in
+	 * Phase 1: {@link JlsModule#register(ExtensionRegistry)} on every
+	 * module, in
 	 * topological order, exactly once.
 	 *
 	 * @throws ModuleActivationException if a registration throws,
@@ -283,7 +343,7 @@ public final class ModuleRuntime {
 
 		for (Map.Entry<String, JlsModule> e : modulesById.entrySet()) {
 			try {
-				e.getValue().register();
+				e.getValue().register(extensionRegistry);
 			} catch (RuntimeException cause) {
 				throw new ModuleActivationException("module '"
 						+ e.getKey() + "' failed during register",

--- a/test/jls/ArchitectureRulesTest.java
+++ b/test/jls/ArchitectureRulesTest.java
@@ -53,22 +53,27 @@ class ArchitectureRulesTest {
 	}
 
 	/**
-	 * The HDL emitters are internal to jls.hdl; the one sanctioned
-	 * consumer outside the package is the CLI wiring point in
-	 * JLSStart, which instantiates the emitter chosen by the output
-	 * file extension (issue #60). Element classes must not grow
-	 * direct emitter knowledge - per-element HDL text lives behind
-	 * the exporter walk.
+	 * The HDL emitters are internal to jls.hdl; the sanctioned
+	 * consumers outside the package are the two wiring points — the
+	 * CLI point in JLSStart, which instantiates the emitter chosen by
+	 * the output file extension (issue #60), and the compiled-in
+	 * module boot assembly in {@code jls.boot}, which contributes the
+	 * built-in emitters to the {@code hdl.exporter} extension point at
+	 * startup (issue #220). Element classes must not grow direct
+	 * emitter knowledge - per-element HDL text lives behind the
+	 * exporter walk.
 	 */
 	@Test
 	void hdlInternalsAreOnlyWiredFromTheCli() {
 		noClasses()
 				.that().resideOutsideOfPackage("jls.hdl..")
+				.and().resideOutsideOfPackage("jls.boot..")
 				.and().doNotHaveFullyQualifiedName("jls.JLSStart")
 				.should().dependOnClassesThat()
 				.resideInAPackage("jls.hdl..")
-				.because("HDL export is reached through the JLSStart"
-						+ " wiring point only (issue #60)")
+				.because("HDL export is reached through the JLSStart CLI"
+						+ " wiring point (issue #60) or the jls.boot"
+						+ " module boot assembly (issue #220) only")
 				.check(classes);
 	}
 

--- a/test/jls/JlsModulesBootTest.java
+++ b/test/jls/JlsModulesBootTest.java
@@ -1,0 +1,116 @@
+package jls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+import jls.boot.JlsModules;
+import jls.edit.GuiExtensionPoints;
+import jls.edit.Palette;
+import jls.edit.PaletteEntry;
+import jls.elem.ElementExtensionPoints;
+import jls.elem.ElementRegistry;
+import jls.elem.ElementType;
+import jls.hdl.HdlEmitter;
+import jls.hdl.HdlExtensionPoints;
+import jls.hdl.VerilogEmitter;
+import jls.hdl.VhdlEmitter;
+import jls.module.ExtensionRegistry;
+import jls.module.JlsModule;
+import jls.module.ModuleActivationException;
+import jls.module.ModuleResolutionException;
+import jls.module.ModuleRuntime;
+
+/**
+ * Golden pin for wiring the compiled-in subsystems as
+ * {@link JlsModule} manifests and booting them through
+ * {@link ModuleRuntime} (issue #220, final DoD item). Asserts the real
+ * four-module set resolves and eagerly starts in one deterministic
+ * topological order — {@code core} first, its dependents id-tie-broken —
+ * identically across shuffled input permutations, and that each shipped
+ * subsystem's built-in contributions land on its declared seam:
+ * {@code elem.element-provider} equals {@link ElementRegistry#all()},
+ * {@code gui.palette-contributor} equals {@link Palette#entries()}, and
+ * {@code hdl.exporter} carries the Verilog and VHDL emitters. All counts
+ * are read dynamically off the live tables so new elements (#201) never
+ * break this pin.
+ */
+class JlsModulesBootTest {
+
+	@Test
+	void bootStartsAllFourModulesInDeterministicTopoOrder() throws
+			ModuleResolutionException, ModuleActivationException {
+		ModuleRuntime runtime = JlsModules.boot();
+		assertEquals(List.of("core", "collab", "gui", "hdl"),
+				runtime.startedIds(),
+				"core boots first; its dependents follow in id-sorted"
+						+ " tie-break order, all eager");
+		assertTrue(runtime.isStarted("core"));
+		assertTrue(runtime.isStarted("gui"));
+		assertTrue(runtime.isStarted("hdl"));
+		assertTrue(runtime.isStarted("collab"));
+	}
+
+	@Test
+	void startOrderIsIndependentOfInputPermutation() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> expected = List.of("core", "collab", "gui", "hdl");
+		Random shuffler = new Random(220);
+		for (int permutation = 0; permutation < 25; permutation++) {
+			List<JlsModule> modules =
+					new ArrayList<>(JlsModules.modules());
+			Collections.shuffle(modules, shuffler);
+			ModuleRuntime runtime =
+					ModuleRuntime.boot(modules, JlsModules.registry());
+			assertEquals(expected, runtime.startedIds(),
+					"start order must not depend on discovery order"
+							+ " (permutation " + permutation + ")");
+		}
+	}
+
+	@Test
+	void coreContributesEveryRegisteredElementType() throws
+			ModuleResolutionException, ModuleActivationException {
+		ExtensionRegistry registry =
+				JlsModules.boot().extensionRegistry();
+		List<ElementType> contributed = registry.contributions(
+				ElementExtensionPoints.ELEMENT_PROVIDER);
+		assertEquals(ElementRegistry.all(), contributed,
+				"the core module contributes exactly the shipped element"
+						+ " registry table, in order");
+	}
+
+	@Test
+	void guiContributesEveryPaletteEntry() throws
+			ModuleResolutionException, ModuleActivationException {
+		ExtensionRegistry registry =
+				JlsModules.boot().extensionRegistry();
+		List<PaletteEntry> contributed = registry.contributions(
+				GuiExtensionPoints.PALETTE_CONTRIBUTOR);
+		assertEquals(Palette.entries(), contributed,
+				"the gui module contributes exactly the shipped palette"
+						+ " table, in order");
+	}
+
+	@Test
+	void hdlContributesBothBuiltInEmitters() throws
+			ModuleResolutionException, ModuleActivationException {
+		ExtensionRegistry registry =
+				JlsModules.boot().extensionRegistry();
+		List<HdlEmitter> emitters =
+				registry.contributions(HdlExtensionPoints.EXPORTER);
+		assertEquals(2, emitters.size(),
+				"exactly the two built-in emitters ship");
+		assertTrue(emitters.get(0) instanceof VerilogEmitter,
+				"the Verilog emitter contributes first");
+		assertTrue(emitters.get(1) instanceof VhdlEmitter,
+				"the VHDL emitter contributes second");
+	}
+
+} // end of JlsModulesBootTest class

--- a/test/jls/ModuleRuntimeTest.java
+++ b/test/jls/ModuleRuntimeTest.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import jls.module.Activation;
+import jls.module.ExtensionPoint;
+import jls.module.ExtensionRegistry;
 import jls.module.JlsModule;
 import jls.module.ModuleActivationException;
 import jls.module.ModuleManifest;
@@ -71,7 +73,7 @@ class ModuleRuntimeTest {
 		}
 
 		@Override
-		public void register() {
+		public void register(ExtensionRegistry registrar) {
 			registerCalls++;
 			log.add("register:" + manifest.id());
 		}
@@ -321,7 +323,7 @@ class ModuleRuntimeTest {
 			}
 
 			@Override
-			public void register() {
+			public void register(ExtensionRegistry registrar) {
 				throw new IllegalStateException("register boom");
 			}
 
@@ -386,6 +388,92 @@ class ModuleRuntimeTest {
 				assertEquals(expectedStarted, runtime.startedIds());
 			}
 		}
+	}
+
+	/** A test-only extension point contributions read back through. */
+	private static final ExtensionPoint<String> POINT =
+			new ExtensionPoint<String>("test.point", String.class);
+
+	/**
+	 * A module that records the registrar it was handed and contributes
+	 * one string to {@link #POINT} during phase 1.
+	 */
+	private static final class ContribModule implements JlsModule {
+
+		/** The static descriptor this module reports. */
+		private final ModuleManifest manifest;
+
+		/** The string this module contributes to the test point. */
+		private final String contribution;
+
+		/** The registrar phase 1 handed this module, or null. */
+		private ExtensionRegistry seenRegistrar;
+
+		ContribModule(ModuleManifest manifest, String contribution) {
+			this.manifest = manifest;
+			this.contribution = contribution;
+		}
+
+		@Override
+		public ModuleManifest manifest() {
+			return manifest;
+		}
+
+		@Override
+		public void register(ExtensionRegistry registrar) {
+			seenRegistrar = registrar;
+			registrar.contribute(POINT, manifest.id(), contribution);
+		}
+
+		@Override
+		public void start() {
+			// no cross-module references to bind
+		}
+
+	} // end of ContribModule class
+
+	@Test
+	void bootHandsRegistrarToRegisterAndReadsContributionsInTopoOrder()
+			throws ModuleResolutionException, ModuleActivationException {
+		ContribModule core = new ContribModule(
+				manifest("core", Set.of(), Set.of(), Set.of(), Set.of(),
+						Set.of(), new Activation.Eager()),
+				"a");
+		ContribModule dependent = new ContribModule(
+				manifest("dependent", Set.of(), Set.of("core"), Set.of(),
+						Set.of(), Set.of(), new Activation.Eager()),
+				"b");
+		ExtensionRegistry registry =
+				new ExtensionRegistry(List.of(POINT));
+		ModuleRuntime runtime = ModuleRuntime
+				.boot(List.of(dependent, core), registry);
+		assertSame(registry, runtime.extensionRegistry(),
+				"the runtime must expose the host's registry");
+		assertSame(registry, core.seenRegistrar,
+				"register() must receive the non-null host registry");
+		assertSame(registry, dependent.seenRegistrar);
+		assertEquals(List.of("a", "b"),
+				registry.contributions(POINT),
+				"contributions read back in deterministic topological"
+						+ " register order, independent of input order");
+	}
+
+	@Test
+	void bootCollectionOverloadStartsWithAnEmptyRegistry() throws
+			ModuleResolutionException, ModuleActivationException {
+		List<String> log = new ArrayList<>();
+		FakeModule core = bare("core", new Activation.Eager(), log);
+		FakeModule gui = requiring("gui", Set.of("core"),
+				new Activation.Eager(), log);
+		ModuleRuntime runtime = ModuleRuntime.boot(List.of(gui, core));
+		assertEquals(List.of("register:core", "register:gui",
+				"start:core", "start:gui"), log,
+				"the single-argument overload keeps the pre-existing"
+						+ " register/start behavior");
+		assertEquals(List.of("core", "gui"), runtime.startedIds());
+		assertTrue(runtime.extensionRegistry().points().isEmpty(),
+				"the single-argument overload boots over an empty,"
+						+ " point-less registry");
 	}
 
 	@Test

--- a/test/jls/NullMarkedRatchetTest.java
+++ b/test/jls/NullMarkedRatchetTest.java
@@ -41,7 +41,8 @@ class NullMarkedRatchetTest {
 			"src/jls/collab/session",
 			"src/jls/elem",
 			"src/jls/edit",
-			"src/jls/module");
+			"src/jls/module",
+			"src/jls/boot");
 
 	/**
 	 * Every package on the marked list still declares


### PR DESCRIPTION
## What

Delivers the final DoD item of #220: the compiled-in subsystems now load
through the manifest + topological-sort path instead of implicit package
coupling. Advances the #224 grand-architecture program.

A new born-`@NullMarked` `jls.boot` assembly layer wires JLS's built-in
subsystems as `JlsModule` manifests and boots them through
`ModuleRuntime`'s resolve → register → start path:

- **`CoreModule`** (`id "core"`, eager) contributes every
  `ElementRegistry.all()` descriptor to the `elem.element-provider` seam —
  making the element registry the canonical built-in instance of the
  extension-point mechanism.
- **`GuiModule`** (`requires "core"`) contributes `Palette.entries()` to
  `gui.palette-contributor`. `Palette`/`PaletteEntry` reference only
  `jls.elem`, so contributing them touches no AWT and boot stays safe in
  headless batch/HDL modes; `start()` binds nothing Swing.
- **`HdlModule`** (`requires "core"`) contributes the Verilog and VHDL
  emitters to `hdl.exporter` via their public no-arg constructors.
- **`CollabModule`** (`requires "core"`) is the manifest for the
  `collab.op-observer` seam; JLS ships no built-in `OpSink` today, so it
  contributes nothing yet but makes the layer a first-class citizen of the
  module graph.
- **`JlsModules`** declares the four host extension points, lists the four
  modules, and exposes `boot()`.

`JLS.main` calls `JlsModules.boot()` once, after `ToolkitPolicy.apply()`
and before `JLSStart.start()`, for every run mode. A resolution/activation
failure of the fixed compiled-in set is rethrown as an unrecoverable
internal error.

The now-unblocked registrar parameter lands on
`JlsModule.register(ExtensionRegistry)` (consuming #259's
`ExtensionRegistry`); `ModuleRuntime` gains the
`boot(Collection, ExtensionRegistry)` overload — the `boot(Collection)`
overload builds an empty registry so existing callers are unaffected —
plus an `extensionRegistry()` getter so consumers read the accumulated
contributions back.

## Why

Booting is side-effect-free with respect to observable behavior: the
registry is populated but nothing reads it for dispatch yet, so batch,
HDL, and GUI behavior is unchanged and stays pinned by the existing golden
suite. This lands the wiring seam so later slices can route
`ElementRegistry`/palette/exporter consumption through the registry.

## Verification

- **`JlsModulesBootTest`** (new): boots the real four-module set, pins the
  deterministic topological start order (`core` first, then the id-sorted
  tie-break `collab`, `gui`, `hdl`) identically across 25 shuffled input
  permutations with all four eager-started, and asserts each seam's
  contributions equal the **live** built-in tables — `ElementRegistry.all()`,
  `Palette.entries()`, and a Verilog + VHDL emitter — read dynamically with
  **no hardcoded counts**, so #201's new elements never break it.
- **`ModuleRuntimeTest`**: the two `FakeModule` overrides adapt to
  `register(ExtensionRegistry)`; new tests pin that `boot(...)` hands the
  non-null host registry to `register()` and reads contributions back in
  deterministic topological order, and that the `boot(Collection)` overload
  keeps the pre-existing register/start behavior over an empty registry.
- `jls.boot` enrolled in `NullMarkedRatchetTest` (NullAway-clean).
- `ArchitectureRulesTest` extended: `jls.boot` is a second sanctioned HDL
  wiring point alongside `jls.JLSStart` (issue #60 intent preserved —
  element classes still may not grow direct emitter knowledge).
- `jls.boot` is intentionally **not** enrolled in the headless-core ratchet:
  it is the above-core wiring layer by design, while every module it wires
  stays on the correct side of the boundary.

Full suite green (`nix develop --command bash -c 'mvn test'`), display
tests skip headless as expected:

```
Tests run: 1354, Failures: 0, Errors: 0, Skipped: 97
```

Advances #224. Advances #220 (final DoD item).
