### PR TITLE
feat(edit): migrate move-selection drag commit behind OpSink (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to JLS are documented here. The format follows
 
 ## [Unreleased] — 5.0.5-SNAPSHOT
 
+### Changed
+- The move-selection drag commit now routes a pure relocation through the `MoveElements` operation behind the `OpSink` seam (#167), keeping the inline `connect()`/`removeCoLinear()` commit only for drops that form a connection, drag a wire end, or induce colinear cleanup.
+
 ### Added
 - The PIT mutation-testing gate is promoted from report-only to a
   blocking climb-ratchet (#159): the `pitest` profile now carries

--- a/docs/operation-layer.md
+++ b/docs/operation-layer.md
@@ -124,7 +124,7 @@ the migration commit.
 | Rotate CCW, context menu | `RotateElement(ccw)` | **migrated** |
 | Flip, context menu | `FlipElement` | **migrated** |
 | Probe attach/remove, context menu | `AttachProbe` / `RemoveProbe` (name prompt stays in the gesture; ops are pure data) | **migrated** |
-| Move-selection commit (mouse release) | `MoveElements` | op implemented + tested, and wired into the keyboard nudge (issue #75, `submitOp(new MoveElements(...))` at `SimpleEditor.java:3254`); the mouse-release drag commit is still inline (live drag must become preview-then-commit) |
+| Move-selection commit (mouse release) | `MoveElements` | **migrated** for a pure relocation, and already the keyboard nudge (issue #75). `SimpleEditor.moveSelectionPlan` returns a one-op `MoveElements` plan when the drop is a pure relocation - every selected element is a plain, editable element carrying no attached put, and no selected element's post-move put lands on a non-selected wire end or put; the live drag is the preview, then the pre-drag positions are restored and the op is the mutation of record, batched through `OpSink.submitAll` as one undo snapshot (`MoveGestureTest`). Any drop that would form a connection, drag a wire end, or induce colinear cleanup (wired elements, wires/wire ends, subcircuits) keeps the inline `fixPosition` + `connect()` + `removeCoLinear()` commit verbatim |
 | Placement drop (fixPosition + connect) | `AddElements` (+ implicit wiring) | op implemented + tested for the unwired case; gesture still inline (the drop's `connect()` needs the wiring vocabulary, and placement must become preview-then-commit) |
 | Matching JumpEnd creation, context menu | `AddElements` | op implemented + tested (jump-source validation included); gesture still inline (the created end stays mouse-attached in `chosen` state, so the commit point is the later drop) |
 | Delete selection (delete key, Edit menu, popup Delete, and CUT's removal half) | `RemoveWire` per attached net + `AddWire` per surviving component + `RemoveElements` | **migrated**: `SimpleEditor.deleteSelectionPlan` maps the selection to an op plan (jump starts expanded with their jump ends; per affected net one `RemoveWire` of the whole net plus, when the selection only clips it, one `AddWire.survivors` per surviving connected component; then `RemoveElements`), submitted as one batch through `OpSink.submitAll` so the gesture stays a single undo snapshot (`DeleteGestureTest`). Only subcircuits, in-progress wiring, and uneditable cascades still take the inline fallback |
@@ -152,10 +152,13 @@ rule 2; only the future `jls.collab.ui` may touch Swing).
 
 ## What lands next
 
-1. Preview-then-commit for the move, placement, and wiring gestures,
+1. Preview-then-commit for the placement and wiring gestures,
    anchored by the #91 gesture harness (`EditorGestureTest`) - the
    step that migrates the remaining gestures whose ops already exist
-   (`MoveElements`, `AddElements`, `AddWire`).
+   (`AddElements`, `AddWire`). The move-selection drag commit is done
+   for pure relocations (`MoveElements`, `moveSelectionPlan`); the
+   connect-forming and wire-end-dragging drops remain inline until the
+   commit-time wiring composition lands.
 2. Wiring the dialog-commit gestures onto `SetElementConfig`, whose op
    already exists; the commit paths mutate in place until then.
 3. Op-inverse (precise) undo activation is explicitly *not* this

--- a/src/jls/edit/SimpleEditor.java
+++ b/src/jls/edit/SimpleEditor.java
@@ -1017,6 +1017,105 @@ public abstract class SimpleEditor extends JPanel {
 	} // end of deleteSelectionPlan method
 
 		/**
+		 * Plan a move-selection drag commit as the {@link MoveElements}
+		 * op, or null when the drop must take the inline commit instead
+		 * (issue #167, the move slice of the operation-layer migration).
+		 * The twin of {@link #deleteSelectionPlan}: a static, Swing-free
+		 * builder so the boundary is testable without constructing the
+		 * editor (which needs a display).
+		 *
+		 * <p>The op path is deliberately conservative - it must produce
+		 * exactly what the inline {@code fixPosition} + {@code connect()}
+		 * + {@code removeCoLinear()} commit produces, and {@code
+		 * MoveElements} alone does none of that connection or cleanup
+		 * work. So a plan is returned only for a pure relocation: every
+		 * selected element is a plain, editable element (no wire, wire
+		 * end, or subcircuit) carrying no attached put - so moving it
+		 * drags no wire end and can neither form nor break a connection
+		 * nor induce colinear cleanup - and no selected element's put,
+		 * at its post-move position, coincides with a non-selected wire
+		 * end or put, which is every coincidence {@code connect()} would
+		 * turn into a new connection. Any other drop returns null and the
+		 * caller keeps the inline commit verbatim.
+		 *
+		 * <p>Called with the selection already at its dropped (dragged)
+		 * position, so the coincidence test reads the same post-move
+		 * geometry {@code connect()} would.
+		 *
+		 * @param circuit The circuit being edited.
+		 * @param selected The dropped selection; not modified.
+		 * @param dx The net x delta of the drag, in model units.
+		 * @param dy The net y delta of the drag, in model units.
+		 * @return the one-op plan, or null when the drop has no plan and
+		 *         the caller must commit inline.
+		 * @jls.testedby jls.edit.MoveGestureTest
+		 */
+		static @Nullable List<CircuitOp> moveSelectionPlan(Circuit circuit,
+				Set<Element> selected, int dx, int dy) {
+
+			if (selected.isEmpty())
+				return null;
+
+			// the vocabulary limit: a pure relocation of plain elements.
+			// A wire, wire end, or subcircuit in the selection, an
+			// uneditable, or any element with an attached put (whose move
+			// drags a wire end and can re-form the net) takes the inline
+			// path, which owns the connect()/removeCoLinear() fix-up.
+			List<ElementId> ids = new ArrayList<ElementId>();
+			for (Element el : selected) {
+				if (el instanceof Wire || el instanceof WireEnd)
+					return null;
+				if (el instanceof SubCircuit)
+					return null;
+				if (el.isUneditable())
+					return null;
+				for (Put put : el.getAllPuts()) {
+					if (put.isAttached())
+						return null;
+				}
+				ids.add(el.getStableId());
+			}
+
+			// connect() forms a connection when a selected element's put,
+			// at its post-move position, lands on a non-selected wire end
+			// or a non-selected element's put; any such drop must take the
+			// inline connect() + removeCoLinear() path so the op path never
+			// diverges from it. Mirror connect()'s neighbourhood query: an
+			// element's index bounds is its body, not its puts, so scan
+			// around the selected element (grown by SPACING, as connect()
+			// does) rather than around each isolated put position.
+			for (Element el : selected) {
+				Set<Put> puts = el.getAllPuts();
+				if (puts.isEmpty())
+					continue;
+				Rectangle near = AwtGeom.awt(el.getIndexBounds());
+				near.grow(Geometry.SPACING,Geometry.SPACING);
+				for (Element other :
+						circuit.elementsNear(AwtGeom.bounds(near))) {
+					if (selected.contains(other))
+						continue;
+					for (Put put : puts) {
+						if (other instanceof WireEnd end) {
+							if (end.getX() == put.getX()
+									&& end.getY() == put.getY())
+								return null;
+						}
+						else {
+							for (Put otherPut : other.getAllPuts()) {
+								if (otherPut.getX() == put.getX()
+										&& otherPut.getY() == put.getY())
+									return null;
+							}
+						}
+					}
+				}
+			}
+
+			java.util.Collections.sort(ids);
+			return List.of(new MoveElements(ids,dx,dy));
+		} // end of moveSelectionPlan method
+
+		/**
 		 * The window the circuit is displayed and edited in.
 		 */
 		private class EditWindow extends JPanel implements ActionListener,MouseListener,MouseMotionListener,MouseWheelListener {
@@ -1123,6 +1222,16 @@ public abstract class SimpleEditor extends JPanel {
 			private int x;
 			/** Latest cursor y coordinate, in model units (issue #74). */
 			private int y;
+			/**
+			 * Cursor x at the moment a move gesture began, in model units
+			 * (issue #167). The whole selection translates uniformly with
+			 * the cursor, so the net drag delta at commit is the current
+			 * cursor minus this reference - the {@code MoveElements} op's
+			 * dx without reading the elements' private saved positions.
+			 */
+			private int moveOriginX;
+			/** Cursor y at the move gesture's start, in model units (issue #167). */
+			private int moveOriginY;
 			/**
 			 * Latest cursor position in this component's own coordinates
 			 * (issue #74). Popup menus and value dialogs are positioned in
@@ -2526,6 +2635,8 @@ public abstract class SimpleEditor extends JPanel {
 									end2.setHighlight(true);
 									end1.savePosition();
 									end2.savePosition();
+									moveOriginX = x;
+									moveOriginY = y;
 									setState(State.moving);
 									return;
 								}
@@ -2538,6 +2649,8 @@ public abstract class SimpleEditor extends JPanel {
 								selected.add(el);
 								el.setHighlight(true);
 								el.savePosition();
+								moveOriginX = x;
+								moveOriginY = y;
 								setState(State.moving);
 								return;
 							}
@@ -2616,6 +2729,8 @@ public abstract class SimpleEditor extends JPanel {
 							for (Element sel : selected) {
 								sel.savePosition();
 							}
+							moveOriginX = x;
+							moveOriginY = y;
 							setState(State.moving);
 						}
 						else if (rightButton) {
@@ -3274,30 +3389,55 @@ public abstract class SimpleEditor extends JPanel {
 					// otherwise
 					else {
 
-						// fix elements at their new positions
-						for (Element el : selected) {
-							el.fixPosition();
+						// a pure relocation commits through the MoveElements
+						// op (issue #167): the live drag was the preview, so
+						// restore the pre-drag positions and let the op be the
+						// mutation of record - undo, checkpointing, and (later)
+						// replication all observe the OpSink seam. The op path
+						// is taken only for drops that form no connection and
+						// induce no colinear cleanup, i.e. exactly what the
+						// inline connect() + removeCoLinear() below would do
+						// nothing at; any other drop keeps that inline commit
+						// verbatim. The net delta is the cursor's travel since
+						// the gesture began (the whole selection moved with it).
+						int dx = x - moveOriginX;
+						int dy = y - moveOriginY;
+						List<CircuitOp> plan =
+								moveSelectionPlan(circuit,selected,dx,dy);
+						if (plan != null) {
+							for (Element el : selected) {
+								el.restorePosition();
+							}
+							submitOps(plan);
 						}
+						else {
 
-						// connect everything possible
-						connect();
+							// inline fallback: fix elements at their new
+							// positions
+							for (Element el : selected) {
+								el.fixPosition();
+							}
 
-						// fix up wire end attached to imaginary puts
-						for (Element el : selected) {
-							if (el instanceof WireEnd end) {
-								if (end.isAttached()) {
-									Put ep = end.getPut();
-									if (ep == null)
-										throw new IllegalStateException("attached wire end has no put");
-									if (ep.getElement() == null) {
-										end.setPut(null);
+							// connect everything possible
+							connect();
+
+							// fix up wire end attached to imaginary puts
+							for (Element el : selected) {
+								if (el instanceof WireEnd end) {
+									if (end.isAttached()) {
+										Put ep = end.getPut();
+										if (ep == null)
+											throw new IllegalStateException("attached wire end has no put");
+										if (ep.getElement() == null) {
+											end.setPut(null);
+										}
 									}
 								}
 							}
-						}
 
-						// record that changes have been made
-						markChanged();
+							// record that changes have been made
+							markChanged();
+						}
 					}
 
 					// clean up

--- a/test/jls/edit/MoveGestureTest.java
+++ b/test/jls/edit/MoveGestureTest.java
@@ -1,0 +1,447 @@
+package jls.edit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import jls.Circuit;
+import jls.JLSInfo;
+import jls.collab.op.CircuitOp;
+import jls.collab.op.MoveElements;
+import jls.collab.op.OpRejected;
+import jls.collab.op.OpSink;
+import jls.elem.Element;
+import jls.elem.ElementId;
+import jls.elem.Pin;
+import jls.elem.SubCircuit;
+import jls.elem.Wire;
+
+/**
+ * The move-selection drag commit's migration behind the OpSink seam
+ * (issue #167), pinned at the Swing-free plan builder
+ * {@link SimpleEditor#moveSelectionPlan} (the editor itself cannot be
+ * constructed headless):
+ *
+ * <ul>
+ * <li>P1 - the op-plan path (restore the pre-drag positions, then apply
+ * one {@link MoveElements}) produces the same canonical bytes (#166) as
+ * the inline {@code move} + {@code fixPosition} commit it replaces, for
+ * single- and multi-element pure relocations, on constructed and on
+ * save/load-restored circuits alike. For an eligible drop the inline
+ * commit's {@code connect()} and {@code removeCoLinear()} do nothing -
+ * that is exactly the boundary the predicate enforces - so the inline
+ * mutation reduces to the drag plus {@code fixPosition};</li>
+ * <li>fallback - a drop that would form a connection, a wired element
+ * (whose move drags a wire end and can re-form its net), a wire, and a
+ * subcircuit all have no plan and take the inline path unchanged;</li>
+ * <li>rejection - a {@link MoveElements} that would push an element off
+ * the canvas is rejected and leaves the circuit byte-identical;</li>
+ * <li>undo granularity - the plan submitted through a batch
+ * {@link OpSink#submitAll} records exactly one markChanged per
+ * gesture.</li>
+ * </ul>
+ */
+class MoveGestureTest {
+
+	/** Two unwired pins whose puts (at 180 and 300) do not coincide. */
+	private static String unwiredPairText() {
+		return "CIRCUIT moves\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\nENDCIRCUIT\n";
+	}
+
+	/**
+	 * Two source pins whose puts sit on facing body edges: pin A's put
+	 * at (156,132), pin B's put at (360,132). Dragging A right by 204
+	 * lands its put exactly on B's, the put-to-put coincidence
+	 * connect() turns into a wire.
+	 */
+	private static String facingPinsText() {
+		return "CIRCUIT facing\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT InputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\nENDCIRCUIT\n";
+	}
+
+	/** The same two pins joined by a one-segment wire net. */
+	private static String wiredPairText() {
+		return "CIRCUIT wired\n"
+				+ "ELEMENT InputPin\n int id 0\n int x 120\n int y 120\n"
+				+ " String sid \"pin:1\"\n String name \"A\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"RIGHT\"\nEND\n"
+				+ "ELEMENT OutputPin\n int id 1\n int x 360\n int y 120\n"
+				+ " String sid \"pin:2\"\n String name \"B\"\n"
+				+ " int bits 1\n int watch 0\n"
+				+ " String orient \"LEFT\"\nEND\n"
+				+ "ELEMENT WireEnd\n int id 2\n int x 180\n int y 120\n"
+				+ " String sid \"we:1\"\n"
+				+ " String put \"output\"\n ref attach 0\n ref wire 3\n"
+				+ "END\n"
+				+ "ELEMENT WireEnd\n int id 3\n int x 300\n int y 120\n"
+				+ " String sid \"we:2\"\n"
+				+ " String put \"input\"\n ref attach 1\n ref wire 2\n"
+				+ "END\nENDCIRCUIT\n";
+	}
+
+	/** A circuit loaded headlessly from inline save-format text. */
+	private static Circuit loadText(String text) throws Exception {
+		Circuit circuit = new Circuit("");
+		assertTrue(circuit.load(new Scanner(text)),
+				() -> "load failed: " + JLSInfo.loadError);
+		assertTrue(circuit.finishLoad(SwingTextMetrics.of(graphics())),
+				() -> "finishLoad failed: " + JLSInfo.loadError);
+		return circuit;
+	}
+
+	/**
+	 * A circuit restored through a save/load round trip (issue #167
+	 * section 10: ops validated on a live circuit may behave
+	 * differently on a restored object graph).
+	 */
+	private static Circuit restored(Circuit circuit) throws Exception {
+		Circuit copy = new Circuit("");
+		assertTrue(copy.load(new Scanner(save(circuit))),
+				() -> "restore load failed: " + JLSInfo.loadError);
+		assertTrue(copy.finishLoad(SwingTextMetrics.of(graphics())),
+				() -> "restore finishLoad failed: " + JLSInfo.loadError);
+		return copy;
+	}
+
+	private static String save(Circuit circuit) {
+		StringWriter out = new StringWriter();
+		try (PrintWriter writer = new PrintWriter(out)) {
+			circuit.save(writer);
+		}
+		return out.toString();
+	}
+
+	private static Graphics2D graphics() {
+		return new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB)
+				.createGraphics();
+	}
+
+	/** All elements matching the predicate, as a selection set. */
+	private static Set<Element> select(Circuit circuit,
+			Predicate<Element> p) {
+		Set<Element> selected = new HashSet<Element>();
+		for (Element el : circuit.getElements()) {
+			if (p.test(el)) {
+				selected.add(el);
+			}
+		}
+		assertTrue(!selected.isEmpty(), "fixture lacks a needed element");
+		return selected;
+	}
+
+	/** A mutable selection set over the given elements. */
+	private static Set<Element> setOf(Element... elements) {
+		Set<Element> selected = new HashSet<Element>();
+		for (Element el : elements) {
+			selected.add(el);
+		}
+		return selected;
+	}
+
+	/** Picks the same selection out of independently loaded circuits. */
+	private interface Selector {
+		Set<Element> select(Circuit circuit);
+	}
+
+	/**
+	 * Drive the selection through a live drag: save the pre-drag
+	 * positions and translate every element by the delta, then reindex
+	 * as the editor's mouseDragged does, so the plan builder reads the
+	 * same post-move geometry connect() would.
+	 */
+	private static void drag(Circuit circuit, Set<Element> selected,
+			int dx, int dy) {
+		for (Element el : selected) {
+			el.savePosition();
+		}
+		for (Element el : selected) {
+			el.move(dx, dy);
+		}
+		circuit.reindexAfterMove(selected);
+	}
+
+	/**
+	 * P1 harness: the op path (drag, plan, restore the pre-drag
+	 * positions, apply the one MoveElements) byte-matches the inline
+	 * commit (drag, fixPosition) for a pure relocation - connect() and
+	 * removeCoLinear() are no-ops on an eligible drop - on the
+	 * constructed circuit and on a save/load-restored one.
+	 */
+	private static void assertMovePlanParity(String text,
+			Selector selector, int dx, int dy) throws Exception {
+		for (boolean restore : new boolean[] { false, true }) {
+			Circuit viaOp = loadText(text);
+			Circuit inline = loadText(text);
+			if (restore) {
+				viaOp = restored(viaOp);
+				inline = restored(inline);
+			}
+
+			Set<Element> opSel = selector.select(viaOp);
+			drag(viaOp, opSel, dx, dy);
+			List<CircuitOp> plan =
+					SimpleEditor.moveSelectionPlan(viaOp, opSel, dx, dy);
+			assertTrue(plan != null, "a pure relocation must have a plan");
+			assertEquals(1, plan.size(), "one MoveElements expected");
+			assertTrue(plan.get(0) instanceof MoveElements,
+					"the single op must be the move");
+			for (Element el : opSel) {
+				el.restorePosition();
+			}
+			apply(viaOp, plan);
+
+			Set<Element> inSel = selector.select(inline);
+			drag(inline, inSel, dx, dy);
+			for (Element el : inSel) {
+				el.fixPosition();
+			}
+
+			assertEquals(save(inline), save(viaOp),
+					(restore ? "restored" : "constructed")
+							+ ": plan and inline move must produce "
+							+ "identical bytes");
+		}
+	}
+
+	/** Apply a plan the way the editor's opSink batch does. */
+	private static void apply(Circuit circuit, List<CircuitOp> plan)
+			throws Exception {
+		for (CircuitOp op : plan) {
+			op.apply(circuit, graphics());
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// P1: plan path vs inline path, byte parity
+	// ------------------------------------------------------------------
+
+	/**
+	 * A single pin dropped in empty space plans to one MoveElements
+	 * whose application byte-matches the inline drag + fixPosition.
+	 */
+	@Test
+	void singleElementRelocationMatchesInline() throws Exception {
+		assertMovePlanParity(unwiredPairText(),
+				c -> select(c, el -> el instanceof Pin
+						&& "A".equals(el.getName())),
+				60, 120);
+	}
+
+	/**
+	 * Both pins dragged together by one delta plan to a single
+	 * MoveElements carrying both ids, byte-matching the inline drag.
+	 */
+	@Test
+	void multiElementRelocationMatchesInline() throws Exception {
+		assertMovePlanParity(unwiredPairText(),
+				c -> select(c, el -> el instanceof Pin), 0, 120);
+	}
+
+	/**
+	 * The plan carries every selected element's stable id and never
+	 * mutates the circuit while planning.
+	 */
+	@Test
+	void planCarriesEveryIdAndDoesNotMutate() throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		Set<Element> selected = select(circuit, el -> el instanceof Pin);
+		drag(circuit, selected, 0, 120);
+		String afterDrag = save(circuit);
+		List<CircuitOp> plan =
+				SimpleEditor.moveSelectionPlan(circuit, selected, 0, 120);
+		assertTrue(plan != null && plan.size() == 1, "one move expected");
+		List<ElementId> ids = ((MoveElements) plan.get(0)).ids();
+		assertEquals(2, ids.size(), "both pins must be in the move");
+		Set<ElementId> want = new HashSet<ElementId>();
+		for (Element el : selected) {
+			want.add(el.getStableId());
+		}
+		assertEquals(want, new HashSet<ElementId>(ids),
+				"the move must address exactly the selection");
+		assertEquals(afterDrag, save(circuit),
+				"planning must never mutate the circuit");
+	}
+
+	// ------------------------------------------------------------------
+	// fallback: drops the vocabulary must not claim
+	// ------------------------------------------------------------------
+
+	/**
+	 * A drop whose put lands on a non-selected element's put would make
+	 * connect() form a wire, so it has no plan and takes the inline
+	 * commit.
+	 */
+	@Test
+	void connectFormingDropHasNoPlan() throws Exception {
+		Circuit circuit = loadText(facingPinsText());
+		// pin A's put starts at (156,132); a +204 drag lands it exactly
+		// on pin B's put at (360,132), the coincidence connect() wires
+		Set<Element> selected = select(circuit, el -> el instanceof Pin
+				&& "A".equals(el.getName()));
+		drag(circuit, selected, 204, 0);
+		assertNull(SimpleEditor.moveSelectionPlan(circuit, selected, 204, 0),
+				"a drop that forms a connection must have no plan");
+	}
+
+	/**
+	 * A wired element's move drags its attached wire end and can re-form
+	 * the net (the connect()/removeCoLinear() work MoveElements does
+	 * not), so a selection carrying an attached put has no plan.
+	 */
+	@Test
+	void wiredElementHasNoPlan() throws Exception {
+		Circuit circuit = loadText(wiredPairText());
+		Set<Element> selected = select(circuit, el -> el instanceof Pin
+				&& "A".equals(el.getName()));
+		assertNull(SimpleEditor.moveSelectionPlan(circuit, selected, 0, 120),
+				"a wired element must take the inline path");
+	}
+
+	/**
+	 * A wire (or wire end) in the selection has no plan; the inline path
+	 * owns wire-end drag/connect fix-up.
+	 */
+	@Test
+	void wireSelectionHasNoPlan() throws Exception {
+		Circuit circuit = loadText(wiredPairText());
+		Set<Element> selected = select(circuit, el -> el instanceof Wire);
+		assertNull(SimpleEditor.moveSelectionPlan(circuit, selected, 0, 120),
+				"a wire selection must take the inline path");
+	}
+
+	/**
+	 * A subcircuit still has no plan - its op kind is deferred - so the
+	 * gesture takes the inline fallback.
+	 */
+	@Test
+	void subCircuitSelectionHasNoPlan() throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		SubCircuit sub = new SubCircuit(circuit);
+		circuit.addElement(sub);
+		assertNull(SimpleEditor.moveSelectionPlan(circuit, setOf(sub), 0, 12),
+				"a subcircuit selection must have no plan");
+	}
+
+	/** An empty selection has no plan (the inline path no-ops it). */
+	@Test
+	void emptySelectionHasNoPlan() throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		assertNull(SimpleEditor.moveSelectionPlan(circuit,
+				new HashSet<Element>(), 0, 12),
+				"an empty selection must have no plan");
+	}
+
+	// ------------------------------------------------------------------
+	// rejection: off-canvas moves change nothing
+	// ------------------------------------------------------------------
+
+	/**
+	 * A MoveElements that would push an element off the canvas is
+	 * rejected atomically and leaves the circuit byte-identical.
+	 */
+	@Test
+	void offCanvasMoveIsRejectedAndLeavesBytesIdentical()
+			throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		String before = save(circuit);
+		Element a = select(circuit, el -> el instanceof Pin
+				&& "A".equals(el.getName())).iterator().next();
+		MoveElements offCanvas =
+				new MoveElements(List.of(a.getStableId()), -360, 0);
+		assertThrows(OpRejected.class,
+				() -> offCanvas.apply(circuit, graphics()),
+				"pin A at x=120 moved by -360 leaves the canvas");
+		assertEquals(before, save(circuit),
+				"a rejected move must not mutate the circuit");
+	}
+
+	// ------------------------------------------------------------------
+	// undo granularity: one markChanged per gesture
+	// ------------------------------------------------------------------
+
+	/**
+	 * A sink shaped like the editor's opSink: submitAll applies every op
+	 * then records exactly once, the shape that keeps a move a single
+	 * undo snapshot.
+	 */
+	private static final class BatchSink implements OpSink {
+
+		private final Circuit circuit;
+		private final List<Integer> marks = new ArrayList<Integer>();
+		private int applied = 0;
+
+		private BatchSink(Circuit circuit) {
+			this.circuit = circuit;
+		}
+
+		@Override
+		public void submit(CircuitOp op) throws OpRejected {
+			op.apply(circuit, graphics());
+			applied += 1;
+			marks.add(applied);
+		}
+
+		@Override
+		public void submitAll(List<CircuitOp> ops) throws OpRejected {
+			for (CircuitOp op : ops) {
+				op.apply(circuit, graphics());
+				applied += 1;
+			}
+			marks.add(applied);
+		}
+	} // end of BatchSink class
+
+	/**
+	 * The move plan submitted as one batch records exactly one
+	 * markChanged for the gesture.
+	 */
+	@Test
+	void batchSubmitRecordsExactlyOneMarkChangedPerGesture()
+			throws Exception {
+		Circuit circuit = loadText(unwiredPairText());
+		Set<Element> selected = select(circuit, el -> el instanceof Pin);
+		drag(circuit, selected, 0, 120);
+		List<CircuitOp> plan =
+				SimpleEditor.moveSelectionPlan(circuit, selected, 0, 120);
+		assertTrue(plan != null && plan.size() == 1,
+				"the relocation must plan to one op");
+		for (Element el : selected) {
+			el.restorePosition();
+		}
+		BatchSink sink = new BatchSink(circuit);
+		sink.submitAll(plan);
+		assertEquals(1, sink.applied, "the single op must apply");
+		assertEquals(List.of(1), sink.marks,
+				"one markChanged, after all ops, per gesture");
+	}
+} // end of MoveGestureTest class

--- a/test/jls/ui/EditorGestureTest.java
+++ b/test/jls/ui/EditorGestureTest.java
@@ -255,4 +255,47 @@ class EditorGestureTest {
 		}
 	}
 
+	/**
+	 * The move-selection drag commit end-to-end through the op path
+	 * (issue #167): a lone gate dragged into empty space is a pure
+	 * relocation, so the plan builder maps it to one MoveElements and
+	 * the drop lands at the drag delta - matching the inline commit,
+	 * whose byte parity is pinned headlessly by
+	 * jls.edit.MoveGestureTest. A single undo then restores the
+	 * pre-drag position, pinning the one-undo-snapshot-per-gesture
+	 * batch submit. Positions rather than full bytes are asserted for
+	 * the reason the delete test notes: undo's restore re-runs display
+	 * init, which sets layout fields the pre-gesture circuit only gains
+	 * once drawn.
+	 */
+	@Test
+	void dragMovesAnElementAndOneUndoRestoresIt() throws Exception {
+		Circuit circuit = oneGate();
+		try (EditorGestureSupport ui = new EditorGestureSupport(circuit)) {
+			AndGate gate = assertElementPresent(circuit, AndGate.class);
+			int beforeX = gate.getX(), beforeY = gate.getY();
+			int fromX = centerX(gate), fromY = centerY(gate);
+
+			ui.leftDrag(fromX, fromY, fromX + 120, fromY + 96);
+			ui.waitFor(() -> gate.getX() != beforeX || gate.getY() != beforeY,
+					"gate moved by the drag");
+			GeometryAssert.assertOnGrid(gate);
+			assertTrue(Math.abs(gate.getX() - (beforeX + 120)) <= 12
+					&& Math.abs(gate.getY() - (beforeY + 96)) <= 12,
+					"the op drop lands at the drag delta, like the inline "
+							+ "commit: " + gate.getX() + "," + gate.getY());
+
+			// one undo restores the pre-drag position; the drag was one
+			// snapshot, so a single undo suffices. Undo swaps in a fresh
+			// circuit, so read the editor's live circuit.
+			ui.rightPress(700, 600);
+			ui.clickPopupItem("Undo");
+			ui.waitFor(() -> {
+				AndGate g = assertElementPresent(
+						ui.currentCircuit(), AndGate.class);
+				return g.getX() == beforeX && g.getY() == beforeY;
+			}, "one undo restored the pre-drag position");
+		}
+	}
+
 }


### PR DESCRIPTION
## What

Migrates one preview-then-commit gesture — the **move-selection drag commit** (mouse release in `State.moving`) — behind the `OpSink` seam using the already-implemented, inverse-tested `MoveElements` op. This is the per-gesture cadence established by the delete slices (#247, #262); placement, wiring, and paste plus the dialog `SetElementConfig` paths remain later slices.

- New Swing-free plan builder `SimpleEditor.moveSelectionPlan(circuit, selected, dx, dy)` — the twin of `deleteSelectionPlan` — returns a one-op `[MoveElements(ids, dx, dy)]` plan for a **pure relocation** and `null` (inline fallback) otherwise. Eligibility (conservative, tuned to keep the oracle parity green): every selected element is a plain, editable element (no wire, wire end, or subcircuit) carrying **no attached put** (so the move drags no wire end and can neither form nor break a connection nor induce colinear cleanup), and no selected element's put — at its post-move position — coincides with a non-selected wire end or put (the read-only mirror of `connect()`'s neighbourhood query, scanned around each selected element's grown index bounds, since a put sits at the body edge, not inside the index bounds).
- New `moveOriginX/moveOriginY` editor field captures the cursor at each `State.moving` entry; the whole selection translates uniformly, so the net delta at commit is `cursor − origin` — no need to read `Element.savex/savey` (private, no getter).
- Rewritten moving-release commit: when not overlapping, compute `(dx,dy)` and call `moveSelectionPlan`; if non-null, `restorePosition()` all selected then `submitOps(plan)` so the op is the mutation of record and the gesture stays one `markChanged` (via the existing `submitAll` override); if null, the inline `fixPosition` + `connect()` + `removeCoLinear()` + `markChanged` path is kept **verbatim**. The overlap branch (restore, no `markChanged`) is unchanged.
- `docs/operation-layer.md`: the "Move-selection commit" inventory row flips to **migrated** with the pure-relocation eligibility + fallback note; move dropped from "What lands next" item 1.
- `CHANGELOG.md`: one Unreleased/Changed line.

## Why

Part of the operation-layer migration (#167, collab Stage 0b): every editor mutation becomes a validated, invertible, serializable op through one entry point (`OpSink`), migrated gesture-by-gesture under the snapshot-undo safety net (§7 incremental mandate). The `MoveElements` op already existed and was inverse-tested; this slice makes the mouse drag commit actually flow through it for the common pure-relocation case.

No new `jls.collab.op.*` classes; no public API or op-layer change, so #170/#263 network/PIT surfaces are untouched. `Palette.java` (#201) and `JLSStart`/`JLS.java` (#220) are not touched.

## Verification

- New headless `test/jls/edit/MoveGestureTest.java` (mirrors `DeleteGestureTest`, canonical-save #166 oracle): P1 op-plan-vs-inline byte parity for single- and multi-element pure relocations on constructed **and** save/load-restored circuits; predicate returns `null` for connect-forming drops, wired elements, wire selections, subcircuits, and the empty selection; `MoveElements` off-canvas rejection leaves the circuit byte-identical; exactly one `markChanged` per gesture via a batch sink.
- `test/jls/ui/EditorGestureTest.java` (`@Tag("display")`): drives a gate drag end-to-end through the op path, asserts the drop lands at the drag delta, and that a single undo restores the pre-drag position (one-undo-snapshot-per-gesture batch submit).

Byte parity holds because the save format persists the snapped `x`/`y`, not the sub-grid `lx`/`ly` that `fixPosition` syncs, and because eligibility excludes every drop where `connect()`/`removeCoLinear()` would do work.

### Build

Full `nix develop --command bash -c 'mvn verify'` green (SpotBugs warnings-as-errors; the display-tagged tests skip headless as expected).

```
Tests run: 1281, Failures: 0, Errors: 0, Skipped: 5
Tests run: 93, Failures: 0, Errors: 0, Skipped: 93
BUILD SUCCESS
```

Advances #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpjPHKerSvSbQorrBsBrgq
